### PR TITLE
Fix `rstcheck` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
     hooks:
       - id: rstcheck
         # https://github.com/rstcheck/rstcheck-core/issues/4
-        args: ["--ignore-messages", "Hyperlink target .* is not referenced"]
+        args: ["--ignore-messages", "Hyperlink target .* is not referenced", "--ignore-directives", "mermaid"]
         additional_dependencies: ["rstcheck[sphinx]"]
 
   - repo: https://github.com/MarketSquare/robotframework-tidy

--- a/poetry.lock
+++ b/poetry.lock
@@ -699,13 +699,13 @@ test = ["flake8", "mypy", "pytest"]
 
 [[package]]
 name = "sphinxcontrib-mermaid"
-version = "0.8.1"
+version = "0.9.2"
 description = "Mermaid diagrams in yours Sphinx powered docs"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "sphinxcontrib-mermaid-0.8.1.tar.gz", hash = "sha256:fa3e5325d4ba395336e6137d113f55026b1a03ccd115dc54113d1d871a580466"},
-    {file = "sphinxcontrib_mermaid-0.8.1-py3-none-any.whl", hash = "sha256:15491c24ec78cf1626b1e79e797a9ce87cb7959cf38f955eb72dd5512aeb6ce9"},
+    {file = "sphinxcontrib-mermaid-0.9.2.tar.gz", hash = "sha256:252ef13dd23164b28f16d8b0205cf184b9d8e2b714a302274d9f59eb708e77af"},
+    {file = "sphinxcontrib_mermaid-0.9.2-py3-none-any.whl", hash = "sha256:6795a72037ca55e65663d2a2c1a043d636dc3d30d418e56dd6087d1459d98a5d"},
 ]
 
 [[package]]
@@ -793,4 +793,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "96dd983c35e1b14c4c813847d3ed7d56f6961c9a6d0af0fbafb5e1a0413904b8"
+content-hash = "3d4b9a5bb2a08ad0cd05db0069eb929ad97d52016268bf2598eaee348653a0c8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ build-backend = "poetry.core.masonry.api"
 python = "^3.8"
 sphinx = "6.1.3"
 sphinx_rtd_theme = "1.2.2"
-sphinxcontrib-mermaid = "0.8.1"
+sphinxcontrib-mermaid = "^0.9.2"
 myst-parser = "2.0.0"
 
 [tool.poetry.group.dev.dependencies]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -265,9 +265,9 @@ sphinxcontrib-jquery==4.1 ; python_version >= "3.8" and python_version < "4.0" \
 sphinxcontrib-jsmath==1.0.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
-sphinxcontrib-mermaid==0.8.1 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:15491c24ec78cf1626b1e79e797a9ce87cb7959cf38f955eb72dd5512aeb6ce9 \
-    --hash=sha256:fa3e5325d4ba395336e6137d113f55026b1a03ccd115dc54113d1d871a580466
+sphinxcontrib-mermaid==0.9.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:252ef13dd23164b28f16d8b0205cf184b9d8e2b714a302274d9f59eb708e77af \
+    --hash=sha256:6795a72037ca55e65663d2a2c1a043d636dc3d30d418e56dd6087d1459d98a5d
 sphinxcontrib-qthelp==1.0.3 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6

--- a/requirements.txt
+++ b/requirements.txt
@@ -241,9 +241,9 @@ sphinxcontrib-jquery==4.1 ; python_version >= "3.8" and python_version < "4.0" \
 sphinxcontrib-jsmath==1.0.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:2ec2eaebfb78f3f2078e73666b1415417a116cc848b72e5172e596c871103178 \
     --hash=sha256:a9925e4a4587247ed2191a22df5f6970656cb8ca2bd6284309578f2153e0c4b8
-sphinxcontrib-mermaid==0.8.1 ; python_version >= "3.8" and python_version < "4.0" \
-    --hash=sha256:15491c24ec78cf1626b1e79e797a9ce87cb7959cf38f955eb72dd5512aeb6ce9 \
-    --hash=sha256:fa3e5325d4ba395336e6137d113f55026b1a03ccd115dc54113d1d871a580466
+sphinxcontrib-mermaid==0.9.2 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:252ef13dd23164b28f16d8b0205cf184b9d8e2b714a302274d9f59eb708e77af \
+    --hash=sha256:6795a72037ca55e65663d2a2c1a043d636dc3d30d418e56dd6087d1459d98a5d
 sphinxcontrib-qthelp==1.0.3 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:4c33767ee058b70dba89a6fc5c1892c0d57a54be67ddd3e7875a18d14cba5a72 \
     --hash=sha256:bd9fc24bcb748a8d51fd4ecaade681350aa63009a347a8c14e637895444dfab6


### PR DESCRIPTION
### Changes
This fix ignores the `mermaid` directive by the `rstcheck` hook since it doesn't support this directive (yet). We should still  find another way to properly check/ lint the Mermaid diagrams we create.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
