### PR TITLE
Add task details to object detail task history table and fix filtering bug

### DIFF
--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-11-06 13:48+0000\n"
+"POT-Creation-Date: 2023-11-07 20:44+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -1028,6 +1028,7 @@ msgstr ""
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/organizations/organization_crisis_room.html
 #: rocky/templates/partials/ooi_report_findings_block_table.html
+#: rocky/templates/partials/task_history.html
 #: rocky/templates/tasks/partials/boefje_task_history.html
 #: rocky/templates/tasks/partials/normalizer_task_history.html
 msgid "Details"
@@ -3613,6 +3614,7 @@ msgstr ""
 #: rocky/templates/crisis_room/crisis_room_findings_block.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/organizations/organization_crisis_room.html
+#: rocky/templates/partials/task_history.html
 #: rocky/templates/tasks/partials/boefje_task_history.html
 #: rocky/templates/tasks/partials/normalizer_task_history.html
 msgid "Close details"
@@ -3621,6 +3623,7 @@ msgstr ""
 #: rocky/templates/crisis_room/crisis_room_findings_block.html
 #: rocky/templates/findings/finding_list.html
 #: rocky/templates/organizations/organization_crisis_room.html
+#: rocky/templates/partials/task_history.html
 #: rocky/templates/tasks/partials/boefje_task_history.html
 #: rocky/templates/tasks/partials/normalizer_task_history.html
 msgid "Open details"
@@ -3854,6 +3857,8 @@ msgid "Crisis room"
 msgstr ""
 
 #: rocky/templates/header.html rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/partials/boefje_task_history.html
+#: rocky/templates/tasks/partials/normalizer_task_history.html
 #: rocky/views/task_detail.py rocky/views/tasks.py
 msgid "Tasks"
 msgstr ""
@@ -4941,6 +4946,30 @@ msgstr ""
 msgid "Created date"
 msgstr ""
 
+#: rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/partials/normalizer_task_history.html
+msgid "Yielded objects"
+msgstr ""
+
+#: rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/boefje_task_detail.html
+#: rocky/templates/tasks/partials/boefje_task_history.html
+#: rocky/templates/tasks/partials/normalizer_task_history.html
+msgid "Download meta and raw data"
+msgstr ""
+
+#: rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/partials/boefje_task_history.html
+#: rocky/templates/tasks/partials/normalizer_task_history.html
+msgid "Reschedule"
+msgstr ""
+
+#: rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/partials/boefje_task_history.html
+#: rocky/templates/tasks/partials/normalizer_task_history.html
+msgid "Download task data"
+msgstr ""
+
 #: rocky/templates/scan.html
 msgid "Boefjes overview:"
 msgstr ""
@@ -5002,12 +5031,6 @@ msgid ""
 msgstr ""
 
 #: rocky/templates/tasks/boefje_task_detail.html
-#: rocky/templates/tasks/partials/boefje_task_history.html
-#: rocky/templates/tasks/partials/normalizer_task_history.html
-msgid "Download meta and raw data"
-msgstr ""
-
-#: rocky/templates/tasks/boefje_task_detail.html
 msgid "Download meta data"
 msgstr ""
 
@@ -5039,26 +5062,12 @@ msgstr ""
 msgid "Input Object"
 msgstr ""
 
-#: rocky/templates/tasks/partials/boefje_task_history.html
-#: rocky/templates/tasks/partials/normalizer_task_history.html
-msgid "Reschedule"
-msgstr ""
-
-#: rocky/templates/tasks/partials/boefje_task_history.html
-#: rocky/templates/tasks/partials/normalizer_task_history.html
-msgid "Download task data"
-msgstr ""
-
 #: rocky/templates/tasks/partials/normalizer_task_history.html
 msgid "Normalizer"
 msgstr ""
 
 #: rocky/templates/tasks/partials/normalizer_task_history.html
 msgid "Boefje input OOI"
-msgstr ""
-
-#: rocky/templates/tasks/partials/normalizer_task_history.html
-msgid "Yielded objects"
 msgstr ""
 
 #: rocky/templates/tasks/partials/tab_navigation.html

--- a/rocky/rocky/templates/partials/task_history.html
+++ b/rocky/rocky/templates/partials/task_history.html
@@ -63,6 +63,7 @@
                     <th scope="col">{% translate "Plugin" %}</th>
                     <th scope="col">{% translate "Status" %}</th>
                     <th scope="col">{% translate "Created date" %}</th>
