### PR TITLE
implement ooi list performance optimization

### DIFF
--- a/octopoes/octopoes/core/service.py
+++ b/octopoes/octopoes/core/service.py
@@ -276,6 +276,16 @@ class OctopoesService:
     def _on_create_ooi(self, event: OOIDBEvent) -> None:
         ooi = event.new_data
 
+        # keep old scan profile, or create new scan profile
+        try:
+            self.scan_profile_repository.get(ooi.reference, event.valid_time)
+        except ObjectNotFoundException:
+            self.scan_profile_repository.save(
+                None,
+                EmptyScanProfile(reference=ooi.reference),
+                valid_time=event.valid_time,
+            )
+
         # analyze bit definitions
         bit_definitions = get_bit_definitions()
         for bit_id, bit_definition in bit_definitions.items():

--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -214,21 +214,10 @@ class XTDBOOIRepository(OOIRepository):
                         :find [(count ?e)]
                         :in [[_object_type ...] [_scan_level ...] [_scan_profile_type ...]]
                         :where [[?e :object_type _object_type]
-                                (or-join [?e _scan_level _scan_profile_type]
-                                  (and
-                                    [?scan_profile :type "ScanProfile"]
-                                    [?scan_profile :reference ?e]
-                                    [?scan_profile :level _scan_level]
-                                    [?scan_profile :scan_profile_type _scan_profile_type]
-                                  )
-                                  (and
-                                      (not-join [?e]
-                                          [?scan_profile :type "ScanProfile"]
-                                          [?scan_profile :reference ?e])
-                                      [(= _scan_level 0)]
-                                      [(= _scan_profile_type "empty")]
-                                  )
-                          )]
+                                [?scan_profile :type "ScanProfile"]
+                                [?scan_profile :reference ?e]
+                                [?scan_profile :level _scan_level]
+                                [?scan_profile :scan_profile_type _scan_profile_type]]
                     }}
                     :in-args [[{object_types}], [{scan_levels}], [{scan_profile_types}]]
                 }}
@@ -247,21 +236,10 @@ class XTDBOOIRepository(OOIRepository):
                         :find [(pull ?e [*])]
                         :in [[_object_type ...] [_scan_level ...]  [_scan_profile_type ...]]
                         :where [[?e :object_type _object_type]
-                                (or-join [?e _scan_level _scan_profile_type]
-                                      (and
-                                        [?scan_profile :type "ScanProfile"]
-                                        [?scan_profile :reference ?e]
-                                        [?scan_profile :level _scan_level]
-                                        [?scan_profile :scan_profile_type _scan_profile_type]
-                                      )
-                                      (and
-                                          (not-join [?e]
-                                              [?scan_profile :type "ScanProfile"]
-                                              [?scan_profile :reference ?e])
-                                          [(= _scan_level 0)]
-                                          [(= _scan_profile_type "empty")]
-                                      )
-                              )]
+                                [?scan_profile :type "ScanProfile"]
+                                [?scan_profile :reference ?e]
+                                [?scan_profile :level _scan_level]
+                                [?scan_profile :scan_profile_type _scan_profile_type]]
                         :limit {limit}
                         :offset {offset}
                     }}

--- a/octopoes/tests/robot/01_scan_profiles.robot
+++ b/octopoes/tests/robot/01_scan_profiles.robot
@@ -21,17 +21,17 @@ Inheritance Of Two Declared Scan Profiles
     Verify Scan Profile Increment Queue    ${REF_HOSTNAME}    ${4}
     Verify Scan Profile Increment Queue    ${REF_IPADDR}    ${2}
     Verify Scan Profile Increment Queue    ${REF_RESOLVEDHOSTNAME}    ${4}
-    Verify Scan LeveL Filter    0    ${1}
     Verify Scan LeveL Filter    1    ${0}
     Verify Scan LeveL Filter    2    ${2}
     Verify Scan LeveL Filter    3    ${0}
     Verify Scan LeveL Filter    4    ${3}
+    Verify Scan LeveL Filter    0    ${1}
     Verify Scan LeveL Filter    ${{ [2,4] }}    ${5}
     Verify Scan LeveL Filter    ${{ [3,4] }}    ${3}
     Verify Scan LeveL Filter    ${{ [2,0] }}    ${3}
-    Verify Scan Profile Mutation Queue    ${REF_HOSTNAME}    ${{[4]}}
-    Verify Scan Profile Mutation Queue    ${REF_IPADDR}    ${{[2]}}
-    Verify Scan Profile Mutation Queue    ${REF_RESOLVEDHOSTNAME}    ${{[4]}}
+    Verify Scan Profile Mutation Queue    ${REF_HOSTNAME}    ${{[0, 4]}}
+    Verify Scan Profile Mutation Queue    ${REF_IPADDR}    ${{[0, 2]}}
+    Verify Scan Profile Mutation Queue    ${REF_RESOLVEDHOSTNAME}    ${{[0, 4]}}
 
 Recalculate Inheritance After Modification
     Declare Scan Profile    ${REF_HOSTNAME}    ${4}
@@ -45,9 +45,9 @@ Recalculate Inheritance After Modification
     Verify Scan Profile Increment Queue    ${REF_HOSTNAME}    ${4}
     Verify Scan Profile Increment Queue    ${REF_IPADDR}    ${2}
     Verify Scan Profile Increment Queue    ${REF_RESOLVEDHOSTNAME}    ${4}
