### PR TITLE
Fix report tables overflowing whole page

### DIFF
--- a/rocky/reports/report_types/dns_report/report.html
+++ b/rocky/reports/report_types/dns_report/report.html
@@ -120,5 +120,4 @@
             </table>
         </div>
     </div>
-</div>
 {% endif %}

--- a/rocky/reports/report_types/dns_report/report.html
+++ b/rocky/reports/report_types/dns_report/report.html
@@ -1,117 +1,124 @@
 {% load i18n %}
 
 <h2>{% translate "IP address lookup" %}</h2>
-<div class="column-2">
-    {% if data.ipv4 %}
-        <table>
-            <thead>
-                <tr>
-                    <th scope="col">IPv4</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    {% for ip in data.ipv4 %}<td>{{ ip }}</td>{% endfor %}
-                </tr>
-            </tbody>
-        </table>
-    {% endif %}
-    {% if not data.enough_ipv6_webservers %}
-        <div class="warning" role="group" aria-label="{% translate "warning" %}">
-            <span>IPv6 {% translate "Warning" %}:</span>
-            <p>
-                {% blocktranslate trimmed %}
+<div class="horizontal-scroll">
+    <div class="column-2">
+        {% if data.ipv4 %}
+            <table>
+                <thead>
+                    <tr>
+                        <th scope="col">IPv4</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        {% for ip in data.ipv4 %}<td>{{ ip }}</td>{% endfor %}
+                    </tr>
+                </tbody>
+            </table>
+        {% endif %}
+        {% if not data.enough_ipv6_webservers %}
+            <div class="warning" role="group" aria-label="{% translate "warning" %}">
+                <span>IPv6 {% translate "Warning" %}:</span>
+                <p>
+                    {% blocktranslate trimmed %}
                     You have less than one webserver that is reachable over IPv6,
                     which is <strong>not</strong> in compliance to internet.nl standards.
-                {% endblocktranslate %}
-            </p>
-        </div>
-    {% else %}
-        <table class="summary">
-            <thead>
-                <tr>
-                    <th scope="col">IPv6</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr>
-                    {% for ip in data.ipv6 %}<td>{{ ip }}</td>{% endfor %}
-                </tr>
-            </tbody>
-        </table>
-    {% endif %}
+                    {% endblocktranslate %}
+                </p>
+            </div>
+        {% else %}
+            <table class="summary">
+                <thead>
+                    <tr>
+                        <th scope="col">IPv6</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        {% for ip in data.ipv6 %}<td>{{ ip }}</td>{% endfor %}
+                    </tr>
+                </tbody>
+            </table>
+        {% endif %}
+    </div>
 </div>
 {% if data.other_records %}
     <h2>{% translate "Other records found" %}</h2>
-    <table>
-        <thead>
-            <tr>
-                <th>{% translate "Record" %}</th>
-                <th>{% translate "Value" %}</th>
-                <th>{% translate "Found by" %}</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for ooi in data.other_records %}
-                <tr>
-                    <td>{{ ooi.human_readable }}</td>
-                    <td>{{ ooi.content }}</td>
-                    <td>{{ ooi.origin }}</td>
-                </tr>
-            {% endfor %}
-        </tbody>
-    </table>
-    <h2>{% translate "Security measures" %}</h2>
-    <div class="column-3">
+    <div class="horizontal-scroll">
         <table>
             <thead>
                 <tr>
-                    <th>{% translate "Enabled" %}</th>
-                    <th>{% translate "Type" %}</th>
+                    <th>{% translate "Record" %}</th>
+                    <th>{% translate "Value" %}</th>
+                    <th>{% translate "Found by" %}</th>
                 </tr>
             </thead>
             <tbody>
-                <tr>
-                    <td>
-                        {% if data.security.spf %}
-                            <i class="icon positive"></i>{% translate "Yes" %}
-                        {% else %}
-                            <i class="icon negative"></i>{% translate "No" %}
-                        {% endif %}
-                    </td>
-                    <td>SPF</td>
-                </tr>
-                <tr>
-                    <td>
-                        {% if data.security.dmarc %}
-                            <i class="icon positive"></i>{% translate "Yes" %}
-                        {% else %}
-                            <i class="icon negative"></i>{% translate "No" %}
-                        {% endif %}
-                    </td>
-                    <td>DMARC</td>
-                </tr>
-                <tr>
-                    <td>
-                        {% if data.security.dkim %}
-                            <i class="icon positive"></i>{% translate "Yes" %}
-                        {% else %}
-                            <i class="icon negative"></i>{% translate "No" %}
-                        {% endif %}
-                    </td>
-                    <td>DKIM</td>
-                </tr>
-                <tr>
-                    <td>
-                        {% if data.security.dnssec %}
-                            <i class="icon positive"></i>{% translate "Yes" %}
-                        {% else %}
-                            <i class="icon negative"></i>{% translate "No" %}
-                        {% endif %}
-                    </td>
-                    <td>DNSSEC</td>
-                </tr>
+                {% for ooi in data.other_records %}
+                    <tr>
+                        <td>{{ ooi.human_readable }}</td>
+                        <td>{{ ooi.content }}</td>
+                        <td>{{ ooi.origin }}</td>
+                    </tr>
+                {% endfor %}
             </tbody>
         </table>
     </div>
