### PR TITLE
Use "on push" instead of "on create" in build-rdo-package workflow

### DIFF
--- a/.github/workflows/build-rdo-package.yml
+++ b/.github/workflows/build-rdo-package.yml
@@ -5,7 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  create:
+  push:
     tags:
       - v*
 


### PR DESCRIPTION
"On create" doesn't support filtering on tags. See https://github.com/actions/runner/issues/1007#issuecomment-808904408 for more information.