### PR TITLE
Fix non-available preselected option on OOI add form

### DIFF
--- a/rocky/tools/ooi_form.py
+++ b/rocky/tools/ooi_form.py
@@ -1,6 +1,6 @@
 from enum import Enum
 from ipaddress import IPv4Address, IPv6Address
-from typing import Dict, List, Type, Union
+from typing import Dict, List, Optional, Type, Union
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -20,6 +20,7 @@ class OOIForm(BaseRockyForm):
         super().__init__(*args, **kwargs)
         self.ooi_class = ooi_class
         self.api_connector = connector
+        self.initial = kwargs.get("initial", {})
 
         fields = self.get_fields()
         for name, field in fields.items():
@@ -50,7 +51,10 @@ class OOIForm(BaseRockyForm):
                 fields[name] = forms.CharField(widget=forms.HiddenInput())
             elif field.name in get_relations(self.ooi_class):
                 fields[name] = generate_select_ooi_field(
-                    self.api_connector, field, get_relations(self.ooi_class)[field.name]
+                    self.api_connector,
+                    field,
+                    get_relations(self.ooi_class)[field.name],
+                    self.initial.get(field.name, None),
                 )
             elif field.type_ in [IPv4Address, IPv6Address]:
                 fields[name] = generate_ip_field(field)
@@ -67,7 +71,10 @@ class OOIForm(BaseRockyForm):
 
 
 def generate_select_ooi_field(
-    api_connector: OctopoesAPIConnector, field: ModelField, related_ooi_type: Type[OOI]
+    api_connector: OctopoesAPIConnector,
+    field: ModelField,
+    related_ooi_type: Type[OOI],
+    initial: Optional[str] = None,
 ) -> forms.fields.Field:
     """Select field will have a list of OOIs"""
     # field is a relation, query all objects, and build select
@@ -76,17 +83,22 @@ def generate_select_ooi_field(
     option_label = default_attrs.get("label", _("option"))
 
     option_text = "-- " + _("Optionally choose a {option_label}").format(option_label=option_label) + " --"
-
     if field.required:
         option_text = "-- " + _("Please choose a {option_label}").format(option_label=option_label) + " --"
 
     # Generate select options
     select_options = [] if is_multiselect else [("", option_text)]
+
+    if initial:
+        select_options.append((initial, initial))
+
     oois = api_connector.list({related_ooi_type}).items
     select_options.extend([(ooi.primary_key, ooi.primary_key) for ooi in oois])
 
     if is_multiselect:
-        return forms.MultipleChoiceField(widget=forms.SelectMultiple(), choices=select_options, **default_attrs)
+        return forms.MultipleChoiceField(
+            widget=forms.SelectMultiple(), choices=select_options, initial=initial, **default_attrs
+        )
 
     return forms.CharField(widget=forms.Select(choices=select_options), **default_attrs)
 


### PR DESCRIPTION
### Changes
The OOI-add-form populates lists of references for foreign-key fields. These are by default limited to 50 items.

Through the "add-related" OOI interface, a value should be preset for a specific field. However, due the limitation to 50 items, it becomes likely that the original OOI is not present in the random 50. This PR fixes this by making sure that the preselected OOI is always part of the option list.

_For later: there should probably an interface to search through all OOIs._

### Issue link
N/A

### Proof
![Screenshot 2023-06-16 at 15 34 21](https://github.com/minvws/nl-kat-coordination/assets/9639395/c395e0e7-d5bf-4a49-8ed3-3bedaee400cd)



---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
