### PR TITLE
Enable and disable bits

### DIFF
--- a/docs/source/introduction/usermanual.rst
+++ b/docs/source/introduction/usermanual.rst
@@ -210,6 +210,19 @@ L4: Intensive scan
 
 The premise of the test profile is to verify whether an attacker can exploit vulnerabilities to give himself more extensive access to the tested environment. Thus, known exploit code is applied in this level.
 
+Bits
+====
+
+Bits are businessrules that assess objects. These can be disabled or enabled using environment variables. Almost all bits are enabled by default and be disabled by adding the bit to `BITS_DISABLED`. The disabled bits can be enabled using `BITS_ENABLED`. For example:
+
+.. code-block:: sh
+
+    BITS_ENABLED='["bit1","bit2"]'
+    BITS_DISABLED='["bit3"]'
+
+
+Note that if you enable a bit that was previously enabled the bit won't be automatically run for every OOIs it should have run on, but only when it is triggered again after a new scan or other bit that has run. When a bit that was previously enabled is disabled the resulting OOIs from that bit will also not be automatically removed. Only when the bit triggers instead of running the bit the resulting OOIs of the previous run will be deleted. This also means that if the bit isn't triggered the old OOIs will not be removed.
+
 Reports
 =======
 

--- a/octopoes/bits/definitions.py
+++ b/octopoes/bits/definitions.py
@@ -1,5 +1,6 @@
 import importlib
 import pkgutil
+from functools import lru_cache
 from logging import getLogger
 from pathlib import Path
 from types import ModuleType
@@ -25,12 +26,17 @@ class BitDefinition(BaseModel):
     parameters: List[BitParameterDefinition]
     module: str
     min_scan_level: int = 1
+    default_enabled: bool = True
 
 
+@lru_cache(maxsize=32)
 def get_bit_definitions() -> Dict[str, BitDefinition]:
     bit_definitions = {}
 
     for package in pkgutil.walk_packages([str(BITS_DIR)]):
+        if package.name in ["definitions", "runner"]:
+            continue
+
         try:
             module: ModuleType = importlib.import_module(".bit", f"{BITS_DIR.name}.{package.name}")
 
@@ -39,9 +45,9 @@ def get_bit_definitions() -> Dict[str, BitDefinition]:
                 bit_definitions[bit_definition.id] = bit_definition
 
             else:
-                logger.debug('module "%s" has no attribute %s', package.name, BIT_ATTR_NAME)
+                logger.warning('module "%s" has no attribute %s', package.name, BIT_ATTR_NAME)
 
         except ModuleNotFoundError:
-            logger.debug('package "%s" has no module %s', package.name, "bit")
+            logger.warning('package "%s" has no module %s', package.name, "bit")
 
     return bit_definitions

--- a/octopoes/octopoes/config/settings.py
+++ b/octopoes/octopoes/config/settings.py
@@ -1,6 +1,7 @@
 import os
 from enum import Enum
 from pathlib import Path
+from typing import Set
 
 from pydantic import BaseSettings
 
@@ -26,3 +27,5 @@ class Settings(BaseSettings):
     katalogus_api: str = "http://localhost:8003"
 
     scan_level_recalculation_interval: int = 60
+    bits_enabled: Set[str] = set()
+    bits_disabled: Set[str] = set()

--- a/octopoes/octopoes/core/service.py
+++ b/octopoes/octopoes/core/service.py
@@ -5,6 +5,7 @@ from typing import List, Optional, Callable, Set, Dict, Type
 
 from bits.definitions import get_bit_definitions
 from bits.runner import BitRunner
+from octopoes.config.settings import Settings
 from octopoes.events.events import (
     OOIDBEvent,
     OriginDBEvent,
@@ -35,6 +36,7 @@ from octopoes.repositories.origin_repository import OriginRepository
 from octopoes.repositories.scan_profile_repository import ScanProfileRepository
 
 logger = getLogger(__name__)
+settings = Settings()
 
 
 def find_relation_in_tree(relation: str, tree: ReferenceTree) -> List[OOI]:
@@ -123,24 +125,27 @@ class OctopoesService:
     def _run_inference(self, origin: Origin, valid_time: datetime):
         bit_definition = get_bit_definitions()[origin.method]
 
-        source = self.ooi_repository.get(origin.source, valid_time)
-
-        parameters_references = self.origin_parameter_repository.list_by_origin(origin.id, valid_time)
-        parameters = self.ooi_repository.get_bulk({x.reference for x in parameters_references}, valid_time)
-
         resulting_oois = []
 
-        try:
-            level = self.scan_profile_repository.get(origin.source, valid_time).level
-        except ObjectNotFoundException:
-            level = 0
-
-        if level >= bit_definition.min_scan_level:
+        if bit_definition.id not in settings.bits_disabled and (
+            bit_definition.id in settings.bits_enabled or bit_definition.default_enabled
+        ):
             try:
-                resulting_oois = BitRunner(bit_definition).run(source, list(parameters.values()))
-            except Exception as e:
-                logger.exception("Error running inference", exc_info=e)
-                return
+                level = self.scan_profile_repository.get(origin.source, valid_time).level
+            except ObjectNotFoundException:
+                level = 0
+
+            if level >= bit_definition.min_scan_level:
+                source = self.ooi_repository.get(origin.source, valid_time)
+
+                parameters_references = self.origin_parameter_repository.list_by_origin(origin.id, valid_time)
+                parameters = self.ooi_repository.get_bulk({x.reference for x in parameters_references}, valid_time)
+
+                try:
+                    resulting_oois = BitRunner(bit_definition).run(source, list(parameters.values()))
+                except Exception as e:
+                    logger.exception("Error running inference", exc_info=e)
+                    return
 
         self.save_origin(origin, resulting_oois, valid_time)
 


### PR DESCRIPTION
This adds the variable default_enabled to the BitDefinition which can be used to disable a bit by default. Two settings BITS_ENABLED and BITS_DISABLED are added to enable or disable bits.

A cache is added to the get_bit_definition function so we don't look up the bits and import them again every time an OOI is updated or a bit is run.

If there is a directory in the bits directory that isn't a bit then is logged with level warning instead of debug.

### Changes
_Please describe the essence of this PR in a few sentences. Mention any breaking changes or required configuration steps._

### Issue link
_Please add a link to the issue. If there is no issue for this PR, please add it to the project board directly._

### Proof
_Please add some proof of your working change here, unless this is not required (e.g. this PR is trivial)._

---
## Checklists for authors:

### Code Checklist
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.


### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
- [ ] The code does not violate Model-View-Template and our other architectural principles.
- [ ] The code prioritizes readability over performance where appropriate.
- [ ] The code does not bypass authentication or security mechanisms.
- [ ] The code does not introduce any dependency on a library that has not been properly vetted.
- [ ] The code contains docstrings, comments, and documentation where needed.

---
## Checklist for QA:
- [ ] I have checked out this branch, and successfully ran a fresh `make kat`.
- [ ] I confirmed that there are no unintended functional regressions in this branch:
    - [ ] I have managed to pass the onboarding flow
    - [ ] Objects and Findings are created properly
    - [ ] Tasks are created and completed properly
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended.

### What works:
* _bullet point + screenshot (if useful) per tested functionality_

### What doesn't work:
* _bullet point + screenshot (if useful) per tested functionality_

### Bug or feature?:
* _bullet point + screenshot (if useful) if it is unclear whether something is a bug or an intended feature._
