### PR TITLE
Remove hyperlink to 'manual' boefje, which isn't actually a boefje and resulted in a 404

### DIFF
--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -43,7 +43,11 @@
                                             <td>{% translate "No input OOI" %}</td>
                                         {% endif %}
                                         <td>
-                                          <a href="{% url 'plugin_detail' organization_code=organization.code plugin_type='boefje' plugin_id=task.p_item.data.raw_data.boefje_meta.boefje.id %}">{{ task.p_item.data.raw_data.boefje_meta.boefje.id }}</a>
+                                          {% if task.p_item.data.raw_data.boefje_meta.boefje.id != 'manual' %}
+                                              <a href="{% url 'plugin_detail' organization_code=organization.code plugin_type='boefje' plugin_id=task.p_item.data.raw_data.boefje_meta.boefje.id %}">{{ task.p_item.data.raw_data.boefje_meta.boefje.id }}</a>
+                                          {% else %}
+                                              {{ task.p_item.data.raw_data.boefje_meta.boefje.id }}
+                                          {% endif %}
                                         </td>
                                         <td>{{ task.p_item.data.normalizer.id }}</td>
                                         {% if task.status.value == "completed" %}


### PR DESCRIPTION
### Changes
Remove hyperlink to 'manual' boefje, which isn't actually a boefje and resulted in a 404. By removing the hyperlink the user will not get the unnecessary 404.

### Proof
<img width="1460" alt="image" src="https://github.com/minvws/nl-kat-coordination/assets/16188579/23e27a65-07ba-4547-98d2-8e933ce80a71">

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.


---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