+                    <th scope="col" class="visually-hidden">{% translate "Details" %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -102,6 +103,40 @@
                             {% endif %}
                         </td>
                         <td>{{ task.created_at }}</td>
+                        <td>
+                            <button type="button"
+                                    class="expando-button normalizer-list-table-row"
+                                    data-icon-open-class="icon ti-chevron-down"
+                                    data-icon-close-class="icon ti-chevron-up"
+                                    data-close-label="{% translate "Close details" %}">
+                                {% translate "Open details" %}
+                            </button>
+                        </td>
+                    </tr>
+                    <tr class="expando-row">
+                        <td colspan="7">
+                            {% if task.type == "normalizer" %}
+                                <section>
+                                    <div id="yielded-objects-{{ task.id }}">
+                                        <h2>{% translate "Yielded objects" %}</h2>
+                                    </div>
+                                </section>
+                                <br>
+                            {% endif %}
+                            <section>
+                                <div class="button-container">
+                                    {% if task.status.value in "completed,failed" %}
+                                        <a class="button"
+                                           href="{% url 'bytes_raw' organization_code=organization.code boefje_meta_id=task.id %}"><span class="icon ti-download"></span>{% translate "Download meta and raw data" %}</a>
+                                        {% include "partials/single_action_form.html" with btn_text=_("Reschedule") btn_class="ghost" btn_icon="icon ti-refresh" action="reschedule_task" key="task_id" value=task.id %}
+
+                                    {% else %}
+                                        <a class="button"
+                                           href="{% url 'download_task_meta' organization_code=organization.code task_id=task.id %}"><span class="icon ti-download"></span>{% translate "Download task data" %}</a>
+                                    {% endif %}
+                                </div>
+                            </section>
+                        </td>
                     </tr>
                 {% endfor %}
             </tbody>

--- a/rocky/rocky/views/ooi_detail.py
+++ b/rocky/rocky/views/ooi_detail.py
@@ -1,4 +1,5 @@
 import json
+import uuid
 from collections import defaultdict
 from datetime import datetime, timezone
 from enum import Enum
@@ -18,10 +19,12 @@ from tools.forms.base import ObservedAtForm
 from tools.forms.ooi import PossibleBoefjesFilterForm
 from tools.models import Indemnification
 from tools.ooi_helpers import format_display
+from tools.view_helpers import schedule_task
 
 from octopoes.models import OOI, Reference
 from octopoes.models.ooi.question import Question
 from rocky import scheduler
+from rocky.scheduler import client
 from rocky.views.ooi_detail_related_object import OOIFindingManager, OOIRelatedObjectAddView
 from rocky.views.ooi_view import BaseOOIDetailView
 
@@ -29,6 +32,7 @@ from rocky.views.ooi_view import BaseOOIDetailView
 class PageActions(Enum):
     START_SCAN = "start_scan"
     SUBMIT_ANSWER = "submit_answer"
+    RESCHEDULE_TASK = "reschedule_task"
 
 
 class OOIDetailView(
@@ -58,6 +62,18 @@ class OOIDetailView(
 
     def handle_page_action(self, action: str) -> bool:
         try:
+            if action == PageActions.RESCHEDULE_TASK.value:
+                task_id = self.request.POST.get("task_id")
+                task = client.get_task_details(task_id)
+
+                # TODO: Consistent UUID-parsing across services https://github.com/minvws/nl-kat-coordination/issues/1451
+                new_id = uuid.uuid4()
+
+                task.p_item.id = new_id
+                task.p_item.data.id = new_id
+
+                schedule_task(self.request, self.organization.code, task.p_item)
+
             if action == PageActions.START_SCAN.value:
                 boefje_id = self.request.POST.get("boefje_id")
                 ooi_id = self.request.GET.get("ooi_id")

--- a/rocky/rocky/views/ooi_detail.py
+++ b/rocky/rocky/views/ooi_detail.py
@@ -108,7 +108,7 @@ class OOIDetailView(
 
         # FIXME: in context of ooi detail is doesn't make sense to search
         # for an object name, so we search on plugin id
-        plugin_id = self.request.GET.get("task_history_search")
+        plugin_id = self.request.GET.get("task_history_search") or None
 
         page = int(self.request.GET.get("task_history_page", 1))
 


### PR DESCRIPTION
### Changes
There was a bug when filtering tasks on the OOI detail page: when the "free search" text input was left empty no results would show up. Defaulting it to `None` fixed this. Also the tasks now have an `expando row` with task details.

### Issue link
Closes #2009 and #2010

### Demo
![image](https://github.com/minvws/nl-kat-coordination/assets/16188579/e5ec85fd-f703-4056-815e-2867b9550359)

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
