### PR TITLE
Fix upgrade with celery beat

### DIFF
--- a/octopoes/debian/postinst
+++ b/octopoes/debian/postinst
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Newer versions might not be able to read the celery beat database so we delete
+# it here before restarting octopoes.
+rm -f /tmp/celerybeat-schedule.db
+
 #DEBHELPER#
 #
 chown -R root:kat /etc/kat


### PR DESCRIPTION
### Changes
Celery beat can't always read its database after an error, resulting in the following exception:

```
[2023-10-05 13:08:58,029: ERROR/Beat] Process Beat
Traceback (most recent call last):
  File "/usr/lib/python3.11/shelve.py", line 111, in __getitem__
    value = self.cache[key]
            ~~~~~~~~~~^^^^^
KeyError: 'entries'
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/billiard/process.py", line 323, in _bootstrap
    self.run()
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 715, in run
    self.service.start(embedded_process=True)
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 631, in start
    humanize_seconds(self.scheduler.max_interval))
                     ^^^^^^^^^^^^^^
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/kombu/utils/objects.py", line 32, in __get__
    return super().__get__(instance, owner)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/functools.py", line 1001, in __get__
    val = self.func(instance)
          ^^^^^^^^^^^^^^^^^^^
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 674, in scheduler
    return self.get_scheduler()
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 665, in get_scheduler
    return symbol_by_name(self.scheduler_cls, aliases=aliases)(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 510, in __init__
    super().__init__(*args, **kwargs)
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 264, in __init__
    self.setup_schedule()
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 538, in setup_schedule
    self._create_schedule()
  File "/opt/venvs/kat-octopoes/lib/python3.11/site-packages/celery/beat.py", line 567, in _create_schedule
    self._store['entries']
    ~~~~~~~~~~~^^^^^^^^^^^
  File "/usr/lib/python3.11/shelve.py", line 114, in __getitem__
    value = Unpickler(f).load()
            ^^^^^^^^^^^^^^^^^^^
ModuleNotFoundError: No module named 'pytz'
```

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
