### PR TITLE
Fix error adding settings when schema doesn't have required attribute

### DIFF
--- a/rocky/katalogus/forms/plugin_settings.py
+++ b/rocky/katalogus/forms/plugin_settings.py
@@ -24,7 +24,7 @@ class PluginSchemaForm(forms.Form):
     def populate_fields(self):
         for field_name, field_props in self.plugin_schema["properties"].items():
             kwargs = {
-                "required": field_name in self.plugin_schema["required"],
+                "required": "required" in self.plugin_schema and field_name in self.plugin_schema["required"],
                 "label": field_props.get("title", field_name),
                 "help_text": _(field_props.get("description", "")),
                 "error_messages": self.error_messages,

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -462,6 +462,29 @@ def plugin_schema():
     }
 
 
+@pytest.fixture
+def plugin_schema_no_required():
+    return {
+        "title": "Arguments",
+        "type": "object",
+        "properties": {
+            "TEST_PROPERTY": {
+                "title": "TEST_PROPERTY",
+                "maxLength": 128,
+                "type": "string",
+                "description": "Test description",
+            },
+            "TEST_PROPERTY2": {
+                "title": "TEST_PROPERTY2",
+                "type": "integer",
+                "minimum": 2,
+                "maximum": 200,
+                "description": "Test description2",
+            },
+        },
+    }
+
+
 def setup_request(request, user):
     request = SessionMiddleware(lambda r: r)(request)
     request.session[DEVICE_ID_SESSION_KEY] = user.staticdevice_set.get().persistent_id


### PR DESCRIPTION
### Changes
The `required` field in the plugin isn't required, so we shouldn't assume that it exists

### Issue link
Closes #1944 

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
