### PR TITLE
Add ROCKY_DB_USER_CREATEDB=CREATEDB back

### DIFF
--- a/.env-defaults
+++ b/.env-defaults
@@ -26,3 +26,6 @@ DJANGO_ALLOWED_HOSTS=127.0.0.1,localhost
 
 # https://docs.openkat.nl/technical_design/hardening.html#django-csrf-trusted-origins
 DJANGO_CSRF_TRUSTED_ORIGINS=http://localhost,http://127.0.0.1
+
+# This allows running pytest inside the container
+ROCKY_DB_USER_CREATEDB=CREATEDB


### PR DESCRIPTION
### Changes
This adds ROCKY_DB_USER_CREATEDB=CREATEDB to .env-defaults. It was lost in the environment variables refactor, but is necessary for running pytest.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
