### PR TITLE
Fix KAT-alogus table view

### DIFF
--- a/rocky/katalogus/templates/partials/katalogus_toolbar.html
+++ b/rocky/katalogus/templates/partials/katalogus_toolbar.html
@@ -2,9 +2,9 @@
 
 {% if object_list %}
     <div class="horizontal-view horizontal-scroll toolbar">
-        <a href="{% url 'katalogus' organization_code=organization.code view="gridview" %}"
-           class="button icon ti-layout-grid {% if view.kwargs.view == "tableview" %}ghost{% endif %}">{% translate "Gridview" %}</a>
-        <a href="{% url 'katalogus' organization_code=organization.code view="tableview" %}"
-           class="button icon ti-menu-2 {% if view.kwargs.view != "tableview" %}ghost{% endif %}">{% translate "Tableview" %}</a>
+        <a href="{% url url_name organization_code=organization.code view_type="grid" %}?{{ request.GET.urlencode }}"
+           class="button icon ti-layout-grid {% if view_type == "table" %}ghost{% endif %}">{% translate "Gridview" %}</a>
+        <a href="{% url url_name organization_code=organization.code view_type="table" %}?{{ request.GET.urlencode }}"
+           class="button icon ti-menu-2 {% if view_type != "table" %}ghost{% endif %}">{% translate "Tableview" %}</a>
     </div>
 {% endif %}

--- a/rocky/katalogus/templates/partials/plugins.html
+++ b/rocky/katalogus/templates/partials/plugins.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 {% load static %}
 
-{% if view.kwargs.view == "tableview" %}
+{% if view_type == "table" %}
     <div class="horizontal-scroll">
         <table class="plugins">
             <caption>{% translate "Plugins overview:" %}</caption>

--- a/rocky/katalogus/templates/partials/plugins_navigation.html
+++ b/rocky/katalogus/templates/partials/plugins_navigation.html
@@ -4,13 +4,13 @@
     <nav class="tabs" aria-label="{% translate "Plugins Navigation" %}">
         <ul>
             <li {% if active == "all" %}aria-current="page"{% endif %}>
-                <a href="{% url 'katalogus' organization.code %}">{% translate "All" %}</a>
+                <a href="{% url 'katalogus' organization.code view_type %}">{% translate "All" %}</a>
             </li>
             <li {% if active == "boefjes" %}aria-current="page"{% endif %}>
-                <a href="{% url 'boefjes_list' organization.code %}">{% translate "Boefjes" %}</a>
+                <a href="{% url 'boefjes_list' organization.code view_type %}">{% translate "Boefjes" %}</a>
             </li>
             <li {% if active == "normalizers" %}aria-current="page"{% endif %}>
-                <a href="{% url 'normalizers_list' organization.code %}">{% translate "Normalizers" %}</a>
+                <a href="{% url 'normalizers_list' organization.code view_type %}">{% translate "Normalizers" %}</a>
             </li>
             <li {% if active == "about-plugins" %}aria-current="page"{% endif %}>
                 <a href="{% url 'about_plugins' organization.code %}">{% translate "About plugins" %}</a>

--- a/rocky/katalogus/urls.py
+++ b/rocky/katalogus/urls.py
@@ -10,7 +10,7 @@ from katalogus.views.plugin_settings_delete import PluginSettingsDeleteView
 
 urlpatterns = [
     path("", KATalogusView.as_view(), name="katalogus"),
-    path("view/<view>/", KATalogusView.as_view(), name="katalogus"),
+    path("view/<view_type>/", KATalogusView.as_view(), name="katalogus"),
     path(
         "settings/",
         KATalogusSettingsView.as_view(),
@@ -27,12 +27,12 @@ urlpatterns = [
         name="confirm_clone_settings",
     ),
     path(
-        "plugins/boefjes/",
+        "plugins/boefjes/<view_type>/",
         BoefjeListView.as_view(),
         name="boefjes_list",
     ),
     path(
-        "plugins/normalizers/",
+        "plugins/normalizers/<view_type>/",
         NormalizerListView.as_view(),
         name="normalizers_list",
     ),

--- a/rocky/tests/katalogus/test_katalogus.py
+++ b/rocky/tests/katalogus/test_katalogus.py
@@ -1,5 +1,6 @@
 import pytest
 from django.core.exceptions import PermissionDenied
+from django.urls import resolve
 from katalogus.client import KATalogusClientV1, parse_plugin
 from katalogus.views.katalogus import AboutPluginsView, BoefjeListView, KATalogusView, NormalizerListView
 from katalogus.views.katalogus_settings import ConfirmCloneSettingsView, KATalogusSettingsView
@@ -117,8 +118,10 @@ def test_katalogus_plugin_listing_no_enable_disable_perm(rf, client_member, mock
     mock_requests.Session().get.return_value = mock_response
     mock_response.json.return_value = get_plugins_data()
 
+    request = rf.get("/en/test/kat-alogus/")
+    request.resolver_match = resolve(request.path)
     response = KATalogusView.as_view()(
-        setup_request(rf.get("katalogus"), client_member.user), organization_code=client_member.organization.code
+        setup_request(request, client_member.user), organization_code=client_member.organization.code
     )
     assert response.status_code == 200
 


### PR DESCRIPTION
### Changes
This fixes the KAT-alogus table view. Filtering stays active when you switch between grid and table view. I had originally also implemented keeping the filter if you switch between all/boefjes/normalizers, but because we haven't implemented the visual indications that a filter is active I decided to not do that as I think it might confusing that a filter is still active if you switch.

This also provides default values for the initial filter arguments to the default filtering is select in the filtering form instead of having no selection.

It also fixes missing bread crums on the about plugins page.

### Issue link
Closes #1772 

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
