### PR TITLE
Bytes: Add better API feedback.

### DIFF
--- a/bytes/bytes/database/sql_meta_repository.py
+++ b/bytes/bytes/database/sql_meta_repository.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from typing import Type, List, Iterator, Optional
 
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import sessionmaker, Session
 
 from bytes.config import Settings, get_settings
@@ -40,7 +41,11 @@ class SQLMetaDataRepository(MetaDataRepository):
 
     def __exit__(self, _exc_type: Type[Exception], _exc_value: str, _exc_traceback: str) -> None:
         logger.info("Committing session")
-        self.session.commit()
+
+        try:
+            self.session.commit()
+        except IntegrityError as e:
+            raise MetaIntegrityError(str(e)) from e
 
     def save_boefje_meta(self, boefje_meta: BoefjeMeta) -> None:
         logger.info("Inserting meta: %s", boefje_meta.json())
@@ -193,6 +198,11 @@ def create_meta_data_repository() -> Iterator[MetaDataRepository]:
 class ObjectNotFoundException(Exception):
     def __init__(self, cls: Type[SQL_BASE], **kwargs):  # type: ignore
         super().__init__(f"The object of type {cls} was not found for query parameters {kwargs}")
+
+
+class MetaIntegrityError(Exception):
+    def __init__(self, message: str):
+        super().__init__(message)
 
 
 def to_boefje_meta_in_db(boefje_meta: BoefjeMeta) -> BoefjeMetaInDB:

--- a/bytes/bytes/database/sql_meta_repository.py
+++ b/bytes/bytes/database/sql_meta_repository.py
@@ -201,8 +201,7 @@ class ObjectNotFoundException(Exception):
 
 
 class MetaIntegrityError(Exception):
-    def __init__(self, message: str):
-        super().__init__(message)
+    """An IntegrityError occurred for the MetaRepository"""
 
 
 def to_boefje_meta_in_db(boefje_meta: BoefjeMeta) -> BoefjeMetaInDB:

--- a/bytes/tests/client.py
+++ b/bytes/tests/client.py
@@ -34,7 +34,7 @@ def retry_with_login(function: ClientSessionMethod) -> ClientSessionMethod:
             return function(self, *args, **kwargs)
         except HTTPError as error:
             if error.response.status_code != 401:
-                raise error from HTTPError
+                raise
 
             self.login()
             return function(self, *args, **kwargs)

--- a/bytes/tests/integration/test_bytes_api_client.py
+++ b/bytes/tests/integration/test_bytes_api_client.py
@@ -24,6 +24,14 @@ def test_boefje_meta(bytes_api_client: BytesAPIClient) -> None:
 
     assert boefje_meta == retrieved_boefje_meta
 
+    with pytest.raises(HTTPError) as ctx:
+        bytes_api_client.save_boefje_meta(boefje_meta)
+
+    assert ctx._excinfo[1].response.json() == {
+        "status": "failed",
+        "message": "Integrity error: object might already exist",
+    }
+
 
 def test_filtered_boefje_meta(bytes_api_client: BytesAPIClient) -> None:
     boefje_meta = get_boefje_meta()


### PR DESCRIPTION
The main feature is handling IntegrityErrors when committing a transaction of BoefjeMeta and NormalizerMeta objects. This gives better feedback in the boefje/normalizer logs as we see duplicate task handling happening.

Original PR: https://github.com/minvws/nl-kat-bytes/pull/56