### PR TITLE
Remove unused max_plugin_runtime configuration variable

### DIFF
--- a/boefjes/boefjes/config.py
+++ b/boefjes/boefjes/config.py
@@ -17,7 +17,6 @@ class Settings(BaseSettings):
     pool_size: int = 2
     poll_interval: float = 1.0
     worker_heartbeat: float = 1.0
-    max_plugin_runtime: Optional[float] = None
 
     # Queue configuration
     queue_name_boefjes: str = "boefjes"


### PR DESCRIPTION
### Changes
This is an artifact from https://github.com/minvws/nl-kat-coordination/pull/1187

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [x] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
