### PR TITLE
Fix organization indemnification permission checks

### DIFF
--- a/rocky/rocky/templates/organizations/organization_detail.html
+++ b/rocky/rocky/templates/organizations/organization_detail.html
@@ -22,18 +22,22 @@
                 <td>{{ organization.name }}</td>
                 <td>{{ organization.code }}</td>
                 <td>
-                  {% spaceless %}
-                    <a href="{% url 'organization_edit' organization.code %}">
-                      <button class="icon ti-edit">{% translate 'Edit' %}</button>
-                    </a>
-                  {% endspaceless %}
+                  {% if perms.tools.change_organization %}
+                    {% spaceless %}
+                      <a href="{% url 'organization_edit' organization.code %}">
+                        <button class="icon ti-edit">{% translate 'Edit' %}</button>
+                      </a>
+                    {% endspaceless %}
+                  {% endif %}
                 </td>
               </tr>
             </tbody>
           </table>
         </div>
-        <a href="{% url 'indemnification_add' organization.code %}"
-           class="button ghost">{% translate 'Add indemnification' %}</a>
+        {% if perms.tools.change_organization %}
+          <a href="{% url 'indemnification_add' organization.code %}"
+             class="button ghost">{% translate 'Add indemnification' %}</a>
+        {% endif %}
       </div>
     </section>
     {% if organization.tags.all %}

--- a/rocky/rocky/views/indemnification_add.py
+++ b/rocky/rocky/views/indemnification_add.py
@@ -1,4 +1,5 @@
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
 from django_otp.decorators import otp_required
@@ -10,9 +11,10 @@ from tools.models import Indemnification
 
 
 @class_view_decorator(otp_required)
-class IndemnificationAddView(OrganizationView, FormView):
+class IndemnificationAddView(PermissionRequiredMixin, OrganizationView, FormView):
     template_name = "indemnification_add.html"
     form_class = IndemnificationAddForm
+    permission_required = "tools.change_organization"
 
     def post(self, request, *args, **kwargs):
         Indemnification.objects.get_or_create(

--- a/rocky/tests/test_organization.py
+++ b/rocky/tests/test_organization.py
@@ -3,6 +3,8 @@ from django.contrib.auth.models import Permission
 from django.core.exceptions import PermissionDenied
 from django.urls import reverse
 from pytest_django.asserts import assertContains, assertNotContains
+
+from rocky.views.indemnification_add import IndemnificationAddView
 from rocky.views.organization_detail import OrganizationDetailView
 from rocky.views.organization_edit import OrganizationEditView
 from rocky.views.organization_list import OrganizationListView
@@ -191,6 +193,20 @@ def test_edit_organization_permissions(rf, redteam_member, client_member):
 
     with pytest.raises(PermissionDenied):
         OrganizationEditView.as_view()(
+            request_client, organization_code=client_member.organization.code, pk=client_member.organization.id
+        )
+
+
+def test_edit_organization_indemnification(rf, redteam_member, client_member):
+    """Redteamers and clients cannot add idemnification."""
+    request_redteam = setup_request(rf.get("indemnification_add"), redteam_member.user)
+    request_client = setup_request(rf.get("indemnification_add"), client_member.user)
+
+    with pytest.raises(PermissionDenied):
+        IndemnificationAddView.as_view()(request_redteam, organization_code=redteam_member.organization.code)
+
+    with pytest.raises(PermissionDenied):
+        IndemnificationAddView.as_view()(
             request_client, organization_code=client_member.organization.code, pk=client_member.organization.id
         )
 


### PR DESCRIPTION
## Changes

Clients and redteamers no longer have access to the organization indemnification page.

## Issue ticket number and link

Fixes #490 

## Proof

![Screenshot 2023-03-23 at 16-44-57 OpenKAT - organization_detail](https://user-images.githubusercontent.com/20283/227258177-9fa4b6dd-8cd7-4baa-9c8d-5060323e2bf3.png)
![Screenshot 2023-03-23 at 16-45-02 OpenKAT - organization_detail](https://user-images.githubusercontent.com/20283/227258194-e266ef67-4838-46e3-8172-91d38b9f3053.png)
![Screenshot 2023-03-23 at 16-45-06 OpenKAT - organization_detail](https://user-images.githubusercontent.com/20283/227258201-61108fb3-3d17-4b3d-9e3c-8a0ac54d5cfe.png)

## Extra instructions for others
_This section may be skipped or omitted. Uncomment and answer the below questions if relevant._

<!---
- Does this PR introduce or depend on API-incompatible changes? If yes: what do other users/developers need to do or confirm before merging?
- Does this PR depend on a specific version of a library?
- Does this PR depend on any other pending PR's?
- Does this PR require config, setup, or `.env` changes?
-->

## Checklist for author(s):
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [x] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [x] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [x] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [x] I have performed a self-review of my own code;
- [x] I have commented my code, particularly in hard-to-understand areas;
- [x] I have made corresponding changes to the documentation, if necessary;
- [x] I have written unit, integration, and end-to-end tests for the change that I made;

If a non-trivial PR:
- [ ] This PR is part of a milestone and has appropriate labels;
- [ ] This PR is properly linked to the project board (either directly or via an issue);
- [ ] I have added screenshots or some other proof that my code does what it is supposed to do;


```
## Checklist for functional reviewer(s):
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] I have checked out this branch, and successfully ran `make kat`;
- [ ] I have ran `make test-rf` and all end-to-end Robot Framework tests pass;
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended;
- [ ] I confirmed that there are no unintended functional regressions in this branch;

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* _bullet point + screenshot (if useful) if it is unclear whether something is a bug or an intended feature._
```

```
## Checklist for code reviewer(s):
- [ ] The code passes the CI tests and linters;
- [ ] The code does not bypass authentication or security mechanisms;
- [ ] The code does not introduce any dependency on a library that has not been properly vetted;
- [ ] The code does not violate Model-View-Template and our other architectural principles;
- [ ] The code contains docstrings, comments, and documentation where needed;
- [ ] The code prioritizes readability over performance where appropriate;
- [ ] The code conforms to our agreed coding standards.
```
