### PR TITLE
Fix sorting in KAT-alogus

### DIFF
--- a/rocky/katalogus/views/katalogus.py
+++ b/rocky/katalogus/views/katalogus.py
@@ -73,7 +73,7 @@ class KATalogusView(ListView, OrganizationView, FormView):
         if sort_options == "a-z":
             return queryset
         if sort_options == "z-a":
-            return list(reversed(queryset))
+            return queryset[::-1]
         if sort_options == "enabled-disabled":
             return sorted(queryset, key=lambda item: not item["enabled"])
         if sort_options == "disabled-enabled":

--- a/rocky/katalogus/views/katalogus.py
+++ b/rocky/katalogus/views/katalogus.py
@@ -73,7 +73,7 @@ class KATalogusView(ListView, OrganizationView, FormView):
         if sort_options == "a-z":
             return queryset
         if sort_options == "z-a":
-            return reversed(queryset)
+            return list(reversed(queryset))
         if sort_options == "enabled-disabled":
             return sorted(queryset, key=lambda item: not item["enabled"])
         if sort_options == "disabled-enabled":


### PR DESCRIPTION
### Changes
When filtering at KAT-alogus from z-a it does not return a list object and it is not subscriptable and also object count does not work

### Issue link
_Please add a link to the issue after "Closes". If there is no issue for this PR, please add it to the project board directly._

Closes ...

### Proof
_Please add some proof of your working change here, unless this is not required (e.g. this PR is trivial)._

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
