### PR TITLE
Add reporting templates to djlint pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,10 +107,18 @@ repos:
   rev: v1.32.1
   hooks:
   - id: djlint-reformat-django
-    files: '^rocky/.*/templates/.*$'
+    files: |
+      (?x)(
+      ^rocky/.*/templates/.*$ |
+      ^rocky/reports/report_types/.*/.*\.html
+      )
 
   - id: djlint-django
-    files: '^rocky/.*/templates/.*$'
+    files: |
+      (?x)(
+      ^rocky/.*/templates/.*$ |
+      ^rocky/reports/report_types/.*/.*\.html
+      )
 
 - repo: https://github.com/thibaudcolas/pre-commit-stylelint
   rev: v15.10.1

--- a/rocky/reports/report_types/dns_report/report.html
+++ b/rocky/reports/report_types/dns_report/report.html
@@ -22,8 +22,8 @@
                 <span>IPv6 {% translate "Warning" %}:</span>
                 <p>
                     {% blocktranslate trimmed %}
-                    You have less than one webserver that is reachable over IPv6,
-                    which is <strong>not</strong> in compliance to internet.nl standards.
+                        You have less than one webserver that is reachable over IPv6,
+                        which is <strong>not</strong> in compliance to internet.nl standards.
                     {% endblocktranslate %}
                 </p>
             </div>


### PR DESCRIPTION
### Changes
The path of the new report templates isn't the standard Django template path so wasn't included in the djlint hook.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
