### PR TITLE
Add explicit `black` config to all modules

### DIFF
--- a/boefjes/pyproject.toml
+++ b/boefjes/pyproject.toml
@@ -40,3 +40,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 [tool.flynt]
 line-length = 120
 transform-concats = true
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120

--- a/bytes/pyproject.toml
+++ b/bytes/pyproject.toml
@@ -85,3 +85,7 @@ wrapt = "^1.14.1"
 [build-system]
 requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120

--- a/keiko/pyproject.toml
+++ b/keiko/pyproject.toml
@@ -34,3 +34,7 @@ httpx = "^0.23.3"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120

--- a/mula/pyproject.toml
+++ b/mula/pyproject.toml
@@ -47,3 +47,7 @@ build-backend = "setuptools.build_meta:__legacy__"
 omit = [
     "scheduler/alembic/*"
 ]
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120

--- a/octopoes/pyproject.toml
+++ b/octopoes/pyproject.toml
@@ -51,3 +51,7 @@ pytest-mock = "^3.10.0"
 pre-commit = "^2.20.0"
 httpx = "^0.23.3"
 pytest-timeout = "^2.1.0"
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [tool.black]
-target-version = ["py38"]
+target-version = ["py38", "py39", "py310", "py311"]
 line-length = 120
 
 [tool.mypy]

--- a/rocky/pyproject.toml
+++ b/rocky/pyproject.toml
@@ -103,3 +103,7 @@ max_line_length = 120
 blank_line_after_tag = "load,extends,include"
 # https://www.djlint.com/docs/linter/#rules
 ignore = "H006,H016,H017,H030,H031"
+
+[tool.black]
+target-version = ["py38", "py39", "py310", "py311"]
+line-length = 120


### PR DESCRIPTION
### Changes
`pre-commit` applies different `black` configs depending on whether it is run with `--all-files` or as part of the git commit hook. Adding explicit `black` configs to all `pyproject.toml` files fixes this. Not a pretty solution, but given that `black`'s config only changes very little it's acceptable imho.

### Issue link
Closes https://github.com/minvws/nl-kat-coordination/pull/1393

### Proof
Fixes my local ping-pong issue where the git commit hook reformats `--all-files` and vice versa.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
