### PR TITLE
fix crisis-room-endpoint in octopoes

### DIFF
--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -585,7 +585,7 @@ class XTDBOOIRepository(OOIRepository):
             {:query {
                 :find [(pull ?finding_type [*]) (count ?finding)]
                 :where [
-                    [?finding :Finding/finding_type ?finding]
+                    [?finding :Finding/finding_type ?finding_type]
                     (not-join [?finding] [?muted_finding :MutedFinding/finding ?finding])
                     ]}}
         """

--- a/octopoes/tests/robot/08_findings.robot
+++ b/octopoes/tests/robot/08_findings.robot
@@ -1,0 +1,63 @@
+*** Settings ***
+Library             OperatingSystem
+Library             RequestsLibrary
+Library             DateTime
+Library             String
+Resource            robot.resource
+
+Test Setup          Setup Test
+Test Teardown       Teardown Test
+
+
+*** Test Cases ***
+List Findings
+    Insert Observation    tests/fixtures/normalizer_output_nxdomain.json
+    Declare Scan Profile    Hostname|internet|example.com    1
+    Await Sync
+
+    Finding List Should Have Length    4
+    Finding Count Per Severity Should Be    'pending'    4
+    Finding Count Per Severity Should Be    'low'    0
+    Finding Count Per Severity Should Be    'critical'    0
+
+
+*** Keywords ***
+Setup Test
+    Start Monitoring    ${QUEUE_URI}
+    Insert Normalizer Output
+    Await Sync
+
+Teardown Test
+    Cleanup
+    Await Sync
+    Stop Monitoring
+
+List Findings
+    ${response}    Get    ${OCTOPOES_URI}/findings
+    ${response_data}    Set Variable    ${response.json()}
+    RETURN    ${response_data}
+
+Get Count Per Severity
+    ${response}    Get    ${OCTOPOES_URI}/findings/count_by_severity
+    ${response_data}    Set Variable    ${response.json()}
+    RETURN    ${response_data}
+
+Finding List Should Have Length
+    [Arguments]    ${expected_length}
+    ${findings}    List Findings
+    Should Be Equal As Integers
+    ...    ${findings['count']}
+    ...    ${expected_length}
+    ...    Expected count of finding list was not as expected
+    Length Should Be
+    ...    ${findings['items']}
+    ...    ${expected_length}
+    ...    Expected length of finding list was not as expected
+
+Finding Count Per Severity Should Be
+    [Arguments]    ${severity}    ${expected_counts}
+    ${counts}    Get Count Per Severity
+    Should Be Equal As Integers
+    ...    ${counts[${severity}]}
+    ...    ${expected_counts}
+    ...    Expected count of finding count per severity was not as expected


### PR DESCRIPTION
### Changes
Fixes a mistake in the query for the count of findings per severity

### Issue link
Closes #1181

### Proof
See tests

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
