### PR TITLE
underscore broke the pdf engine (again)

### DIFF
--- a/rocky/OOI_database_seed.json
+++ b/rocky/OOI_database_seed.json
@@ -465,7 +465,7 @@
       "last_updated": "2021-08-09T14:50:09.835Z",
       "data": {
         "description": "The encrypted connection provides no protection against downgrade attacks.",
-        "recommendation": "Implement TLS_FALLBACK_SCSV.",
+        "recommendation": "Implement TLS-FALLBACK-SCSV.",
         "source": "https://www.rfc-editor.org/rfc/rfc7507",
         "risk": "Low"
       },


### PR DESCRIPTION
### Changes
The `"recommendation": "Implement TLS_FALLBACK_SCSV."` in the rocky database seed breaks the LaTeX engine due to the special character `_` being unsanitized. Changing this to `-` allows Keiko to not crash when the `KATFindingType|KAT-NO-TLS-FALLBACK-SCSV` gets reported.

### Proof
```
Underfull \hbox (badness 4819) in paragraph at lines 8877--8878
keiko_1                | []|\OT1/phv/m/n/10.95 The en-cryp-ted con-nec-tion pro-vi-des no pro-tec-tion
keiko_1                | ! Missing $ inserted.
keiko_1                | <inserted text>
keiko_1                |                 $
keiko_1                | l.8883                         Aanbeveling & Implement TLS_
keiko_1                |                                       FALLBACK_SCSV. \\
keiko_1                | ! Missing $ inserted.
keiko_1                | <inserted text>
keiko_1                |                 $
keiko_1                | l.8884
```

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
