### PR TITLE
Add pyproject.toml to black pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -48,6 +48,7 @@ repos:
     rev: "23.3.0"
     hooks:
       - id: black
+        files: pyproject.toml$
 
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: v1.2.0


### PR DESCRIPTION
### Issue
Black did not listen to pyrpoject.tml configs when running `pre-commit` with `git commit`

### Changes
Black did not listen to configuration of pyproject.toml, now added to the .pre-commit-config.yaml