### PR TITLE
Remove redundant `pyproject` config entries

### DIFF
--- a/boefjes/pyproject.toml
+++ b/boefjes/pyproject.toml
@@ -37,15 +37,6 @@ black = "^23.1.0"
 requires = ["setuptools>=45", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
 
-[tool.black]
-line-length = 120
-target-version = ["py38"]
-
-[tool.vulture]
-paths = ["boefjes/"]
-min_confidence = 90
-sort_by_size = true
-
 [tool.flynt]
 line-length = 120
 transform-concats = true

--- a/bytes/pyproject.toml
+++ b/bytes/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "bytes"
 version = "0.0.1.dev1"
-description = "KAT forensic data store"
+description = "KAT's forensic data store"
 authors = ["MinVWS <maintainer@openkat.nl>"]
 license = "EUPL"
 
@@ -81,28 +81,6 @@ setuptools = "^68.0.0"
 toml = "^0.10.2"
 tomli = "^2.0.1"
 wrapt = "^1.14.1"
-
-[tool.black]
-line-length = 120
-target-version = ['py38']
-
-[tool.mypy]
-python_version = 3.8
-plugins = ["pydantic.mypy"]
-exclude = "bytes-data"
-strict = true
-ignore_missing_imports = true
-disallow_untyped_decorators = false # Needed for FastAPI decorators
-
-
-[tool.vulture]
-min_confidence = 90
-paths = ["bytes"]
-
-[tool.pylint.master]
-disable = ["missing-module-docstring", "missing-class-docstring", "missing-function-docstring", "too-few-public-methods", "import-error", "too-many-arguments"]
-max-line-length = 120
-check-quote-consistency = true
 
 [build-system]
 requires = ["setuptools>=65", "wheel"]

--- a/mula/pyproject.toml
+++ b/mula/pyproject.toml
@@ -39,42 +39,6 @@ pytest = "^7.2.2"
 pytest-cov = "^4.0.0"
 httpx = "^0.23.3"
 
-[tool.black]
-line-length = 120
-target-version = ['py38']
-
-[tool.mypy]
-python_version = 3.8
-strict = false
-install_types = true
-non_interactive = true
-ignore_missing_imports = true
-implicit_reexport = true
-exclude = "^(tests|whitelist.py)"
-
-[tool.pylint.master]
-fail-under=7.0
-max-line-length=120
-check-quote-consistency=true
-extension-pkg-whitelist = [
-    "pydantic",
-    "mmh3"
-]
-disable = [
-    "missing-module-docstring",
-    "missing-class-docstring",
-    "missing-function-docstring",
-    "too-few-public-methods",
-    "cyclic-import",
-    "fixme",
-    "invalid-name",
-]
-
-[tool.vulture]
-min_confidence = 90
-paths = ["./"]
-exclude = ["tests"]
-
 [build-system]
 requires = ["setuptools>=59", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"

--- a/rocky/pyproject.toml
+++ b/rocky/pyproject.toml
@@ -91,30 +91,6 @@ django-admin-auto-tests = { git = "https://github.com/dekkers/django-admin-auto-
 requires = ["setuptools>=62.2", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
 
-[tool.black]
-target-version = ['py38']
-line-length = 120
-
-[tool.mypy]
-python_version = "3.8"
-exclude = [".git", "__pycache__", "old", "build", "dist", "venv"]
-strict = true
-ignore_missing_imports = true # Required as third-party modules may not come with type stubs
-follow_imports = "skip"
-
-[tool.vulture]
-exclude = [".git", "__pycache__", "old", "build", "dist", "venv"]
-paths = ["./"]
-min_confidence = 90
-ignore_names = ["mock_*"]
-
-[tool.pylint.format]
-max-line-length = 120
-
-[tool.pylint."MESSAGES CONTROL"]
-extension-pkg-whitelist = "pydantic" # Ignore pydantic import checks
-disable = ["E0203", "F0401", "R0914", "W1514", "R0903", "E0401"]
-
 [tool.pytest.ini_options]
 addopts = "--cov --cov-branch --cov-report=term-missing:skip-covered"
 DJANGO_SETTINGS_MODULE = "rocky.settings"


### PR DESCRIPTION
### Changes
See title. These config options are redundant as they are configured in the root `pyproject.toml`. 

### Issue link
Linked directly.

### Proof
See CI.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
