### PR TITLE
Fix `PrimaryKeyToken` class

### DIFF
--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -241,7 +241,10 @@ def format_id_short(id_: str) -> str:
 class PrimaryKeyToken(RootModel):
     root: Dict[str, Union[str, PrimaryKeyToken]]
 
-    def __getattr__(self, item) -> Union[str, PrimaryKeyToken]:
+    def __getattr__(self, item):
+        return self.root[item]
+
+    def __getitem__(self, item) -> Union[str, PrimaryKeyToken]:
         return self.root[item]
 
 


### PR DESCRIPTION
### Changes
This class fixes the `TypeError: 'PrimaryKeyToken' object is not subscribable`. `PrimaryKeyToken` object properties can now be accessed as dictionaries (`token['address']`) or as attributes (`token.address`).

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
