### PR TITLE
:lock: hide sensitive secrets

### DIFF
--- a/rocky/katalogus/templates/plugin_settings_list.html
+++ b/rocky/katalogus/templates/plugin_settings_list.html
@@ -22,11 +22,15 @@
                             <tr>
                                 <td>{{ setting.name }}</td>
                                 <td>
-                                    {% if setting.value is None %}
-                                        {% translate "Unset" %}
-                                    {% else %}
-                                        {{ setting.value }}
-                                    {% endif %}
+                                    {% with sname=setting.name.lower %}
+                                        {% if setting.value is None %}
+                                            {% translate "Unset" %}
+                                        {% elif "token" in sname or "key" in sname or "api" in sname or "secret" in sname %}
+                                            •••••••••••••
+                                        {% else %}
+                                            {{ setting.value }}
+                                        {% endif %}
+                                    {% endwith %}
                                 </td>
                                 <td>
                                     {% if setting.required %}


### PR DESCRIPTION
### Changes
Adds functionality to hide sensitive secrets from the boefje detail page in the katalogus.

### Issue link
Was mentioned on Figma

### Proof
![image](https://github.com/minvws/nl-kat-coordination/assets/115991818/1243eadb-6c74-42df-99cd-a4f786002419)

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
