### PR TITLE
Move the ID of the button to the parent element

### DIFF
--- a/rocky/katalogus/templates/katalogus.html
+++ b/rocky/katalogus/templates/katalogus.html
@@ -50,7 +50,7 @@
                             </thead>
                             <tbody>
                                 {% for plugin in object_list %}
-                                    <tr>
+                                    <tr id="enableform_{{ plugin.id|slugify }}">
                                         <td scope="row">{{ plugin.name }}</td>
                                         <td>{{ plugin.description }}</td>
                                         <td>

--- a/rocky/katalogus/templates/katalogus.html
+++ b/rocky/katalogus/templates/katalogus.html
@@ -50,7 +50,7 @@
                             </thead>
                             <tbody>
                                 {% for plugin in object_list %}
-                                    <tr id="enableform_{{ plugin.id|slugify }}">
+                                    <tr id="plugin_{{ plugin.id|slugify }}">
                                         <td scope="row">{{ plugin.name }}</td>
                                         <td>{{ plugin.description }}</td>
                                         <td>

--- a/rocky/katalogus/templates/partials/enable_disable_plugin.html
+++ b/rocky/katalogus/templates/partials/enable_disable_plugin.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if perms.tools.can_enable_disable_boefje %}
-    <form id="enableform_{{ plugin.id|slugify }}"
+    <form
           action="{% url "plugin_enable_disable" organization_code=organization.code plugin_type=plugin.type plugin_id=plugin.id plugin_state=plugin.enabled %}"
           method="post"
           class="inline">

--- a/rocky/katalogus/templates/partials/enable_disable_plugin.html
+++ b/rocky/katalogus/templates/partials/enable_disable_plugin.html
@@ -8,7 +8,7 @@
         {% csrf_token %}
         <input type="hidden"
                name="current_url"
-               value="{{ request.path }}#enableform_{{ plugin.id|slugify }}">
+               value="{{ request.path }}#plugin_{{ plugin.id|slugify }}">
         <button type="submit"
                 class="{% if not plugin.enabled %}button{% else %}ghost{% endif %}">
             {% if not plugin.enabled %}

--- a/rocky/katalogus/templates/partials/plugin_tile.html
+++ b/rocky/katalogus/templates/partials/plugin_tile.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load static %}
 
-<div role="group">
+<div role="group" id="enableform_{{ plugin.id|slugify }}">
     <img src="{% url "plugin_cover" organization_code=organization.code plugin_id=plugin.id %}"
          alt="boefje placeholder image"/>
     <div class="horizontal-view scan-intensity">
@@ -18,6 +18,5 @@
     <a href="{% url "plugin_detail" organization_code=organization.code plugin_type=plugin.type plugin_id=plugin.id %}">{% translate "See details" %}</a>
     <div class="action-buttons">
         {% include "partials/enable_disable_plugin.html" with plugin=plugin %}
-
     </div>
 </div>

--- a/rocky/katalogus/templates/partials/plugin_tile.html
+++ b/rocky/katalogus/templates/partials/plugin_tile.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load static %}
 
-<div role="group" id="enableform_{{ plugin.id|slugify }}">
+<div role="group" id="plugin_{{ plugin.id|slugify }}">
     <img src="{% url "plugin_cover" organization_code=organization.code plugin_id=plugin.id %}"
          alt="boefje placeholder image"/>
     <div class="horizontal-view scan-intensity">


### PR DESCRIPTION
Due to a small UX flaw I moved the ID from the button to the parent/root element of the plugin instance. With the ID on the button in the tiles view the tile went out of the scroll view, with the button aligning with the top of the view. Instead of the whole plugin aligning at the top of the view.

**Before this fix**

https://user-images.githubusercontent.com/16188579/233085911-8f7e6bf3-83bc-4fc5-b665-79b77dea5ed0.mov



**After this fix**

https://user-images.githubusercontent.com/16188579/233085580-1cd84a84-2d40-4441-abd1-ef60e5361a9e.mov


