### PR TITLE
Fix backwards compatibility settings

### DIFF
--- a/bytes/bytes/config.py
+++ b/bytes/bytes/config.py
@@ -50,6 +50,9 @@ class BackwardsCompatibleEnvSettings:
         if "rfc3161_provider" in d and not d["rfc3161_provider"]:
             del d["rfc3161_provider"]
 
+        if "rfc3161_cert_file" in d and not d["rfc3161_cert_file"]:
+            del d["rfc3161_cert_file"]
+
         return d
 
 

--- a/mula/scheduler/config/settings.py
+++ b/mula/scheduler/config/settings.py
@@ -35,9 +35,7 @@ class BackwardsCompatibleEnvSettings(PydanticBaseSettingsSource):
             if new_name not in env_vars and old_name in env_vars:
                 logging.warning("Deprecation: %s is deprecated, use %s instead", old_name.upper(), new_name.upper())
                 if new_name == "queue_uri":
-                    d["host_mutation"] = env_vars[old_name]
-                    d["host_raw_data"] = env_vars[old_name]
-                    d["host_normalizer_meta"] = env_vars[old_name]
+                    d["QUEUE_URI"] = env_vars[old_name]
                 else:
                     d[new_name[len(env_prefix) :]] = env_vars[old_name]
 


### PR DESCRIPTION
This fixes the backwards compatibilty code for the setting files that we shipped in Debian packages before 1.11.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
