### PR TITLE
Fix failing test-debian-install in CI

### DIFF
--- a/.github/workflows/test_debian_packages_on_ubuntu.yml
+++ b/.github/workflows/test_debian_packages_on_ubuntu.yml
@@ -217,7 +217,7 @@ jobs:
         run: sudo sed -i "s/XTDB_TYPE=\"xtdb\"/XTDB_TYPE=\"xtdb-multinode\"/g" /etc/kat/octopoes.conf
 
       - name: Restart KAT
-        run: sudo systemctl restart kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker xtdb-http-multinode
+        run: sudo systemctl restart kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
 
       - name: Setup accounts in Rocky
         run: |
@@ -246,7 +246,7 @@ jobs:
 
       - name: Check XTDB health or print response and logs
         run: |
-          for i in {1..15}; do curl -s -H "Accept: application/edn" http://localhost:3000/_dev/_xtdb/test/status && s=0 && break || s=$? && sleep 1 ; done
+          for i in {1..30}; do curl -s -H "Accept: application/edn" http://localhost:3000/_dev/_xtdb/test/status && s=0 && break || s=$? && sleep 1 ; done
           if [ $s != 0 ]; then echo $(curl -s -H "Accept: application/edn" http://localhost:3000/_dev/_xtdb/test/status) || true && journalctl --no-pager -u xtdb-http-multinode.service && exit $s ; fi
 
       - name: Create _dev node in Octopoes


### PR DESCRIPTION
I saw that the tests for the Debian packages fail sometimes. I think this is because xtdb-http-multinode takes a long time to start and we do not wait enough. This should fix that by not unnecessarily restarting xtdb-http-multinode and also wait longer for xtdb to be ready.

I manually ran the action to test it and that works: https://github.com/minvws/nl-kat-coordination/actions/runs/5178133783

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
