### PR TITLE
Fix boefje request that fetches settings

### DIFF
--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -83,9 +83,12 @@ def serialize_ooi(ooi: OOI):
 
 def get_environment_settings(boefje_meta: BoefjeMeta, environment_keys: List[str]) -> Dict[str, str]:
     try:
-        environment = requests.get(
-            f"{settings.katalogus_api}/v1/organisations/{boefje_meta.organization}/{boefje_meta.boefje.id}/settings"
-        ).json()
+        katalogus_api = str(settings.katalogus_api).rstrip("/")
+        response = requests.get(
+            f"{katalogus_api}/v1/organisations/{boefje_meta.organization}/{boefje_meta.boefje.id}/settings"
+        )
+        response.raise_for_status()
+        environment = response.json()
 
         # Add prefixed BOEFJE_* global environment variables
         for key, value in os.environ.items():


### PR DESCRIPTION
### Changes
The request to fetch katalogus settings didn't work because of a double `//`, but it also didn't check the status of the request.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
