### PR TITLE
Edit icon and Text were missing at Organization settings page

### DIFF
--- a/rocky/rocky/templates/organizations/organization_settings.html
+++ b/rocky/rocky/templates/organizations/organization_settings.html
@@ -30,26 +30,28 @@
         <div class="horizontal-scroll">
           <table>
             <thead>
-            <tr>
-              <th>{% translate "Name" %}</th>
-              <th>{% translate "Code" %}</th>
-              <th>{% translate "Edit" %}</th>
-            </tr>
+              <tr>
+                <th>{% translate "Name" %}</th>
+                <th>{% translate "Code" %}</th>
+                {% if perms.tools.change_organization %}
+                  <th>{% translate "Edit" %}</th>
+                {% endif %}
+              </tr>
             </thead>
             <tbody>
-            <tr>
-              <td>{{ organization.name }}</td>
-              <td>{{ organization.code }}</td>
-              <td>
-                {% if perms.tools.can_change_organization %}
-                  {% spaceless %}
-                    <a href="{% url "organization_edit" organization.code %}">
-                      <button class="icon ti-edit action-button">{% translate "Edit" %}</button>
-                    </a>
-                  {% endspaceless %}
+              <tr>
+                <td>{{ organization.name }}</td>
+                <td>{{ organization.code }}</td>
+                {% if perms.tools.change_organization %}
+                  <td>
+                    {% spaceless %}
+                      <a href="{% url "organization_edit" organization.code %}">
+                        <button class="icon ti-edit action-button">{% translate "Edit" %}</button>
+                      </a>
+                    {% endspaceless %}
+                  </td>
                 {% endif %}
-              </td>
-            </tr>
+              </tr>
             </tbody>
           </table>
         </div>

--- a/rocky/tests/test_organization.py
+++ b/rocky/tests/test_organization.py
@@ -448,3 +448,41 @@ def test_organization_list_perms(rf, superuser_member, admin_member, redteam_mem
             setup_request(rf.get("organization_list"), client_member.user),
             organization_code=client_member.organization.code,
         )
+
+
+@pytest.mark.parametrize("member", ["superuser_member", "admin_member"])
+def test_organization_edit_perms(request, member, rf):
+    member = request.getfixturevalue(member)
+
+    response = OrganizationEditView.as_view()(
+        setup_request(rf.get("organization_edit"), member.user),
+        organization_code=member.organization.code,
+        pk=member.organization.id,
+    )
+
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize("member", ["superuser_member", "admin_member"])
+def test_organization_edit_view(request, member, rf):
+    member = request.getfixturevalue(member)
+
+    response = OrganizationSettingsView.as_view()(
+        setup_request(rf.get("organization_settings"), member.user),
+        organization_code=member.organization.code,
+    )
+
+    assert response.status_code == 200
+    assertContains(response, "Edit")
+    assertContains(response, "icon ti-edit")
+
+
+@pytest.mark.parametrize("member", ["redteam_member", "client_member"])
+def test_organization_edit_perms_on_settings_view(request, member, rf):
+    member = request.getfixturevalue(member)
+
+    with pytest.raises(PermissionDenied):
+        OrganizationSettingsView.as_view()(
+            setup_request(rf.get("organization_settings"), member.user),
+            organization_code=member.organization.code,
+        )


### PR DESCRIPTION
### Changes
- Fix wrong permission naming
- Put back edit icon and text in template
- Test which members are able to see Edit button and text, also view permissions for members

### Issue link
_Please add a link to the issue after "Closes". If there is no issue for this PR, please add it to the project board directly._

Closes ...

### Proof
<img width="979" alt="image" src="https://github.com/minvws/nl-kat-coordination/assets/30832687/0dd5d344-96d9-403a-95c1-3ed24f01b1f6">


---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [x] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
