### PR TITLE
Adjust inconsistency of spacing in CVE label

### DIFF
--- a/octopoes/bits/retire_js/retirejs.json
+++ b/octopoes/bits/retire_js/retirejs.json
@@ -3061,7 +3061,7 @@
         "identifiers": {
           "summary": "XSS is possible in the data-target attribute.",
           "CVE": [
-            " CVE-2016-10735"
+            "CVE-2016-10735"
           ]
         },
         "info": [
@@ -3075,7 +3075,7 @@
         "identifiers": {
           "summary": "XSS is possible in the data-target attribute.",
           "CVE": [
-            " CVE-2016-10735"
+            "CVE-2016-10735"
           ]
         },
         "info": [


### PR DESCRIPTION
### Changes
The spacing of " CVE-2016-10735" label is inconsistent with the other CVE's, this patch adjusts that.

### Issue link
N/A (Found as part of research #1963).

### Demo
Extremely minor changes.
---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
