### PR TITLE
Improve filter by muted findings on findings page

### DIFF
--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -326,6 +326,7 @@ def get_scan_profile_inheritance(
 @router.get("/findings", tags=["Findings"])
 def list_findings(
     exclude_muted: bool = True,
+    only_muted: bool = False,
     offset=DEFAULT_OFFSET,
     limit=DEFAULT_LIMIT,
     octopoes: OctopoesService = Depends(octopoes_service),
@@ -335,6 +336,7 @@ def list_findings(
     return octopoes.ooi_repository.list_findings(
         severities,
         exclude_muted,
+        only_muted,
         offset,
         limit,
         valid_time,

--- a/octopoes/octopoes/connector/octopoes.py
+++ b/octopoes/octopoes/connector/octopoes.py
@@ -204,6 +204,7 @@ class OctopoesAPIConnector:
         self,
         severities: Set[RiskLevelSeverity],
         exclude_muted: bool = True,
+        only_muted: bool = False,
         valid_time: Optional[datetime] = None,
         offset: int = DEFAULT_OFFSET,
         limit: int = DEFAULT_LIMIT,
@@ -214,6 +215,7 @@ class OctopoesAPIConnector:
             "limit": limit,
             "severities": {s.value for s in severities},
             "exclude_muted": exclude_muted,
+            "only_muted": only_muted,
         }
         res = self.session.get(f"/{self.client}/findings", params=params)
         return Paginated[Finding].parse_obj(res.json())

--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -635,6 +635,7 @@ class XTDBOOIRepository(OOIRepository):
         self,
         severities: Set[RiskLevelSeverity],
         exclude_muted=False,
+        only_muted=False,
         offset=DEFAULT_OFFSET,
         limit=DEFAULT_LIMIT,
         valid_time: Optional[datetime] = None,
@@ -654,9 +655,11 @@ class XTDBOOIRepository(OOIRepository):
         ]
         or_scores = f"(or {' '.join(score_clauses)})"
 
-        exclude_muted_clause = ""
+        muted_clause = ""
         if exclude_muted:
-            exclude_muted_clause = "(not-join [?finding] [?muted_finding :MutedFinding/finding ?finding])"
+            muted_clause = "(not-join [?finding] [?muted_finding :MutedFinding/finding ?finding])"
+        elif only_muted:
+            muted_clause = "[?muted_finding :MutedFinding/finding ?finding]"
 
         severity_values = ", ".join([str_val(severity.value) for severity in severities])
 
@@ -669,7 +672,7 @@ class XTDBOOIRepository(OOIRepository):
                             [?finding :Finding/finding_type ?finding_type]
                             [(== ?severity severities_)]
                             {or_severities}
-                            {exclude_muted_clause}]
+                            {muted_clause}]
                 }}
                 :in-args [[{severity_values}]]
             }}
@@ -690,7 +693,7 @@ class XTDBOOIRepository(OOIRepository):
                             [(== ?severity severities_)]
                             {or_severities}
                             {or_scores}
-                            {exclude_muted_clause}]
+                            {muted_clause}]
                     :limit {limit}
                     :offset {offset}
                     :order-by [[?score :desc]]

--- a/rocky/assets/src/bundles/app/css/components/form.scss
+++ b/rocky/assets/src/bundles/app/css/components/form.scss
@@ -1,4 +1,7 @@
 /* Added min height for form buttons */
