### PR TITLE
Fix observed_at parsing

### DIFF
--- a/rocky/rocky/views/ooi_list.py
+++ b/rocky/rocky/views/ooi_list.py
@@ -42,7 +42,6 @@ class OOIListView(BaseOOIListView, OctopoesView):
 
         context["active_filters"] = self.get_active_filters()
         context["ooi_type_form"] = OOITypeMultiCheckboxForm(self.request.GET)
-        context["observed_at"] = self.get_observed_at()
         context["mandatory_fields"] = get_mandatory_fields(self.request, params=["observed_at"])
         context["select_oois_form"] = SelectOOIForm(
             context.get("ooi_list", []),

--- a/rocky/tests/test_observed_at.py
+++ b/rocky/tests/test_observed_at.py
@@ -1,0 +1,42 @@
+from datetime import datetime, timezone
+
+from rocky.views.mixins import ObservedAtMixin
+
+
+def test_observed_at_no_value(mocker):
+    mock_mixin_datetime = mocker.patch("rocky.views.mixins.datetime")
+    mock_request = mocker.Mock()
+    mock_request.GET = {}
+    now = datetime(2023, 10, 24, 9, 34, 56, 316699, tzinfo=timezone.utc)
+    mock_mixin_datetime.now.return_value = now
+
+    observed_at = ObservedAtMixin()
+    observed_at.request = mock_request
+    assert observed_at.get_observed_at() == now
+
+
+def test_observed_at_date(mocker):
+    mock_request = mocker.Mock()
+    mock_request.GET = {"observed_at": "2023-10-24"}
+
+    observed_at = ObservedAtMixin()
+    observed_at.request = mock_request
+    assert observed_at.get_observed_at() == datetime(2023, 10, 24, 23, 59, 59, 999999, tzinfo=timezone.utc)
+
+
+def test_observed_at_datetime(mocker):
+    mock_request = mocker.Mock()
+    mock_request.GET = {"observed_at": "2023-10-24T09:34:56"}
+
+    observed_at = ObservedAtMixin()
+    observed_at.request = mock_request
+    assert observed_at.get_observed_at() == datetime(2023, 10, 24, 9, 34, 56, 0, tzinfo=timezone.utc)
+
+
+def test_observed_at_datetime_with_timezone(mocker):
+    mock_request = mocker.Mock()
+    mock_request.GET = {"observed_at": "2023-10-24T11:34:56+02:00"}
+
+    observed_at = ObservedAtMixin()
+    observed_at.request = mock_request
+    assert observed_at.get_observed_at() == datetime(2023, 10, 24, 9, 34, 56, 0, tzinfo=timezone.utc)


### PR DESCRIPTION
### Changes
This fixes observed_at parsing. Creates `ObservedAtMixin` to get rid of the copypasted `get_observed_at` in crisis room view.

Also removes the unnecessary `CrisisRoomBreadcrumbsMixin` class.

Adds unit tests that tests the different values that get_observed_at should accept.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