-    Verify Scan Profile Mutation Queue    ${REF_HOSTNAME}    ${{[4, 0]}}
-    Verify Scan Profile Mutation Queue    ${REF_IPADDR}    ${{[2]}}
-    Verify Scan Profile Mutation Queue    ${REF_RESOLVEDHOSTNAME}    ${{[4, 0]}}
+    Verify Scan Profile Mutation Queue    ${REF_HOSTNAME}    ${{[0, 4, 0]}}
+    Verify Scan Profile Mutation Queue    ${REF_IPADDR}    ${{[0, 2]}}
+    Verify Scan Profile Mutation Queue    ${REF_RESOLVEDHOSTNAME}    ${{[0, 4, 0]}}
 
 Empty Scan Profiles
     Recalculate Scan Profiles

--- a/octopoes/tests/robot/02_list_objects.robot
+++ b/octopoes/tests/robot/02_list_objects.robot
@@ -30,7 +30,10 @@ Object List Should Contain Reported Items
     ${response_data}    Get Objects
     # 6, because 2 objects are created by bits
     Should Be Equal    ${response_data["count"]}    ${6}
-    Should Be Equal    ${response_data["items"][0]["primary_key"]}    ${REF_HOSTNAME}
+
+    # verify that REF_HOSTNAME is in the list
+    ${pks} =   Evaluate    [item["primary_key"] for item in ${response_data["items"]}]
+    Should Contain    ${pks}    ${REF_HOSTNAME}   ${REF_HOSTNAME} not found in object list
 
 Verify Object List With Filter
     ${response_data}    Get Objects With ScanLevel 0

--- a/octopoes/tests/robot/04_save_declaration.robot
+++ b/octopoes/tests/robot/04_save_declaration.robot
@@ -14,7 +14,7 @@ Add Several Append Origins
     Verify Object Present    Hostname|internet|calvinnormalizer.org
     Verify Origin Present    Hostname|internet|calvinnormalizer.org.    43210
 
-    Insert Regular Declaration
+    Insert Regular Declarations
 
 
 *** Keywords ***

--- a/octopoes/tests/robot/robot.resource
+++ b/octopoes/tests/robot/robot.resource
@@ -101,6 +101,7 @@ Cleanup
     Get Messages From Queue    ${SCAN_PROFILE_MUTATION_QUEUE}    ack_requeue_false
 
 Await Sync
+    Sleep     100ms
     Await Tasks Done
     Wait For XTDB Synced
 


### PR DESCRIPTION
## Changes
This PR improves the OOI List performance. This is achieved by removing the outer-join from the query, which basically provided default scan-profiles for OOI's without a scan profile. 

**Context:**  
Scan-profiles are calculated asynchronously by Octopoes. Ideally, a default empty scan profile is created in the `on_create_ooi` event hook. This usually happens pretty fast after creating an OOI. 

However, the previously described event processing might fail in case of system crash, DB downtime, etc. Fault tolerance is achieved here by a periodic `recalculate_scan_profiles` job.

In the worst case scenario, a scan-profile object is not present for an OOI between OOI creation and the next iteration of `recalculate_scan_profiles` (default interval is set to 60 seconds). 

To allow filtering of the OOI List based on scan profiles, a join is made to the scan-profile. This results in the simplest case in an inner join, so that only OOIs are retrieved that actually have a scan profile. During the scenario in which an OOI does not have a scan profile temporarily, the OOI will not appear in the list. The previous solution added default scan-profile at query time to prevent this. However, it appears that that resulted in extreme performance loss with larger datasets.

Hence the removal of this part of the query. This PR does reintroduce the worst case scenario of new OOI's not appearing, however it attempts to minimize it by adding the scan-profile in the `on_create_ooi` event hook.

_I ran into some obscure concurrency issues in the robot tests, so I introduced a slight timeout before starting the polling for the celery task completions._

## Issue ticket number and link
https://github.com/minvws/nl-kat-coordination/issues/429

## Proof

Benchmark: total of 785 objects

Old: 7542ms
![Screenshot 2023-03-14 at 16 49 31](https://user-images.githubusercontent.com/9639395/225058331-0684e6aa-6833-499e-ab03-841b784a70ca.png)

New: 288ms
![Screenshot 2023-03-14 at 16 48 52](https://user-images.githubusercontent.com/9639395/225058245-b20650a4-5e3b-4a2c-b6a6-cee06df97092.png)






## Extra instructions for others
-N/A

<!---
- Does this PR introduce or depend on API-incompatible changes? If yes: what do other users/developers need to do or confirm before merging?
- Does this PR depend on a specific version of a library?
- Does this PR depend on any other pending PR's?
- Does this PR require config, setup, or `.env` changes?
-->

## Checklist for author(s):
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [x] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [x] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [x] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [x] I have performed a self-review of my own code;
- [x] I have commented my code, particularly in hard-to-understand areas;
- [x] I have made corresponding changes to the documentation, if necessary;
- [x] I have written unit, integration, and end-to-end tests for the change that I made;

If a non-trivial PR:
- [x] This PR is part of a milestone and has appropriate labels;
- [x] This PR is properly linked to the project board (either directly or via an issue);
- [x] I have added screenshots or some other proof that my code does what it is supposed to do;


```
## Checklist for functional reviewer(s):
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] I have checked out this branch, and successfully ran `make kat`;
- [ ] I have ran `make test-rf` and all end-to-end Robot Framework tests pass;
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended;
- [ ] I confirmed that there are no unintended functional regressions in this branch;

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* _bullet point + screenshot (if useful) if it is unclear whether something is a bug or an intended feature._
```

```
## Checklist for code reviewer(s):
- [ ] The code passes the CI tests and linters;
- [ ] The code does not bypass authentication or security mechanisms;
- [ ] The code does not introduce any dependency on a library that has not been properly vetted;
- [ ] The code does not violate Model-View-Template and our other architectural principles;
- [ ] The code contains docstrings, comments, and documentation where needed;
- [ ] The code prioritizes readability over performance where appropriate;
- [ ] The code conforms to our agreed coding standards.
```