### PR TITLE
Fix crisis room not correctly handling Octopoes error

### DIFF
--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -34,7 +34,10 @@ class OrganizationFindingCountPerSeverity:
 
     @property
     def total_critical(self) -> int:
-        return self.finding_count_per_severity[RiskLevelSeverity.CRITICAL.value]
+        try:
+            return self.finding_count_per_severity[RiskLevelSeverity.CRITICAL.value]
+        except KeyError:
+            return 0
 
 
 class CrisisRoomBreadcrumbsMixin(BreadcrumbsMixin):
@@ -65,7 +68,11 @@ class CrisisRoomView(CrisisRoomBreadcrumbsMixin, ConnectorFormMixin, TemplateVie
             return api_connector.count_findings_by_severity(valid_time=self.get_observed_at())
         except ConnectorException:
             messages.add_message(
-                self.request, messages.ERROR, _("Failed to get list of findings, check server logs for more details.")
+                self.request,
+                messages.ERROR,
+                _("Failed to get list of findings for organization {}, check server logs for more details.").format(
+                    organization.code
+                ),
             )
             logger.exception("Failed to get list of findings for organization %s", organization.code)
             return {}

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -219,6 +219,15 @@ def client_member_b(clientuser_b, organization_b):
 
 
 @pytest.fixture
+def client_user_two_organizations(clientuser, organization, organization_b):
+    member = create_member(clientuser, organization)
+    add_client_group_permissions(member)
+    member = create_member(clientuser, organization_b)
+    add_client_group_permissions(member)
+    return clientuser
+
+
+@pytest.fixture
 def new_member(django_user_model, organization):
     user = create_user(django_user_model, "cl1@openkat.nl", "TestTest123!!", "New user", "default_new_user")
     member = create_member(user, organization)

--- a/rocky/tests/test_crisis_room.py
+++ b/rocky/tests/test_crisis_room.py
@@ -7,6 +7,7 @@ from crisis_room.views import (
 from django.urls import resolve, reverse
 from pytest_django.asserts import assertContains
 
+from octopoes.connector import ConnectorException
 from tests.conftest import setup_request
 
 
@@ -22,7 +23,8 @@ def test_crisis_room(rf, client_member, mock_crisis_room_octopoes):
     response = CrisisRoomView.as_view()(request)
 
     assert response.status_code == 200
-    assertContains(response, "1")
+    assertContains(response, '<a href="/en/test/findings/?severity=medium">1</a>', html=True)
+    assertContains(response, '<td><span class="critical">Critical</span></td><td class="number">0</td>', html=True)
 
     assert mock_crisis_room_octopoes().count_findings_by_severity.call_count == 1
 
@@ -43,3 +45,30 @@ def test_crisis_room_observed_at(rf, client_member, mock_crisis_room_octopoes):
 
 def test_org_finding_count_total():
     assert OrganizationFindingCountPerSeverity("dev", "_dev", {"medium": 1, "low": 2}).total == 3
+
+
+def test_crisis_room_error(rf, client_user_two_organizations, mock_crisis_room_octopoes):
+    request = setup_request(rf.get("crisis_room"), client_user_two_organizations)
+    request.resolver_match = resolve(reverse("crisis_room"))
+
+    mock_crisis_room_octopoes().count_findings_by_severity.side_effect = [
+        {
+            "medium": 1,
+            "critical": 0,
+        },
+        ConnectorException("error"),
+    ]
+
+    response = CrisisRoomView.as_view()(request)
+
+    assert response.status_code == 200
+    assertContains(response, '<a href="/en/test/findings/?severity=medium">1</a>', html=True)
+    assertContains(response, '<td><span class="critical">Critical</span></td><td class="number">0</td>', html=True)
+
+    messages = list(request._messages)
+    assert (
+        messages[0].message
+        == "Failed to get list of findings for organization org_b, check server logs for more details."
+    )
+
+    assert mock_crisis_room_octopoes().count_findings_by_severity.call_count == 2


### PR DESCRIPTION
It will show 0 findings and an error message. Also adds test case to make sure it doesn't happen again.