### PR TITLE
small fix to add jump to enabled/disabled plugin in enable_disable_plugin.html

### DIFF
--- a/rocky/katalogus/templates/partials/enable_disable_plugin.html
+++ b/rocky/katalogus/templates/partials/enable_disable_plugin.html
@@ -1,11 +1,11 @@
 {% load i18n %}
 
 {% if perms.tools.can_enable_disable_boefje %}
-  <form action="{% url 'plugin_enable_disable' organization_code=organization.code plugin_type=plugin.type plugin_id=plugin.id plugin_state=plugin.enabled %}"
+  <form id="enableform_{{ plugin.id|slugify }}" action="{% url 'plugin_enable_disable' organization_code=organization.code plugin_type=plugin.type plugin_id=plugin.id plugin_state=plugin.enabled %}"
         method="post"
         class="inline">
     {% csrf_token %}
-    <input type="hidden" name="current_url" value="{{ request.path }}"/>
+    <input type="hidden" name="current_url" value="{{ request.path }}#enableform_{{ plugin.id|slugify }}" >
     <button type="submit"
             class="{% if not plugin.enabled %}button{% else %}ghost{% endif %}">
       {% if not plugin.enabled %}


### PR DESCRIPTION
First step to mitigate some user annoyances mentioned in https://github.com/minvws/nl-kat-coordination/issues/410

## Changes
Add an ID to the pluginform and jump to that anchor after changing the enabled state.

## Issue ticket number and link
https://github.com/minvws/nl-kat-coordination/issues/410

## Checklist for author(s):
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [x] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [x] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [x] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [ ] I have performed a self-review of my own code;
- [ ] I have commented my code, particularly in hard-to-understand areas;
- [ ] I have made corresponding changes to the documentation, if necessary;
- [ ] I have written unit, integration, and end-to-end tests for the change that I made;