### PR TITLE
Fix scan level propagation: Celery beat scheduler crashed on a faulty katalogus_api url 

### DIFF
--- a/octopoes/octopoes/connector/katalogus.py
+++ b/octopoes/octopoes/connector/katalogus.py
@@ -5,8 +5,10 @@ import requests
 
 class KATalogusClientV1:
     def __init__(self, base_uri: str):
-        self.base_uri = f"{base_uri}/v1"
+        self.base_uri = f"{base_uri.rstrip('/')}/v1"
 
     def get_organisations(self) -> List[str]:
         response = requests.get(f"{self.base_uri}/organisations")
+        response.raise_for_status()
+
         return response.json().keys()


### PR DESCRIPTION
Also: add better logging and exception handling to the worker tasks. Raise for status in the Katalogus client in Octopoes after getting organisations.

### Changes
Trivial

### Demo
Two hostnames linked by the `registered_domain` field and just increased L1 to L2 for one of them:

![image](https://github.com/minvws/nl-kat-coordination/assets/46660228/a6049e35-e978-4f7a-bd69-e3f7db90aec6)


Wait a bit and refresh to find the level propagated:

![image](https://github.com/minvws/nl-kat-coordination/assets/46660228/19ec4677-9df8-4395-9837-950ca4770217)


---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [x] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
