### PR TITLE
[BIT] [HTTPS-REDIRECT] :memo: Make missing HTTPS redirect warning clear

### DIFF
--- a/octopoes/bits/https_redirect/https_redirect.py
+++ b/octopoes/bits/https_redirect/https_redirect.py
@@ -15,7 +15,9 @@ def run(
         return
 
     if "location" not in header_keys:
-        ft = KATFindingType(id="KAT-HTTPS-REDIRECT")
+        ft = KATFindingType(id="KAT-NO-HTTPS-REDIRECT")
         yield Finding(
-            ooi=input_ooi.reference, finding_type=ft.reference, description="This HTTP URL does not redirect to HTTPS"
+            ooi=input_ooi.reference,
+            finding_type=ft.reference,
+            description="This HTTP URL may not redirect to HTTPS; 'location' was not found in HTTPHeader.",
         )

--- a/rocky/OOI_database_seed.json
+++ b/rocky/OOI_database_seed.json
@@ -1099,6 +1099,19 @@
   },
   {
     "model": "tools.ooiinformation",
+    "pk": "KATFindingType|KAT-NO-HTTPS-REDIRECT",
+    "fields": {
+      "last_updated": "2021-12-07T17:24:09.835Z",
+      "data": {
+        "description": "This HTTP URL may not redirect to HTTPS; 'location' was not found in HTTPHeader.",
+        "recommendation": "Check if redirection is setup properly.",
+        "risk": "Low"
+      },
+      "consult_api": false
+    }
+  },
+  {
+    "model": "tools.ooiinformation",
     "pk": "KATFindingType|KAT-CERTIFICATE-EXPIRING-SOON",
     "fields": {
       "last_updated": "2022-12-20T15:59:09.835Z",


### PR DESCRIPTION
Because it seems that https://github.com/minvws/nl-kat-octopoes/pull/95 got lost in the merge to monorepo.