### PR TITLE
Fixed invalid `Optional` fields

### DIFF
--- a/keiko/templates/bevindingenrapport/model.py
+++ b/keiko/templates/bevindingenrapport/model.py
@@ -61,4 +61,4 @@ class DataShape(DataShapeBase):
     report_source_type: str
     report_source_value: str
     filters: dict
-    report_url: Optional[str]
+    report_url: Optional[str] = None

--- a/octopoes/octopoes/models/ooi/network.py
+++ b/octopoes/octopoes/models/ooi/network.py
@@ -107,8 +107,8 @@ class AutonomousSystem(OOI):
 class NetBlock(OOI):
     network: Reference = ReferenceField(Network)
 
-    name: Optional[str]
-    description: Optional[str]
+    name: Optional[str] = None
+    description: Optional[str] = None
 
     announced_by: Optional[Reference] = ReferenceField(AutonomousSystem, default=None)
     parent: Optional[Reference] = ReferenceField("NetBlock", default=None)

--- a/octopoes/octopoes/models/ooi/web.py
+++ b/octopoes/octopoes/models/ooi/web.py
@@ -301,7 +301,7 @@ class SecurityTXT(OOI):
     redirects_to: Optional[Reference] = ReferenceField(
         "SecurityTXT", max_issue_scan_level=2, max_inherit_scan_level=0, default=None
     )
-    security_txt: Optional[str]
+    security_txt: Optional[str] = None
 
     _natural_key_attrs = ["website", "url"]
     _reverse_relation_names = {


### PR DESCRIPTION
### Changes
Pydantic V2 changes some of the logic for specifying whether a field annotated as `Optional` is required or not and now more closely matches the behavior of `dataclasses`. A field annotated as `typing.Optional[T]` will be required, and will allow for a value of `None`. It does not mean that the field has a default value of `None`. This is a breaking change from V1 and is now applied to some of the models that weren't updated in the bigger upgrade PR.

### Demo
The error as mentioned by @Donnype 

![image](https://github.com/minvws/nl-kat-coordination/assets/3471807/9edc2ed8-1597-4795-a86a-2961d8312929)

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
