### PR TITLE
Fix manual scan regression

### DIFF
--- a/rocky/rocky/views/ooi_detail.py
+++ b/rocky/rocky/views/ooi_detail.py
@@ -18,7 +18,7 @@ from tools.forms.base import ObservedAtForm
 from tools.forms.ooi import PossibleBoefjesFilterForm
 from tools.models import Indemnification
 from tools.ooi_helpers import format_display
-from tools.view_helpers import schedule_task
+from tools.view_helpers import reschedule_task
 
 from octopoes.models import OOI, Reference
 from octopoes.models.ooi.question import Question
@@ -62,7 +62,7 @@ class OOIDetailView(
         try:
             if action == PageActions.RESCHEDULE_TASK.value:
                 task_id = self.request.POST.get("task_id")
-                schedule_task(self.request, self.organization.code, task_id)
+                reschedule_task(self.request, self.organization.code, task_id)
 
             if action == PageActions.START_SCAN.value:
                 boefje_id = self.request.POST.get("boefje_id")

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -10,7 +10,7 @@ from django.utils.translation import gettext_lazy as _
 from django.views.generic.list import ListView
 from katalogus.views.mixins import BoefjeMixin, NormalizerMixin
 from requests import HTTPError
-from tools.view_helpers import schedule_task
+from tools.view_helpers import reschedule_task
 
 from rocky.scheduler import TaskNotFoundError, client
 
@@ -79,7 +79,7 @@ class TaskListView(OrganizationView, ListView):
     def handle_page_action(self, action: str) -> None:
         if action == PageActions.RESCHEDULE_TASK.value:
             task_id = self.request.POST.get("task_id")
-            schedule_task(self.request, self.organization.code, task_id)
+            reschedule_task(self.request, self.organization.code, task_id)
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)

--- a/rocky/tools/view_helpers.py
+++ b/rocky/tools/view_helpers.py
@@ -11,11 +11,8 @@ from django.utils.translation import gettext_lazy as _
 
 from octopoes.models.types import OOI_TYPES
 from rocky.scheduler import (
-    BadRequestError,
-    ConflictError,
+    QueuePrioritizedItem,
     SchedulerError,
-    TaskNotFoundError,
-    TooManyRequestsError,
     client,
 )
 
@@ -165,11 +162,10 @@ class ObjectsBreadcrumbsMixin(BreadcrumbsMixin, OrganizationView):
         ]
 
 
-def schedule_task(request: HttpRequest, organization_code: str, task_id: str) -> None:
+def schedule_task(request: HttpRequest, organization_code: str, p_item: QueuePrioritizedItem) -> None:
     try:
-        task = client.get_task_details(organization_code, task_id)
-        client.push_task(f"{task.p_item.data.type}-{organization_code}", task.p_item)
-    except (TaskNotFoundError, BadRequestError, TooManyRequestsError, ConflictError, SchedulerError) as error:
+        client.push_task(f"{p_item.data.type}-{organization_code}", p_item)
+    except SchedulerError as error:
         messages.error(request, error.message)
     else:
         messages.success(
@@ -180,3 +176,12 @@ def schedule_task(request: HttpRequest, organization_code: str, task_id: str) ->
                 "It may take some time, a refresh of the page may be needed to show the results."
             ),
         )
+
+
+def reschedule_task(request: HttpRequest, organization_code: str, task_id: str) -> None:
+    try:
+        task = client.get_task_details(organization_code, task_id)
+    except SchedulerError as error:
+        messages.error(request, error.message)
+    else:
+        schedule_task(request, organization_code, task.p_item)


### PR DESCRIPTION
### Changes
#2095 changed `schedule_task` function so that functionality is actually rescheduling a task given a task id. This didn't take into account that this function was also used on the ooi detail and boefje pages to manually start a scan and broke that functionality. This restores the `schedule_task` function and creates a new `reschedule_task`

I also changed the try/except to only catch `SchedulerError` because all the other exceptions are subclasses of `SchedulerError` and there is no need to list them.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
