### PR TITLE
Normalize host urls in scheduler v1.12

### DIFF
--- a/mula/scheduler/connectors/connector.py
+++ b/mula/scheduler/connectors/connector.py
@@ -2,7 +2,6 @@ import logging
 import socket
 import time
 from typing import Callable
-from urllib.parse import urljoin
 
 import requests
 
@@ -40,7 +39,7 @@ class Connector:
             A boolean
         """
         try:
-            url = urljoin(host, health_endpoint)
+            url = f"{host}/{health_endpoint}"
             response = requests.get(url, timeout=5)
             healthy = response.json().get("healthy")
             return healthy

--- a/mula/scheduler/connectors/services/bytes.py
+++ b/mula/scheduler/connectors/services/bytes.py
@@ -1,7 +1,6 @@
 import typing
 from functools import wraps
 from typing import Any, Callable, Dict, Optional
-from urllib.parse import urljoin
 
 import requests
 from requests.models import HTTPError
@@ -59,7 +58,7 @@ class Bytes(HTTPService):
         response.raise_for_status()
 
     def _get_token(self) -> str:
-        url = urljoin(self.host, "/token")
+        url = f"{self.host}/token"
         response = self.post(
             url=url,
             payload=self.credentials,
@@ -73,7 +72,7 @@ class Bytes(HTTPService):
     @retry_with_login
     @exception_handler
     def get_last_run_boefje(self, boefje_id: str, input_ooi: str, organization_id: str) -> Optional[BoefjeMeta]:
-        url = urljoin(self.host, "/bytes/boefje_meta")
+        url = f"{self.host}/bytes/boefje_meta"
         response = self.get(
             url=url,
             params={
@@ -95,7 +94,7 @@ class Bytes(HTTPService):
     @retry_with_login
     @exception_handler
     def get_last_run_boefje_by_organisation_id(self, organization_id: str) -> Optional[BoefjeMeta]:
-        url = urljoin(self.host, "/bytes/boefje_meta")
+        url = f"{self.host}/bytes/boefje_meta"
         response = self.get(
             url=url,
             params={

--- a/mula/scheduler/connectors/services/katalogus.py
+++ b/mula/scheduler/connectors/services/katalogus.py
@@ -1,5 +1,4 @@
 from typing import Dict, List
-from urllib.parse import urljoin
 
 from scheduler.connectors.errors import exception_handler
 from scheduler.models import Boefje, Organisation, Plugin
@@ -119,30 +118,30 @@ class Katalogus(HTTPService):
 
     @exception_handler
     def get_boefjes(self) -> List[Boefje]:
-        url = urljoin(self.host, "/boefjes")
+        url = f"{self.host}/boefjes"
         response = self.get(url)
         return [Boefje(**boefje) for boefje in response.json()]
 
     @exception_handler
     def get_boefje(self, boefje_id: str) -> Boefje:
-        url = urljoin(self.host, f"/boefjes/{boefje_id}")
+        url = f"{self.host}/boefjes/{boefje_id}"
         response = self.get(url)
         return Boefje(**response.json())
 
     @exception_handler
     def get_organisation(self, organisation_id) -> Organisation:
-        url = urljoin(self.host, f"/v1/organisations/{organisation_id}")
+        url = f"{self.host}/v1/organisations/{organisation_id}"
         response = self.get(url)
         return Organisation(**response.json())
 
     @exception_handler
     def get_organisations(self) -> List[Organisation]:
-        url = urljoin(self.host, "/v1/organisations")
+        url = f"{self.host}/v1/organisations"
         response = self.get(url)
         return [Organisation(**organisation) for organisation in response.json().values()]
 
     def get_plugins_by_organisation(self, organisation_id: str) -> List[Plugin]:
-        url = urljoin(self.host, f"/v1/organisations/{organisation_id}/plugins")
+        url = f"{self.host}/v1/organisations/{organisation_id}/plugins"
         response = self.get(url)
         return [Plugin(**plugin) for plugin in response.json()]
 

--- a/mula/scheduler/connectors/services/octopoes.py
+++ b/mula/scheduler/connectors/services/octopoes.py
@@ -1,5 +1,4 @@
 from typing import List
-from urllib.parse import urljoin
 
 from scheduler.connectors.errors import exception_handler
 from scheduler.models import OOI, Organisation
@@ -31,7 +30,7 @@ class Octopoes(HTTPService):
         if scan_level is None:
             scan_level = []
 
-        url = urljoin(self.host, f"/{organisation_id}/objects")
+        url = f"{self.host}/{organisation_id}/objects"
 
         params = {
             "types": object_types,
@@ -63,7 +62,7 @@ class Octopoes(HTTPService):
         if scan_level is None:
             scan_level = []
 
-        url = urljoin(self.host, f"/{organisation_id}/objects/random")
+        url = f"{self.host}/{organisation_id}/objects/random"
 
         params = {
             "amount": str(n),

--- a/mula/scheduler/connectors/services/services.py
+++ b/mula/scheduler/connectors/services/services.py
@@ -36,7 +36,7 @@ class HTTPService(Connector):
     """
 
     name: Optional[str] = None
-    health_endpoint: Optional[str] = "/health"
+    health_endpoint: Optional[str] = "health"
 
     def __init__(self, host: str, source: str, timeout: int = 5, retries: int = 5):
         """Initializer of the HTTPService class. During initialization the

--- a/mula/scheduler/context/context.py
+++ b/mula/scheduler/context/context.py
@@ -42,20 +42,20 @@ class AppContext:
 
         # Services
         katalogus_service = services.Katalogus(
-            host=str(self.config.host_katalogus),
+            host=self._remove_trailing_slash(str(self.config.host_katalogus)),
             source=f"scheduler/{scheduler.__version__}",
             cache_ttl=self.config.katalogus_cache_ttl,
         )
 
         bytes_service = services.Bytes(
-            host=str(self.config.host_bytes),
+            host=self._remove_trailing_slash(str(self.config.host_bytes)),
             user=self.config.host_bytes_user,
             password=self.config.host_bytes_password,
             source=f"scheduler/{scheduler.__version__}",
         )
 
         octopoes_service = services.Octopoes(
-            host=str(self.config.host_octopoes),
+            host=self._remove_trailing_slash(str(self.config.host_octopoes)),
             source=f"scheduler/{scheduler.__version__}",
             orgs=katalogus_service.get_organisations(),
             timeout=self.config.octopoes_request_timeout,
@@ -103,3 +103,9 @@ class AppContext:
             registry=self.metrics_registry,
             labelnames=["scheduler_id"],
         )
+
+    def _remove_trailing_slash(self, url: str) -> str:
+        """Removes trailing slash from url."""
+        if url.endswith("/"):
+            return url[:-1]
+        return url


### PR DESCRIPTION
### Changes

Fixes how configurable host urls are handled in the scheduler. Trailing slashes are removed and formatted strings are used instead of `urljoin()`.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/1884