### PR TITLE
Force ip for ipv4 http

### DIFF
--- a/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
@@ -38,9 +38,7 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
                 # Not a valid IP address, so don't try to hack it into the URL
                 pass
             else:
-                if addr.version == 6:
-                    # IPv6 addresses need to be wrapped in brackets
-                    url_parts = url_parts._replace(netloc=f"[{ip}]")
+                url_parts = url_parts._replace(netloc=f"[{ip}]") if addr.version == 6 else url_parts._replace(netloc=ip)
 
             uri = urlunsplit(
                 [


### PR DESCRIPTION
### Changes
IPV4 was not forced for http in the webpage analysis boefje. Now it is.

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
