### PR TITLE
fix normalizer yielded objects output

### DIFF
--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -34,6 +34,6 @@
 {% block html_at_end_body %}
     {{ block.super }}
     {% compress js %}
-        <script src="{% static "js/renderNormalizerOutputOOIs.js" %}" nonce="{{ request.csp_nonce }}"></script>
+        <script type="module" src="{% static "js/renderNormalizerOutputOOIs.js" %}" nonce="{{ request.csp_nonce }}"></script>
     {% endcompress %}
 {% endblock html_at_end_body %}


### PR DESCRIPTION
### Changes
We import parts from other modules, which means the importer also needs to be a module. This fixes the error when showing normaliser task details. This restores functionality in which the yielded objects are shown.

### Demo
![image](https://github.com/minvws/nl-kat-coordination/assets/1902670/ddfe7876-b349-41b7-b990-3315baa5ecec)

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
