### PR TITLE
Accept "No changes detected" as well in migrations unit test

### DIFF
--- a/rocky/tests/test_migrations.py
+++ b/rocky/tests/test_migrations.py
@@ -11,5 +11,12 @@ def test_for_missing_migrations():
     output = StringIO()
     call_command("makemigrations", no_input=True, dry_run=True, stdout=output)
     lines = output.getvalue().strip().splitlines()
-    assert len(lines) == 3
-    assert lines[0] == "Migrations for 'two_factor':"
+
+    # The outcome of makemigrations here depends on having run `makemigrations` in your local environment, which creates
+    # a missing migration for two_factor (also see https://github.com/jazzband/django-two-factor-auth/issues/611).
+
+    if len(lines) == 1:
+        assert lines[0] == "No changes detected"
+    else:
+        assert len(lines) == 3
+        assert lines[0] == "Migrations for 'two_factor':"


### PR DESCRIPTION
## Changes
This is a small fix for an issue I encountered: when you run `python manage.py makemigrations` and then `python -m pytest`, one unit test breaks because it expects a migration for the `two_factor` app to be missing. Also see https://github.com/jazzband/django-two-factor-auth/issues/611.
