### PR TITLE
Update ADR-validator to v0.2.0

### DIFF
--- a/boefjes/boefjes/plugins/kat_adr_validator/main.py
+++ b/boefjes/boefjes/plugins/kat_adr_validator/main.py
@@ -5,8 +5,8 @@ import docker
 from boefjes.job_models import BoefjeMeta
 
 
-ADR_VALIDATOR_REPOSITORY = "registry.gitlab.com/commonground/don/adr-validator/tmp"
-ADR_VALIDATOR_VERSION = "main"
+ADR_VALIDATOR_REPOSITORY = "registry.gitlab.com/commonground/don/adr-validator"
+ADR_VALIDATOR_VERSION = "0.2.0"
 
 
 def run_adr_validator(url: str) -> str:


### PR DESCRIPTION
Use a released version of the ADR-validator Docker image.

Good practice to pin the version 🙂 

The changelog: https://gitlab.com/commonground/don/adr-validator/-/blob/main/CHANGELOG.md#020-2023-03-14