### PR TITLE
Fix import location of `graph.js` and `graph.css`

### DIFF
--- a/rocky/rocky/templates/graph-d3.html
+++ b/rocky/rocky/templates/graph-d3.html
@@ -35,6 +35,6 @@
     {{ tree|json_script:"tree-data" }}
     <script src="{% static "/js/stringHelpers.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "/js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
-    <script src="{% static "/dist/graph.js" %}" nonce="{{ request.csp_nonce }}"></script>
-    <link href="{% static "/dist/graph.css" %}" rel="stylesheet">
+    <script src="{% static "/dist/imports/graph.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <link href="{% static "/dist/imports/graph.css" %}" rel="stylesheet">
 {% endblock html_at_end_body %}


### PR DESCRIPTION
### Changes
I just found out that the graph view on many pages don't work. The solution was trivial: we forgot to change the path to `graph.js` and `graph.css` after we merged https://github.com/minvws/nl-kat-coordination/pull/1388.

### Issue link
Linked directly.

### Proof
Notice that the graph view is broken on `main`, and switching to this branch and refreshing the page fixes it. 

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
