### PR TITLE
Update install script with new env vars

### DIFF
--- a/scripts/installation/openkat-install.sh
+++ b/scripts/installation/openkat-install.sh
@@ -186,20 +186,15 @@ sudo sed -i "/BYTES_DB_URI=/s/.*/BYTES_DB_URI=postgresql:\/\/bytes:${BYTESDB_PAS
 echo "Step 4.6.4 - Update KATALOGUS_DB_URI in /etc/kat/boefjes.conf to ${KATALOGUSDB_PASSWORD}"
 sudo sed -i "/KATALOGUS_DB_URI=/s/.*/KATALOGUS_DB_URI=postgresql:\/\/katalogus:${KATALOGUSDB_PASSWORD}@localhost\/katalogus_db/" /etc/kat/boefjes.conf
 
-echo "Step 4.6.5 - Update SCHEDULER_DSP_BROKER_URL in /etc/kat/mula.conf to ${RABBITMQ_PASSWORD}"
-sudo sed -i "/SCHEDULER_DSP_BROKER_URL=/s/.*/SCHEDULER_DSP_BROKER_URL=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/mula.conf
+echo "Step 4.6.5 - Update SCHEDULER_DB_URI in /etc/kat/mula.conf to ${MULADB_PASSWORD}"
+sudo sed -i "/SCHEDULER_DB_URI=/s/.*/SCHEDULER_DB_URI=postgresql:\/\/mula:${MULADB_PASSWORD}@localhost\/mula_db/" /etc/kat/mula.conf
 
-echo "Step 4.6.6 - Update SCHEDULER_RABBITMQ_DSN in /etc/kat/mula.conf to ${RABBITMQ_PASSWORD}"
-sudo sed -i "/SCHEDULER_RABBITMQ_DSN=/s/.*/SCHEDULER_RABBITMQ_DSN=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/mula.conf
-
-echo "Step 4.6.7 - Update SCHEDULER_DB_DSN in /etc/kat/mula.conf to ${MULADB_PASSWORD}"
-sudo sed -i "/SCHEDULER_DB_DSN=/s/.*/SCHEDULER_DB_DSN=postgresql:\/\/mula:${MULADB_PASSWORD}@localhost\/mula_db/" /etc/kat/mula.conf
-
-echo "Step 4.6.8 - Update QUEUE_URI in rocky.conf, bytes.conf, boefjes.conf, octopoes.conf to ${RABBITMQ_PASSWORD}"
+echo "Step 4.6.6 - Update QUEUE_URI in rocky.conf, bytes.conf, boefjes.conf, mula.conf, octopoes.conf to ${RABBITMQ_PASSWORD}"
 sudo sed -i "/QUEUE_URI=/s/.*/QUEUE_URI=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/rocky.conf
 sudo sed -i "/QUEUE_URI=/s/.*/QUEUE_URI=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/bytes.conf
 sudo sed -i "/QUEUE_URI=/s/.*/QUEUE_URI=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/boefjes.conf
 sudo sed -i "/QUEUE_URI=/s/.*/QUEUE_URI=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/octopoes.conf
+sudo sed -i "/QUEUE_URI=/s/.*/QUEUE_URI=amqp:\/\/kat:${RABBITMQ_PASSWORD}@127.0.0.1:5672\/kat/" /etc/kat/mula.conf
 
 echo "Step 4.7 - Initialize databases"
 


### PR DESCRIPTION
### Changes
Minor changes to two required env variables in the openkat install script since https://github.com/minvws/nl-kat-coordination/pull/1517 was merged.

`SCHEDULER_DSP_BROKER_URL` has been unused for a year and has thus been removed from the script.

### Issue link
Related to https://github.com/minvws/nl-kat-coordination/issues/1580

### Proof
Should be a trivial change (name changes only).

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
