### PR TITLE
Fix OOI edit form

### DIFF
--- a/rocky/rocky/templates/oois/ooi_edit.html
+++ b/rocky/rocky/templates/oois/ooi_edit.html
@@ -9,11 +9,8 @@
     <main id="main-content">
         <article>
             <div class="layout-form">
-                <h1>{% blocktranslate %}Edit {{ display_type }}{% endblocktranslate %}</h1>
-                <p>{% blocktranslate %}Here you can edit the {{ display_type }}.{% endblocktranslate %}</p>
-                <p>
-                    {% blocktranslate %}Some fields are disabled:<br>In this version primary key fields can't be edited.{% endblocktranslate %}
-                </p>
+                <h1>{% blocktranslate %}Edit {{ type }}: {{ ooi_human_readable }}{% endblocktranslate %}</h1>
+                <p>{% blocktranslate %}Primary key fields cannot be edited.{% endblocktranslate %}</p>
                 <form method="post" class="horizontal-view">
                     {% csrf_token %}
                     {% if form.non_field_errors %}<div class="warning">{{ form.non_field_errors }}</div>{% endif %}
@@ -27,7 +24,6 @@
                         </div>
                         {% for field in form %}
                             {% include "partials/form/field_input_wrapper.html" %}
-
                         {% endfor %}
                     </fieldset>
                     <button type="submit">{% blocktranslate %}Save {{ display_type }}{% endblocktranslate %}</button>

--- a/rocky/rocky/views/ooi_edit.py
+++ b/rocky/rocky/views/ooi_edit.py
@@ -1,7 +1,6 @@
 from django.utils.translation import gettext_lazy as _
 from tools.view_helpers import get_ooi_url
 
-from octopoes.models import Reference
 from rocky.views.ooi_view import BaseOOIFormView
 
 
@@ -17,12 +16,13 @@ class OOIEditView(BaseOOIFormView):
         initial = super().get_initial()
 
         for attr, value in self.ooi:
-            if isinstance(value, Reference):
-                initial[attr] = str(value)
-            elif isinstance(value, list):
+            if isinstance(value, list):
                 initial[attr] = [str(x) for x in value]
-            else:
+            elif isinstance(value, dict):
+                # Config OOIs use dicts for their values
                 initial[attr] = value
+            else:
+                initial[attr] = str(value)
 
         return initial
 

--- a/rocky/rocky/views/ooi_edit.py
+++ b/rocky/rocky/views/ooi_edit.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from django.utils.translation import gettext_lazy as _
 from tools.view_helpers import get_ooi_url
 
@@ -18,6 +20,8 @@ class OOIEditView(BaseOOIFormView):
         for attr, value in self.ooi:
             if isinstance(value, list):
                 initial[attr] = [str(x) for x in value]
+            elif isinstance(value, Enum):
+                initial[attr] = value.value
             elif isinstance(value, dict):
                 # Config OOIs use dicts for their values
                 initial[attr] = value

--- a/rocky/rocky/views/ooi_edit.py
+++ b/rocky/rocky/views/ooi_edit.py
@@ -43,6 +43,7 @@ class OOIEditView(BaseOOIFormView):
         )
 
         context["type"] = self.ooi_class.get_ooi_type()
+        context["ooi_human_readable"] = self.ooi.human_readable
         context["breadcrumbs"] = breadcrumb_list
 
         return context


### PR DESCRIPTION
### Changes

**Convert to string in OOI edit form**
    
Currently, the form can have e.g. an `ipaddress.IPv4Address` passed in,
causing errors when saving the form.
    
There are some exceptions to this, such as dicts used for JSON fields
(Config OOIs).

**Fix initial value for enum fields**

**Clean up OOI edit form template**

### Issue link
Fixes #1495

### Proof
n/a

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