+
+$breakpoint-filter: 60rem;
+
 form {
 	button,
 	a.button,
@@ -6,6 +9,22 @@ form {
 	input[type="submit"],
 	input[type="reset"] {
 		min-height: 2.75rem;
+	}
+
+	.filter-fields-direction {
+		display: flex;
+
+		&.column {
+			flex-direction: column;
+		}
+	}
+
+	@media (min-width:$breakpoint-filter) {
+		.filter-fields-direction {
+			&.row {
+				flex-direction: row;
+			}
+		}
 	}
 }
 

--- a/rocky/assets/src/bundles/app/css/themes/soft/manon/form-fieldset.scss
+++ b/rocky/assets/src/bundles/app/css/themes/soft/manon/form-fieldset.scss
@@ -3,3 +3,9 @@
 :root {
   --form-horizontal-view-fieldset-label-margin-top: 0;
 }
+
+form legend {
+  font-weight: var(--form-fieldset-legend-font-weight);
+  margin-bottom: var(--form-fieldset-legend-margin-bottom);
+  padding: 0;
+}

--- a/rocky/rocky/templates/findings/findings_filter.html
+++ b/rocky/rocky/templates/findings/findings_filter.html
@@ -2,7 +2,6 @@
 
 {% load static %}
 {% load i18n %}
-{% load i18n %}
 
 {% block title %}
     {% if count %}<span>{{ count }}</span>{% endif %}
@@ -11,9 +10,11 @@
 {% block filter_form %}
     <form method="get" class="help">
         {% include "partials/form/fieldset.html" with fields=observed_at_form %}
-        {% include "partials/form/fieldset.html" with fields=muted_findings_filter_form %}
-        {% include "partials/form/fieldset.html" with fields=severity_filter_form %}
 
+        <div class="column-3 filter-fields-direction row">
+            {% include "partials/form/fieldset.html" with fields=severity_filter fieldset_class="filter-fields-direction column" %}
+            {% include "partials/form/fieldset.html" with fields=muted_findings_filter fieldset_class="filter-fields-direction column" %}
+        </div>
         <div class="button-container">
             <input type="submit"
                    value="{% if submit_text %}{{ submit_text }}{% else %}{% translate "Set filters" %}{% endif %}"/>

--- a/rocky/rocky/templates/partials/form/field_input_multiselect.html
+++ b/rocky/rocky/templates/partials/form/field_input_multiselect.html
@@ -1,4 +1,4 @@
-<fieldset class="grouped-choice-list">
+<fieldset class="{{ fieldset_class }}">
     <legend>{{ field.label }}</legend>
     {% for choice in field %}
         <div class="checkbox">

--- a/rocky/rocky/templates/partials/form/field_input_radio.html
+++ b/rocky/rocky/templates/partials/form/field_input_radio.html
@@ -1,6 +1,6 @@
 {% load i18n %}
 
-<fieldset class="grouped-choice-list">
+<fieldset class="{{ fieldset_class }}">
     <legend>{{ field.label }}</legend>
     {% if field.field.required %}
         <span class="nota-bene">{% translate "This field is required" %}</span>

--- a/rocky/rocky/views/finding_list.py
+++ b/rocky/rocky/views/finding_list.py
@@ -5,7 +5,7 @@ from django.urls.base import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView
 from tools.forms.base import ObservedAtForm
-from tools.forms.findings import FindingMutedSelectionForm, FindingSeverityMultiSelectForm
+from tools.forms.findings import FindingSeverityMultiSelectForm, MutedFindingSelectionForm
 from tools.view_helpers import BreadcrumbsMixin
 
 from octopoes.models.ooi.findings import RiskLevelSeverity
@@ -55,18 +55,25 @@ class FindingListFilter(OctopoesView, ConnectorFormMixin, SeveritiesMixin, ListV
         super().setup(request, *args, **kwargs)
         self.severities = self.get_severities()
         self.valid_time = self.get_observed_at()
-        self.exclude_muted = request.GET.get("exclude_muted", False)
+        self.muted_findings = request.GET.get("muted_findings", "non-muted")
+
+        self.exclude_muted = self.muted_findings == "non-muted"
+        self.only_muted = self.muted_findings == "muted"
 
     def get_queryset(self) -> FindingList:
         return FindingList(
-            self.octopoes_api_connector, self.valid_time, self.severities, exclude_muted=self.exclude_muted
+            octopoes_connector=self.octopoes_api_connector,
+            valid_time=self.valid_time,
+            severities=self.severities,
+            exclude_muted=self.exclude_muted,
+            only_muted=self.only_muted,
         )
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["observed_at_form"] = self.get_connector_form()
-        context["severity_filter_form"] = FindingSeverityMultiSelectForm(self.request.GET)
-        context["muted_findings_filter_form"] = FindingMutedSelectionForm(self.request.GET)
+        context["severity_filter"] = FindingSeverityMultiSelectForm({"severity": list(self.severities)})
+        context["muted_findings_filter"] = MutedFindingSelectionForm({"muted_findings": self.muted_findings})
         return context
 
 

--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -192,7 +192,8 @@ class FindingList:
         octopoes_connector: OctopoesAPIConnector,
         valid_time: datetime,
         severities: Set[RiskLevelSeverity],
-        exclude_muted: bool = True,
+        exclude_muted: bool = False,
+        only_muted: bool = False,
     ):
         self.octopoes_connector = octopoes_connector
         self.valid_time = valid_time
@@ -200,12 +201,14 @@ class FindingList:
         self._count = None
         self.severities = severities
         self.exclude_muted = exclude_muted
+        self.only_muted = only_muted
 
     @cached_property
     def count(self) -> int:
         return self.octopoes_connector.list_findings(
             severities=self.severities,
             exclude_muted=self.exclude_muted,
+            only_muted=self.only_muted,
             valid_time=self.valid_time,
             limit=0,
         ).count
@@ -220,6 +223,7 @@ class FindingList:
             findings = self.octopoes_connector.list_findings(
                 severities=self.severities,
                 exclude_muted=self.exclude_muted,
+                only_muted=self.only_muted,
                 valid_time=self.valid_time,
                 offset=offset,
                 limit=limit,

--- a/rocky/tools/forms/findings.py
+++ b/rocky/tools/forms/findings.py
@@ -8,6 +8,12 @@ FINDINGS_SEVERITIES_CHOICES = (
     (str(severity.name).lower(), str(severity.value).lower()) for severity in RiskLevelSeverity
 )
 
+MUTED_FINDINGS_CHOICES = (
+    ("non-muted", _("Show non-muted findings")),
+    ("muted", _("Show muted findings")),
+    ("all", _("Show all findings")),
+)
+
 
 class FindingSeverityMultiSelectForm(forms.Form):
     severity = forms.MultipleChoiceField(
@@ -18,5 +24,11 @@ class FindingSeverityMultiSelectForm(forms.Form):
     )
 
 
-class FindingMutedSelectionForm(BaseRockyForm):
-    exclude_muted = forms.BooleanField(label=_("Exclude Muted Findings"), required=False)
+class MutedFindingSelectionForm(BaseRockyForm):
+    muted_findings = forms.ChoiceField(
+        initial="non-muted",
+        label=_("Filter by muted findings"),
+        required=False,
+        choices=MUTED_FINDINGS_CHOICES,
+        widget=forms.RadioSelect,
+    )


### PR DESCRIPTION
This improves the muted findings filter on the findings page. Based on @Rieven's work in PR #1341. While testing I found the UX with the two checkboxes confusing, so  I've changed it to radio button with the option of non-muted findings, muted findings or both. The default view/selection is to only show non-muted findings.

### Issue link
Closes #890
Closes #906

### Proof
![image](https://github.com/minvws/nl-kat-coordination/assets/656182/da5c63dc-a6c2-4606-beda-d9ccb21f162f)

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
