### PR TITLE
Fix indentation and counter of child OOIs from the OOI tree view

### DIFF
--- a/rocky/assets/src/bundles/app/css/components/tree-tables.scss
+++ b/rocky/assets/src/bundles/app/css/components/tree-tables.scss
@@ -1,73 +1,36 @@
-/*
-For a tree-view (tables in tables), we can save some space
-*/
-table.tree-view tbody > tr > td[colspan] {
-  padding-right: 0;
-}
+$start: 2;
+$end: 15;
 
-table.tree-view tr > .col-ooi-id {
-  width: 65%;
-}
-table.tree-view tr > .col-ooi-type {
-  width: 20%;
-}
-table.tree-view tr > .col-action {
-  width: 15%;
-}
+table {
 
-table.tree-view tr.folded > td {
-  background-color: #cccccc;
-  overflow: hidden;
-}
+  &.tree-view {
 
-table.tree-view tr.folded > td:first-child {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  width: 100%;
-}
+    .tree-children-counter {
+      display: inline-block;
+      border-radius: 100%;
+      border: 1px solid var(--tabs-item-text-color);
+      font-size: var(--tile-font-size);
+      min-width: 15px;
+      height: 15px;
+      text-align: center;
+      line-height: 15px;
+      padding: 4px;
+    }
 
-/*
-show/hide table body, easy-mode (NOT accessibility compliant)
+    tr {
 
-You'll need to include checkboxToggler.js in the HTML
+      &.tree {
 
-Markup:
-<input type="checkbox" class="toggle-table-body is-hidden" id="checkbox-id">
-<table>
-  <thead>
-    <tr><th>
-      <label for="checkbox-id">
-        Title of table
-      </label>
-    </th></tr>
-  </thead>
-  <tbody>
-    <tr><td>Body of table</td></tr>
-  </tbody>
-</table>
-*/
-.toggle-table-body:not(:checked) + table.tree-view tbody {
-  display: none;
-}
+        td {
 
-.toggle-table-body + table.tree-view > thead label {
-  cursor: pointer;
-}
+          @for $i from $start through $end {
+            &.indent-#{$i} {
+              padding-left: calc(16px + #{$i * 16}px);
+            }
+          }
 
-.toggle-table-body:checked + table.tree-view > thead .ro-icon.open {
-  display: none;
-}
-
-.toggle-table-body:not(:checked) + table.tree-view > thead .ro-icon.close {
-  display: none;
-}
-
-table.tree-view {
-  table-layout: fixed;
-}
-
-table.tree-view th > div {
-  display: flex;
-  justify-content: space-between;
+        }
+      }
+    }
+  }
 }

--- a/rocky/rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
+++ b/rocky/rocky/templates/partials/elements/ooi_tree_condensed_table_row.html
@@ -5,13 +5,15 @@
 {% translate object.ooi_type as object_ooi_type %}
 {% translate object.tree_meta.child_count as child_count %}
 {% if not filtered_types or object.ooi_type in filtered_types or object.id == ooi_id %}
-    <tr class="tree-depth-{{ object.tree_meta.depth }} tree-{{ object.tree_meta.location }} type-{{ object.ooi_type }}">
-        <td style="padding-left: calc({{ object.tree_meta.depth }}rem * 2);">
-            {% if object.tree_meta.child_count != "0" %}<span class="icon ti-chevron-down"></span>{% endif %}
+    <tr class="tree"
+        data-location="{{ object.tree_meta.location }}"
+        data-ooi-type="{{ object.ooi_type }}">
+        <td class="indent-{{ object.tree_meta.depth }}">
             <a href="{% ooi_url "ooi_detail" object.id organization.code query=mandatory_fields %}"
                title="{% blocktranslate %}Show details for {{ object_id }}, with {{ child_count }} children.{% endblocktranslate %}">
-                {% if object.tree_meta.child_count != "0" %}({{ object.tree_meta.child_count }}){% endif %}
-            {{ object.human_readable }}</a>
+                {{ object.human_readable }}
+            </a>
+            {% if child_count|add:"0" > 0 %}<span class="tree-children-counter">{{ child_count }}</span>{% endif %}
         </td>
         <td>
             <a href="{% ooi_url "ooi_tree" object.id organization.code ooi_type=object.ooi_type %}"


### PR DESCRIPTION
### Changes
- Fix indentation and counter of child OOIs from the OOI tree view
- Remove chevron down icon which did not had any purpose (also confusing, users want to click open the tree view)
- Positioning of child counter which makes indentation more visible

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/878

Closes https://github.com/minvws/nl-kat-coordination/issues/878

### Proof
<img width="1396" alt="image" src="https://github.com/minvws/nl-kat-coordination/assets/30832687/3149cfae-6b8a-4233-9f37-40216c31b337">


---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
