### PR TITLE
Improve documentation about pre-commit and signed commits

### DIFF
--- a/docs/source/guidelines/contributions.rst
+++ b/docs/source/guidelines/contributions.rst
@@ -25,8 +25,8 @@ See :ref:`Development` for our code style, coding conventions, and overall workf
     - This branch should be in the following format:
     - ``[feature|enhancement|bug|hotfix]/random-cat-popup-on-screen``
 - Commit and push the code
-    - Make sure the code is linted, formatted and has correct typing
-    - The code must pass ``pre-commit`` locally
+    - Make sure the code is linted, formatted and has correct typing. Use ``pre-commit`` locally for this, see :ref:`Pre-commit`.
+    - All commits must be signed, see :ref:`Signed commits`.
 - Submit Pull Request
     - Make sure your code is tested and the PR has a good title and description
     - Use the PR template

--- a/docs/source/guidelines/development.rst
+++ b/docs/source/guidelines/development.rst
@@ -38,16 +38,31 @@ Pre-commit
 
 Continuous Integration will run several checks as mentioned above, like ``black``, ``ruff`` and more using pre-commit hooks.
 Any warnings from these checks will cause the Continuous Integration to fail; therefore, it is helpful to run the check yourself before submitting code.
-This can be done by `installing pre-commit <https://pre-commit.com/#install>`_::
+This can be done automatically by `installing pre-commit <https://pre-commit.com/#install>`_. We recommend that you first
+`install pipx <https://pipx.pypa.io/stable/installation/>`_ and then use pipx to install pre-commit:
 
-    pip install pre-commit
+    pipx install pre-commit
 
-and then running::
+If you already use homebrew you can also use it to install pre-commit:
+
+    brew install pre-commit
+
+Note that using apt to install pre-commit is not recommended because that will give you an old pre-commit version that might
+not work. After pre-commit is installed, run::
 
     pre-commit install
 
 from the root directory of a repository. Now all of the checks will be run each time you commit changes without your needing to run each one manually.
 In addition, using pre-commit will also allow you to more easily remain up-to-date with our code checks as they change.
+
+Signed commits
+==============
+
+The OpenKAT github project is configured to require all commits of a PR to be
+signed. The easiest way to do this is to configure git to automatically sign all
+commits by default. See the `GitHub documentation
+<https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits>`_
+how to do this.
 
 Type Hinting
 ============

--- a/docs/source/technical_design/index.rst
+++ b/docs/source/technical_design/index.rst
@@ -13,6 +13,7 @@ Contains documentation for developers and contributors.
    scripts
    hardening
    localinstall
+   windowsinstall
    gitpod
    nginx
    debuggingtroubleshooting

--- a/docs/source/technical_design/windowsinstall.rst
+++ b/docs/source/technical_design/windowsinstall.rst
@@ -1,6 +1,6 @@
-===================================
-Installation of OpenKAT on Windows
-===================================
+================================
+Development: make kat on Windows
+================================
 
 This manual helps you to install and run OpenKAT on your Windows with the use of WSL2.
 


### PR DESCRIPTION
### Changes
This adds documentation about signed commits and improves documentation about pre-commit.

It also adds the windows installation manual to the table of contents so it is visible in the documentation.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
