### PR TITLE
Dynamically checkout the latest release tag with `clone-stable`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ ifeq ("$(wildcard .env)","")
 	make env
 endif
 	make clean
-	make clone-main
+	make clone-stable
 	make build
 	make up
 
@@ -62,13 +62,13 @@ clone:
 	-git clone https://github.com/minvws/nl-kat-keiko.git
 	-git clone https://github.com/minvws/nl-kat-rocky.git
 
-clone-main:
-	-git clone --branch main https://github.com/minvws/nl-kat-boefjes.git
-	-git clone --branch main https://github.com/minvws/nl-kat-bytes.git
-	-git clone --branch main https://github.com/minvws/nl-kat-octopoes.git
-	-git clone --branch main https://github.com/minvws/nl-kat-mula.git
-	-git clone --branch main https://github.com/minvws/nl-kat-keiko.git
-	-git clone --branch main https://github.com/minvws/nl-kat-rocky.git
+clone-stable:
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-boefjes/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-boefjes.git
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-bytes/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-bytes.git
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-octopoes/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-octopoes.git
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-mula/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-mula.git
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-keiko/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-keiko.git
+	-git clone --branch $(shell curl --silent  "https://api.github.com/repos/minvws/nl-kat-rocky/tags" | jq -r '.[0].name') https://github.com/minvws/nl-kat-rocky.git
 
 pull:
 	-git pull


### PR DESCRIPTION
As we now no longer work with a dedicated `develop` branch, `make kat-stable` should be based on release tags, and not the `main` branch. This PR tweaks that command such that it dynamically fetches the latest release tag through the GitHub API for all modules, and checks them out. 

This may be a temporary measure until we move to a monorepo. I'm not entirely sure though whether this "temporary measure" is desirable though, as it immediately parses remote data. Do @minvws/kat-managers consider this acceptable from a security perspective? If not, I suggest we drop this PR and wait until we have made the monorepo-switch.