### PR TITLE
Fix reports and normalizer detail page

### DIFF
--- a/rocky/MANIFEST.in
+++ b/rocky/MANIFEST.in
@@ -1,4 +1,3 @@
-include README.md
 include LICENSE
 
 recursive-include rocky/templates *.html
@@ -13,3 +12,4 @@ recursive-include account/templates *.html
 recursive-include account/templates *.txt
 recursive-include onboarding/templates *.html
 recursive-include onboarding/templates *.txt
+recursive-include reports *.html

--- a/rocky/katalogus/templates/normalizer_detail.html
+++ b/rocky/katalogus/templates/normalizer_detail.html
@@ -70,6 +70,6 @@
 {% endblock content %}
 {% block html_at_end_body %}
     {{ block.super }}
-    <script src="{% static "/js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
-    <script src="{% static "/js/autoSubmit.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/autoSubmit.js" %}" nonce="{{ request.csp_nonce }}"></script>
 {% endblock html_at_end_body %}

--- a/rocky/reports/templates/report_oois_selection.html
+++ b/rocky/reports/templates/report_oois_selection.html
@@ -77,5 +77,5 @@
 {% endblock content %}
 {% block html_at_end_body %}
     {{ block.super }}
-    <script src="{% static "/js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
 {% endblock html_at_end_body %}

--- a/rocky/reports/templates/report_types_selection.html
+++ b/rocky/reports/templates/report_types_selection.html
@@ -60,5 +60,5 @@
 {% endblock content %}
 {% block html_at_end_body %}
     {{ block.super }}
-    <script src="{% static "/js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
 {% endblock html_at_end_body %}


### PR DESCRIPTION
### Changes
This fixes missing templates in the Debian pacakge because they weren't listed in MANIFEST.in.

It also fixes the js static files that started with a `/` which is not correct and doesn't work with django-compressor.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
