### PR TITLE
Fix pre-commit exclude

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: end-of-file-fixer
         exclude: |
           (?x)(
-          ^boefjes/tests/examples/rdns-nxdomain.txt$ |
+          ^boefjes/tests/examples/rdns-nxdomain.txt$
           )
 
 


### PR DESCRIPTION
The extra `|` means it excludes everything...