### PR TITLE
Default scan level filter to 0

### DIFF
--- a/boefjes/boefjes/katalogus/types.py
+++ b/boefjes/boefjes/katalogus/types.py
@@ -18,4 +18,4 @@ class FilterParameters(BaseModel):
     q: Optional[str] = None
     type: Optional[Literal["boefje", "normalizer", "bit"]] = None
     state: Optional[bool] = None
-    scan_level: int = 1
+    scan_level: int = 0


### PR DESCRIPTION
### Changes
Change the default scan level in katalogus filtering to 0.


