### PR TITLE
Set fixed number of gunicorn workers in Debian packages

### DIFF
--- a/boefjes/packaging/deb/data/etc/kat/katalogus.gunicorn.conf.py
+++ b/boefjes/packaging/deb/data/etc/kat/katalogus.gunicorn.conf.py
@@ -1,4 +1,2 @@
-import multiprocessing
-
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = 3
 bind = ["127.0.0.1:8003"]

--- a/bytes/packaging/deb/data/etc/kat/bytes.gunicorn.conf.py
+++ b/bytes/packaging/deb/data/etc/kat/bytes.gunicorn.conf.py
@@ -1,4 +1,2 @@
-import multiprocessing
-
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = 3
 bind = ["127.0.0.1:8002"]

--- a/keiko/packaging/deb/data/etc/kat/keiko.gunicorn.conf.py
+++ b/keiko/packaging/deb/data/etc/kat/keiko.gunicorn.conf.py
@@ -1,5 +1,2 @@
-"""Keiko gunicorn configuration file."""
-import multiprocessing
-
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = 2
 bind = ["127.0.0.1:8005"]

--- a/octopoes/packaging/deb/data/etc/kat/octopoes.gunicorn.conf.py
+++ b/octopoes/packaging/deb/data/etc/kat/octopoes.gunicorn.conf.py
@@ -1,4 +1,2 @@
-import multiprocessing
-
-workers = multiprocessing.cpu_count() * 2 + 1
+workers = 4
 bind = ["127.0.0.1:8001"]


### PR DESCRIPTION
I think it is best to just set it to a fixed number that is usable for smaller installations and let users of bigger installations tweak it.

### Issue link
Closes #1562 

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
