### PR TITLE
add readmes to table of contents

### DIFF
--- a/docs/source/developer_documentation/index.rst
+++ b/docs/source/developer_documentation/index.rst
@@ -8,3 +8,8 @@ Contains documentation for developers and contributors.
    :caption: Contents
 
    rocky
+   mula
+   boefjes
+   bytes
+   octopoes
+   keiko


### PR DESCRIPTION
this adds the readmes to the TOC so they appear on docs.openkat.nl