### PR TITLE
Adds task details to task history table on plugin detail pages

### DIFF
--- a/rocky/assets/js/renderNormalizerOutputOOIs.js
+++ b/rocky/assets/js/renderNormalizerOutputOOIs.js
@@ -1,10 +1,11 @@
+import { language, organization_code } from './utils.js'
 
 const buttons = document.querySelectorAll(".expando-button.normalizer-list-table-row");
 
 buttons.forEach((button) => {
   const raw_task_id = button.closest('tr').getAttribute('data-task-id');
   const task_id = button.closest('tr').getAttribute('data-task-id').replace(/-/g, "");
-  const json_url = location.pathname + "/" + encodeURI(task_id);
+  const json_url = "/" + language + "/" + organization_code +"/tasks/normalizers/" + encodeURI(task_id);
 
   const getJson = (url, callback) => {
     var xhr = new XMLHttpRequest();
@@ -48,7 +49,7 @@ buttons.forEach((button) => {
       // Retrieve JSON containing yielded objects of task.
       getJson(json_url, function(data) {
         if(data['oois'].length > 0) {
-          const url = location.pathname.replace('/tasks/normalizers', '');
+          const url = "/" + language + "/" + organization_code;
           let object_list = "";
 
           // Build HTML snippet for every yielded object.

--- a/rocky/assets/js/utils.js
+++ b/rocky/assets/js/utils.js
@@ -1,0 +1,8 @@
+const htmlElement = document.getElementsByTagName('html')[0];
+const language = htmlElement.getAttribute('lang');
+const organization_code = htmlElement.getAttribute('data-organization-code');
+
+export {
+  language,
+  organization_code,
+}

--- a/rocky/katalogus/templates/normalizer_detail.html
+++ b/rocky/katalogus/templates/normalizer_detail.html
@@ -72,4 +72,5 @@
     {{ block.super }}
     <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "js/autoSubmit.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/renderNormalizerOutputOOIs.js" %}" type="module" nonce="{{ request.csp_nonce }}"></script>
 {% endblock html_at_end_body %}

--- a/rocky/rocky/templates/layouts/base.html
+++ b/rocky/rocky/templates/layouts/base.html
@@ -3,7 +3,8 @@
 {% load i18n %}
 
 {% get_current_language as LANGUAGE_CODE %}
-<html lang="{{ LANGUAGE_CODE }}">
+<html lang="{{ LANGUAGE_CODE }}"
+      data-organization-code="{{ organization.code }}">
     {% block head %}
         {% include "head.html" %}
 

--- a/rocky/rocky/templates/partials/task_history.html
+++ b/rocky/rocky/templates/partials/task_history.html
@@ -65,12 +65,12 @@
                         <th scope="col">{% translate "Created date" %}</th>
                         <th scope="col">{% translate "Input Object" %}</th>
                         {# FIXME: implement detail page according to designs #}
-                        {# <th scope="col">{% translate "Details" %}</th> #}
+                        <th scope="col">{% translate "Details" %}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for task in task_history %}
-                        <tr>
+                        <tr data-task-id="{{ task.id }}">
                             <td>
                                 {% if task.type == "boefje" %}
                                     <a href="{% url "boefje_detail" organization.code task.p_item.data.boefje.id %}">{{ task.p_item.data.boefje.name }}</a>
@@ -106,7 +106,32 @@
                                 {% endif %}
                             </td>
                             {# FIXME: implement detail page according to designs #}
-                            {# <td><a href="">{% translate "View Details" %}</a></td> #}
+                            <td>
+                                <button type="button"
+                                        class="expando-button normalizer-list-table-row"
+                                        data-icon-open-class="icon ti-chevron-down"
+                                        data-icon-close-class="icon ti-chevron-up"
+                                        data-close-label="{% translate "Close details" %}">
+                                    {% translate "Open details" %}
+                                </button>
+                            </td>
+                        </tr>
+                        <tr class="expando-row">
+                            <td colspan="7">
+                                <section>
+                                    <div class="button-container">
+                                        {% if task.status.value in "completed,failed" %}
+                                            <a class="button"
+                                               href="{% url 'bytes_raw' organization_code=organization.code boefje_meta_id=task.id %}"><span class="icon ti-download"></span>{% translate "Download meta and raw data" %}</a>
+                                            {% include "partials/single_action_form.html" with btn_text=_("Reschedule") btn_class="ghost" btn_icon="icon ti-refresh" action="reschedule_task" key="task_id" value=task.id %}
+
+                                        {% else %}
+                                            <a class="button"
+                                               href="{% url 'download_task_meta' organization_code=organization.code task_id=task.id %}"><span class="icon ti-download"></span>{% translate "Download task data" %}</a>
+                                        {% endif %}
+                                    </div>
+                                </section>
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -125,12 +150,12 @@
                         <th scope="col">{% translate "Boefje" %}</th>
                         <th scope="col">{% translate "Boefje input OOI" %}</th>
                         {# FIXME: implement detail page according to designs #}
-                        {# <th scope="col">{% translate "Details" %}</th> #}
+                        <th scope="col">{% translate "Details" %}</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for task in task_history %}
-                        <tr>
+                        <tr data-task-id="{{ task.id }}">
                             <td>
                                 <a href="{% url "normalizer_detail" organization.code task.p_item.data.normalizer.id %}">{{ task.p_item.data.normalizer.id }}</a>
                             </td>
@@ -157,7 +182,40 @@
                                 <a href="{% ooi_url "ooi_detail" task.p_item.data.raw_data.boefje_meta.input_ooi organization.code observed_at=task.created_at|date:'Y-m-d' %}">{{ task.p_item.data.raw_data.boefje_meta.input_ooi }}</a>
                             </td>
                             {# FIXME: implement detail page according to designs #}
-                            {# <td><a href="">{% translate "View Details" %}</a></td> #}
+                            <td>
+                                <button type="button"
+                                        class="expando-button normalizer-list-table-row"
+                                        data-icon-open-class="icon ti-chevron-down"
+                                        data-icon-close-class="icon ti-chevron-up"
+                                        data-close-label="{% translate "Close details" %}">
+                                    {% translate "Open details" %}
+                                </button>
+                            </td>
+                        </tr>
+                        <tr class="expando-row">
+                            <td colspan="7">
+                                <section>
+                                    <div id="yielded-objects-{{ task.id }}">
+                                        <h2>{% translate "Yielded objects" %}</h2>
+                                    </div>
+                                </section>
+                                <br>
+                                <section>
+                                    <div>
+                                        <div class="button-container">
+                                            {% if task.status.value in "completed,failed" %}
+                                                <a class="button"
+                                                   href="{% url 'bytes_raw' organization_code=organization.code boefje_meta_id=task.p_item.data.raw_data.boefje_meta.id %}"><span class="icon ti-download"></span>{% translate "Download meta and raw data" %}</a>
+                                                {% include "partials/single_action_form.html" with btn_text=_("Reschedule") btn_class="ghost" btn_icon="icon ti-refresh" action="reschedule_task" key="task_id" value=task.id %}
+
+                                            {% else %}
+                                                <a class="button"
+                                                   href="{% url 'download_task_meta' organization_code=organization.code task_id=task.id %}"><span class="icon ti-download"></span>{% translate "Download task data" %}</a>
+                                            {% endif %}
+                                        </div>
+                                    </div>
+                                </section>
+                            </td>
                         </tr>
                     {% endfor %}
                 </tbody>
@@ -175,12 +233,12 @@
                         <th scope="col">{% translate "Status" %}</th>
                         <th scope="col">{% translate "Created date" %}</th>
                         {# FIXME: implement detail page according to designs #}
-                        {# <th scope="col">{% translate "Scan Details" %}</th> #}
+                        {% comment %} <th scope="col">{% translate "Scan Details" %}</th> {% endcomment %}
                     </tr>
                 </thead>
                 <tbody>
                     {% for task in task_history %}
-                        <tr>
+                        <tr data-task-id="{{ task.id }}">
                             <td>
                                 {% if task.type == "boefje" %}
                                     <a href="{% ooi_url "ooi_detail" task.p_item.data.input_ooi organization.code %}">{{ task.p_item.data.input_ooi }}</a>
@@ -216,7 +274,11 @@
                             </td>
                             <td>{{ task.created_at }}</td>
                             {# FIXME: implement detail page according to designs #}
-                            {# <td><a href="">{% translate "View Details" %}</a></td> #}
+                            {% comment %} <td>
+                              <button type="button" class="expando-button normalizer-list-table-row" data-icon-open-class="icon ti-chevron-down" data-icon-close-class="icon ti-chevron-up" data-close-label="{% translate "Close details" %}">
+                              {% translate "Open details" %}
+                            </button>
+                            </td> {% endcomment %}
                         </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
### Changes
Merging this PR adds `expando rows` to the task history table rows on the plugin detail pages. For both boefjes as normalizers. It's a draft because I still want to refactor the `task history` tables a bit, so it remains "DRY". Because their appearance is almost (if not entirely) the same as the standard task list tables.

### Issue link
Closes [#1842](https://github.com/minvws/nl-kat-coordination/issues/1842)

### Proof
![Screenshot 2023-10-31 at 17 03 27](https://github.com/minvws/nl-kat-coordination/assets/16188579/83ae8279-f36b-4b7b-bdfb-9ad9b890b47a)
![Screenshot 2023-10-31 at 17 03 40](https://github.com/minvws/nl-kat-coordination/assets/16188579/a2b5b48b-9f8e-4123-a343-a7a54015be92)


---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