+    <h2>{% translate "Security measures" %}</h2>
+    <div class="horizontal-scroll">
+        <div class="column-3">
+            <table>
+                <thead>
+                    <tr>
+                        <th>{% translate "Enabled" %}</th>
+                        <th>{% translate "Type" %}</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>
+                            {% if data.security.spf %}
+                                <i class="icon positive"></i>{% translate "Yes" %}
+                            {% else %}
+                                <i class="icon negative"></i>{% translate "No" %}
+                            {% endif %}
+                        </td>
+                        <td>SPF</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            {% if data.security.dmarc %}
+                                <i class="icon positive"></i>{% translate "Yes" %}
+                            {% else %}
+                                <i class="icon negative"></i>{% translate "No" %}
+                            {% endif %}
+                        </td>
+                        <td>DMARC</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            {% if data.security.dkim %}
+                                <i class="icon positive"></i>{% translate "Yes" %}
+                            {% else %}
+                                <i class="icon negative"></i>{% translate "No" %}
+                            {% endif %}
+                        </td>
+                        <td>DKIM</td>
+                    </tr>
+                    <tr>
+                        <td>
+                            {% if data.security.dnssec %}
+                                <i class="icon positive"></i>{% translate "Yes" %}
+                            {% else %}
+                                <i class="icon negative"></i>{% translate "No" %}
+                            {% endif %}
+                        </td>
+                        <td>DNSSEC</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
 {% endif %}

--- a/rocky/reports/report_types/tls_report/report.html
+++ b/rocky/reports/report_types/tls_report/report.html
@@ -2,42 +2,44 @@
 
 <h3>Ciphers</h3>
 {% if data.suites %}
-<table>
-    <thead>
-        <tr>
-            <th>{% translate "Status" %}</th>
-            <th>{% translate "Protocol" %}</th>
-            <th>{% translate "Name" %}</th>
-            <th>{% translate "Encryption Algorithm" %}</th>
-            <th>{% translate "Bits" %}</th>
-            <th>{% translate "Key Size" %}</th>
-            <th>{% translate "Code" %}</th>
-        </tr>
-    </thead>
-    <tbody>
-        {% for protocol, suites in data.suites.items %}
-            {% for suite in suites %}
+    <div class="horizontal-scroll">
+        <table>
+            <thead>
                 <tr>
-                    <td>
-                        {% if suite.cipher_suite_name in data.suites_with_findings %}
-                            <i class="icon negative"></i> {% translate "Phase out" %}
-                        {% else %}
-                            <i class="icon positive"></i> {% translate "Good" %}
-                        {% endif %}
-                    </td>
-                    <td>{{ protocol }}</td>
-                    <td>{{ suite.cipher_suite_alias }}</td>
-                    <td>{{ suite.encryption_algorithm }}</td>
-                    <td>{{ suite.bits }}</td>
-                    <td>{{ suite.key_size }}</td>
-                    <td>{{ suite.cipher_suite_code }}</td>
+                    <th>{% translate "Status" %}</th>
+                    <th>{% translate "Protocol" %}</th>
+                    <th>{% translate "Name" %}</th>
+                    <th>{% translate "Encryption Algorithm" %}</th>
+                    <th>{% translate "Bits" %}</th>
+                    <th>{% translate "Key Size" %}</th>
+                    <th>{% translate "Code" %}</th>
                 </tr>
-            {% endfor %}
-        {% endfor %}
-    </tbody>
-</table>
+            </thead>
+            <tbody>
+                {% for protocol, suites in data.suites.items %}
+                    {% for suite in suites %}
+                        <tr>
+                            <td>
+                                {% if suite.cipher_suite_name in data.suites_with_findings %}
+                                    <i class="icon negative"></i> {% translate "Phase out" %}
+                                {% else %}
+                                    <i class="icon positive"></i> {% translate "Good" %}
+                                {% endif %}
+                            </td>
+                            <td>{{ protocol }}</td>
+                            <td>{{ suite.cipher_suite_alias }}</td>
+                            <td>{{ suite.encryption_algorithm }}</td>
+                            <td>{{ suite.bits }}</td>
+                            <td>{{ suite.key_size }}</td>
+                            <td>{{ suite.cipher_suite_code }}</td>
+                        </tr>
+                    {% endfor %}
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% else %}
-<p>{% translate "No ciphers found for this IPService" %}</p>
+    <p>{% translate "No ciphers found for this IPService" %}</p>
 {% endif %}
 {% if data.findings %}
     <h3>{% translate "Findings" %}</h3>


### PR DESCRIPTION
### Changes
- When values in report tables are too long the page will overflow. Now added a fix for table to have a horizontal scroll bar.

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/1939

Closes https://github.com/minvws/nl-kat-coordination/issues/1939

### Proof
![image](https://github.com/minvws/nl-kat-coordination/assets/30832687/84672bd0-cafb-4dda-9025-eb1f4d639132)


---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
