### PR TITLE
fix expiring cert bit

### DIFF
--- a/octopoes/bits/expiring_certificate/bit.py
+++ b/octopoes/bits/expiring_certificate/bit.py
@@ -5,8 +5,6 @@ from octopoes.models.ooi.web import Website
 BIT = BitDefinition(
     id="expiring-certificate",
     consumes=X509Certificate,
-    parameters=[
-        BitParameterDefinition(ooi_type=Website, relation_path="certificate"),
-    ],
+    parameters=[],
     module="bits.expiring_certificate.expiring_certificate",
 )

--- a/octopoes/bits/expiring_certificate/bit.py
+++ b/octopoes/bits/expiring_certificate/bit.py
@@ -1,6 +1,5 @@
-from bits.definitions import BitDefinition, BitParameterDefinition
+from bits.definitions import BitDefinition
 from octopoes.models.ooi.certificate import X509Certificate
-from octopoes.models.ooi.web import Website
 
 BIT = BitDefinition(
     id="expiring-certificate",

--- a/octopoes/bits/expiring_certificate/expiring_certificate.py
+++ b/octopoes/bits/expiring_certificate/expiring_certificate.py
@@ -11,15 +11,14 @@ THRESHOLD = datetime.timedelta(weeks=2)
 
 def run(input_ooi: X509Certificate, additional_oois: List[Website]) -> Iterator[OOI]:
     # only applies to OOIs referencing the certificate
-    if additional_oois:
-        if input_ooi.expired:
-            ft = KATFindingType(id="KAT-CERTIFICATE-EXPIRED")
-            yield ft
-            yield Finding(ooi=input_ooi.reference, finding_type=ft.reference, description="TLS certificate has expired")
+    if input_ooi.expired:
+        ft = KATFindingType(id="KAT-CERTIFICATE-EXPIRED")
+        yield ft
+        yield Finding(ooi=input_ooi.reference, finding_type=ft.reference, description="TLS certificate has expired")
 
-        elif input_ooi.expires_in is not None and input_ooi.expires_in < THRESHOLD:
-            ft = KATFindingType(id="KAT-CERTIFICATE-EXPIRING-SOON")
-            yield ft
-            yield Finding(
-                ooi=input_ooi.reference, finding_type=ft.reference, description="TLS certificate is expiring soon"
-            )
+    elif input_ooi.expires_in is not None and input_ooi.expires_in < THRESHOLD:
+        ft = KATFindingType(id="KAT-CERTIFICATE-EXPIRING-SOON")
+        yield ft
+        yield Finding(
+            ooi=input_ooi.reference, finding_type=ft.reference, description="TLS certificate is expiring soon"
+        )

--- a/octopoes/tests/test_bit_expiring_certificate.py
+++ b/octopoes/tests/test_bit_expiring_certificate.py
@@ -4,7 +4,7 @@ from octopoes.models.ooi.certificate import X509Certificate
 from bits.expiring_certificate.expiring_certificate import run
 
 
-def test_spf_discovery_simple_success():
+def test_expiring_cert_simple_success():
     certificate = X509Certificate(
         subject="example.com",
         valid_from="2022-11-15T08:52:57",
@@ -17,7 +17,7 @@ def test_spf_discovery_simple_success():
     assert len(results) == 0
 
 
-def test_spf_discovery_simple_expired():
+def test_expiring_cert_simple_expired():
     certificate = X509Certificate(
         subject="example.com",
         valid_from="2022-11-15T08:52:57",
@@ -30,7 +30,7 @@ def test_spf_discovery_simple_expired():
     assert len(results) == 2
 
 
-def test_spf_discovery_simple_expires_soon():
+def test_expiring_cert_simple_expires_soon():
     certificate = X509Certificate(
         subject="example.com",
         valid_from="2022-11-15T08:52:57",

--- a/octopoes/tests/test_bit_expiring_certificate.py
+++ b/octopoes/tests/test_bit_expiring_certificate.py
@@ -1,0 +1,28 @@
+from octopoes.models.ooi.certificate import X509Certificate
+from bits.expiring_certificate.expiring_certificate import run
+
+
+def test_spf_discovery_simple_success():
+    certificate = X509Certificate(
+        subject="example.com",
+        valid_from="2022-11-15T08:52:57",
+        valid_until="2030-11-15T08:52:57",
+        serial_number="abc123",
+    )
+
+    results = list(run(certificate, []))
+
+    assert len(results) == 0
+
+
+def test_spf_discovery_simple_expired():
+    certificate = X509Certificate(
+        subject="example.com",
+        valid_from="2022-11-15T08:52:57",
+        valid_until="2022-11-15T08:52:57",
+        serial_number="abc123",
+    )
+
+    results = list(run(certificate, []))
+
+    assert len(results) == 2

--- a/octopoes/tests/test_bit_expiring_certificate.py
+++ b/octopoes/tests/test_bit_expiring_certificate.py
@@ -1,3 +1,5 @@
+from _datetime import datetime, timedelta
+
 from octopoes.models.ooi.certificate import X509Certificate
 from bits.expiring_certificate.expiring_certificate import run
 
@@ -21,6 +23,20 @@ def test_spf_discovery_simple_expired():
         valid_from="2022-11-15T08:52:57",
         valid_until="2022-11-15T08:52:57",
         serial_number="abc123",
+    )
+
+    results = list(run(certificate, []))
+
+    assert len(results) == 2
+
+
+def test_spf_discovery_simple_expires_soon():
+    certificate = X509Certificate(
+        subject="example.com",
+        valid_from="2022-11-15T08:52:57",
+        valid_until=str(datetime.now() + timedelta(days=2)),
+        serial_number="abc123",
+        expires_in=timedelta(days=2),
     )
 
     results = list(run(certificate, []))


### PR DESCRIPTION
This PR solves two problems:

- Findings were not created because the relationship between Cert and Website is optional and therefore bits do not retrigger (this is a design choice of bits). Updates in ParameterDefinitions in this bit would never be noticed.
- Expiring higher-level certificates would never yield a finding because they are not directly related to a website.