### PR TITLE
Fix <no title> in the user guide docs

### DIFF
--- a/docs/source/manual/index.rst
+++ b/docs/source/manual/index.rst
@@ -1,3 +1,8 @@
+User Guide
+##########
+
+An overview of all KAT functionality, from a user perspective.
+
 .. toctree::
    :maxdepth: 4
    :caption: Contents


### PR DESCRIPTION
Before:

![image](https://github.com/minvws/nl-kat-coordination/assets/9536436/4fd9601f-23a8-4441-a476-509d07167f2f)


After:

![image](https://github.com/minvws/nl-kat-coordination/assets/9536436/4a569bee-2afb-4e30-8874-e1bb90bd4ba2)

