### PR TITLE
Let xtdb exit when the JVM is OOM

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,8 @@ services:
       - "127.0.0.1:3000:3000"
     volumes:
       - xtdb-data:/var/lib/xtdb
+    environment:
+      JAVA_TOOL_OPTIONS: "-Xms128M -Xmx512M -XX:MaxDirectMemorySize=512M -XX:+ExitOnOutOfMemoryError"
 
   octopoes_api:
     restart: on-failure


### PR DESCRIPTION
## Changes

Add `-XX:+ExitOnOutOfMemoryError` flag to xtdb JVM so that it exits when reaching an out-of-memory situation, instead of lingering in a zombie state (#652).

## Issue ticket number and link

Relates to #652.

## Proof

Running with only 128MB max heap size and then doing a big query:
```
Picked up JAVA_TOOL_OPTIONS: -Xms128M -Xmx128M -XX:MaxDirectMemorySize=512M -XX:+ExitOnOutOfMemoryError
17:01:15.593 [main] INFO  org.eclipse.jetty.util.log - Logging initialized @3109ms to org.eclipse.jetty.util.log.Slf4jLog
17:01:15.676 [main] INFO  xtdb-http-multinode.core - Starting node zeef
17:01:17.674 [main] INFO  xtdb.tx - Started tx-ingester
17:01:17.906 [main] INFO  org.eclipse.jetty.server.Server - jetty-9.4.43.v20210629; built: 2021-06-30T11:07:22.254Z; git: 526006ecfa3af7f1a27ef3a288e2bef7ea9dd7e8; jvm 11.0.16+8
17:01:17.951 [main] INFO  o.e.jetty.server.AbstractConnector - Started ServerConnector@814b60b{HTTP/1.1, (http/1.1, h2c)}{0.0.0.0:3000}
17:01:17.951 [main] INFO  org.eclipse.jetty.server.Server - Started @5469ms
17:01:17.952 [main] INFO  xtdb-http-multinode.core - HTTP server started on host 0.0.0.0 port 3000
Terminating due to java.lang.OutOfMemoryError: Java heap space
```
After which the container is automatically restarted.

## Extra instructions for others
_This section may be skipped or omitted. Uncomment and answer the below questions if relevant._

<!---
- Does this PR introduce or depend on API-incompatible changes? If yes: what do other users/developers need to do or confirm before merging?
- Does this PR depend on a specific version of a library?
- Does this PR depend on any other pending PR's?
- Does this PR require config, setup, or `.env` changes?
-->

## Checklist for author(s):
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR comes from a `feature` or `hotfix` branch, in line with our git branching strategy;
- [x] This PR is "bite-sized" and only focuses on a single issue, problem, or feature;
- [x] I am not reinventing the wheel: there is no high-quality library that already has this feature;
- [x] I have changed the example `.env` files if I added, removed, or changed any config options, and I have informed others that they need to modify their `.env` files if required;
- [x] I have performed a self-review of my own code;
- [x] I have commented my code, particularly in hard-to-understand areas;
- [ ] I have made corresponding changes to the documentation, if necessary;
- [ ] I have written unit, integration, and end-to-end tests for the change that I made;

If a non-trivial PR:
- [ ] This PR is part of a milestone and has appropriate labels;
- [ ] This PR is properly linked to the project board (either directly or via an issue);
- [ ] I have added screenshots or some other proof that my code does what it is supposed to do;


```
## Checklist for functional reviewer(s):
- [ ] If a non-trivial PR: This PR is properly linked to an issue on the project board;
- [ ] I have checked out this branch, and successfully ran `make kat`;
- [ ] I have ran `make test-rf` and all end-to-end Robot Framework tests pass;
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended;
- [ ] I confirmed that there are no unintended functional regressions in this branch;

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* _bullet point + screenshot (if useful) if it is unclear whether something is a bug or an intended feature._
```

```
## Checklist for code reviewer(s):
- [ ] The code passes the CI tests and linters;
- [ ] The code does not bypass authentication or security mechanisms;
- [ ] The code does not introduce any dependency on a library that has not been properly vetted;
- [ ] The code does not violate Model-View-Template and our other architectural principles;
- [ ] The code contains docstrings, comments, and documentation where needed;
- [ ] The code prioritizes readability over performance where appropriate;
- [ ] The code conforms to our agreed coding standards.
```
