### PR TITLE
Fix: Add red teamer permissions to admin as well

### DIFF
--- a/rocky/tools/management/commands/setup_dev_account.py
+++ b/rocky/tools/management/commands/setup_dev_account.py
@@ -49,6 +49,12 @@ class Command(BaseCommand):
                 "can_delete_oois",
                 "add_indemnification",
                 "can_recalculate_bits",
+                "can_scan_organization",
+                "can_enable_disable_boefje",
+                "can_set_clearance_level",
+                "can_mute_findings",
+                "can_view_katalogus_settings",
+                "can_set_katalogus_settings",
             ]
         )
         self.group_admin.permissions.set(admin_permissions)

--- a/rocky/tools/management/commands/setup_dev_account.py
+++ b/rocky/tools/management/commands/setup_dev_account.py
@@ -39,38 +39,34 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         self.setup_kat_groups()
 
+        redteamer_permissions = [
+            "can_scan_organization",
+            "can_enable_disable_boefje",
+            "can_set_clearance_level",
+            "can_delete_oois",
+            "can_mute_findings",
+            "can_view_katalogus_settings",
+            "can_set_katalogus_settings",
+        ]
+
+        redteam_permissions = self.get_permissions(redteamer_permissions)
+        self.group_redteam.permissions.set(redteam_permissions)
+
         admin_permissions = self.get_permissions(
-            [
+            redteamer_permissions
+            + [
                 "view_organization",
                 "view_organizationmember",
                 "add_organizationmember",
                 "change_organization",
                 "change_organizationmember",
-                "can_delete_oois",
                 "add_indemnification",
                 "can_recalculate_bits",
-                "can_scan_organization",
-                "can_enable_disable_boefje",
-                "can_set_clearance_level",
-                "can_mute_findings",
-                "can_view_katalogus_settings",
-                "can_set_katalogus_settings",
             ]
         )
         self.group_admin.permissions.set(admin_permissions)
 
-        redteam_permissions = self.get_permissions(
-            [
-                "can_scan_organization",
-                "can_enable_disable_boefje",
-                "can_set_clearance_level",
-                "can_delete_oois",
-                "can_mute_findings",
-                "can_view_katalogus_settings",
-                "can_set_katalogus_settings",
-            ]
-        )
-        self.group_redteam.permissions.set(redteam_permissions)
         client_permissions = self.get_permissions(["can_scan_organization"])
         self.group_client.permissions.set(client_permissions)
+
         logging.info("ROCKY HAS BEEN SETUP SUCCESSFULLY")

--- a/rocky/tools/migrations/0040_admin_inherits_red_teamer_permissions.py
+++ b/rocky/tools/migrations/0040_admin_inherits_red_teamer_permissions.py
@@ -1,0 +1,46 @@
+from django.contrib.auth.management import create_permissions
+from django.db import migrations
+
+from tools.models import GROUP_ADMIN
+
+
+# same as in 0026_auto_20221031_1344.py
+# https://stackoverflow.com/a/40092780/1336275
+def migrate_permissions(apps, schema_editor):
+    for app_config in apps.get_app_configs():
+        app_config.models_module = True
+        create_permissions(app_config, apps=apps, verbosity=0)
+        app_config.models_module = None
+
+
+def add_group_permissions(apps, schema_editor):
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+    try:
+        admin = Group.objects.get(name=GROUP_ADMIN)
+
+        redteamer_permissions = [
+            "can_scan_organization",
+            "can_enable_disable_boefje",
+            "can_set_clearance_level",
+            "can_delete_oois",
+            "can_mute_findings",
+            "can_view_katalogus_settings",
+            "can_set_katalogus_settings",
+        ]
+
+        for permission in redteamer_permissions:
+            admin.permissions.add(Permission.objects.get(codename=permission))
+    except Group.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("tools", "0039_update_permissions"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_permissions),
+        migrations.RunPython(add_group_permissions),
+    ]


### PR DESCRIPTION
### Changes
Fix the problem where admins couldn't access boefje detail pages and couldn't enable/disable them. It was intended for admins to have the same permissions as red teamers, so this PR fixes that.

### Issue link
Closes https://github.com/minvws/nl-kat-coordination/issues/1492

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
