### PR TITLE
Exclude muted findings from report by default

### DIFF
--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -199,7 +199,7 @@ class FindingList:
         octopoes_connector: OctopoesAPIConnector,
         valid_time: datetime,
         severities: Set[RiskLevelSeverity],
-        exclude_muted: bool = False,
+        exclude_muted: bool = True,
         only_muted: bool = False,
     ):
         self.octopoes_connector = octopoes_connector


### PR DESCRIPTION
### Changes
It was True before, but was wrongly changed to False.

Note that on main it already works correctly in the web interface after #1711 because `exclude_muted` is set explicitly, but the generate_report management command would still  generate a wrong report.

### Issue link
Closes #1659

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
