### PR TITLE
Update Makefile, fix tab/space issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ kat: env-if-empty build up
 	@echo "The KAT frontend is running at http://localhost:8000,"
 	@echo "An initial superuser has been created"
 	@echo "The username is stored in DJANGO_SUPERUSER_EMAIL in the .env-default file."
-        @echo "run `grep 'DJANGO_SUPERUSER_EMAIL' .env` to find it."
+	@echo "run `grep 'DJANGO_SUPERUSER_EMAIL' .env` to find it."
 	@echo "The related password can be found as DJANGO_SUPERUSER_PASSWORD in the .env file."
-        @echo "run `grep 'DJANGO_SUPERUSER_PASSWORD' .env` to find it."
+	@echo "run `grep 'DJANGO_SUPERUSER_PASSWORD' .env` to find it."
 	@echo
 	@echo "WARNING: This is a development environment, do not use in production!"
 	@echo "See https://docs.openkat.nl/technical_design/install.html for production"


### PR DESCRIPTION
### Changes
Fixes the linting issue seen in:

https://github.com/minvws/nl-kat-coordination/actions/runs/7223588374/job/19682984635
"Makefile:30: *** missing separator (did you mean TAB instead of 8 spaces?).  Stop."


### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
