### PR TITLE
Remove containers after `docker-compose run`

### DIFF
--- a/boefjes/Makefile
+++ b/boefjes/Makefile
@@ -31,7 +31,7 @@ help: ## Show this help.
 build: seed
 
 seed:  # Seed the katalogus database
-	-docker-compose run katalogus python -m boefjes.seed
+	-docker-compose run --rm katalogus python -m boefjes.seed
 
 ##
 ##|------------------------------------------------------------------------|
@@ -42,12 +42,12 @@ migrations: ## Generate a migration using alembic
 ifeq ($(m),)
 	$(HIDE) (echo "Specify a message with m={message} and a rev-id with revid={revid} (e.g. 0001 etc.)"; exit 1)
 else
-	docker-compose run katalogus python -m alembic --config /app/boefjes/boefjes/alembic.ini revision --autogenerate -m "$(m)"
+	docker-compose run --rm katalogus python -m alembic --config /app/boefjes/boefjes/alembic.ini revision --autogenerate -m "$(m)"
 endif
 
 
 sql: ## Generate raw sql for the migrations
-	docker-compose run katalogus python -m alembic --config /app/boefjes/boefjes/alembic.ini upgrade $(rev1):$(rev2) --sql
+	docker-compose run --rm katalogus python -m alembic --config /app/boefjes/boefjes/alembic.ini upgrade $(rev1):$(rev2) --sql
 
 check:
 	pre-commit run --all-files --color always

--- a/bytes/Makefile
+++ b/bytes/Makefile
@@ -34,7 +34,7 @@ done: lint test ## Prepare for a commit.
 lint: ## Format the code using black.
 	pre-commit run --all-files --show-diff-on-failure --color always
 
-py-run := docker-compose run bytes python
+py-run := docker-compose --rm run bytes python
 
 
 export revid

--- a/mula/Makefile
+++ b/mula/Makefile
@@ -83,7 +83,7 @@ ifeq ($(m),)
 else ifeq ($(revid),)
 	$(HIDE) (echo "ERROR: Specify a message with m={message} and a rev-id with revid={revid} (e.g. 0001 etc.)"; exit 1)
 else
-	docker-compose run scheduler \
+	docker-compose run --rm scheduler \
 		alembic --config /app/scheduler/scheduler/alembic.ini \
 		revision --autogenerate \
 		-m "$(m)" --rev-id "$(revid)"


### PR DESCRIPTION
### Changes
Remove containers after `docker-compose run`. This prevents e.g. `katalogus-run-...` containers from piling up in development environments.

### Issue link
n/a

### Proof
n/a

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
