### PR TITLE
Fix form rendering optional fields

### DIFF
--- a/rocky/rocky/views/ooi_edit.py
+++ b/rocky/rocky/views/ooi_edit.py
@@ -26,7 +26,7 @@ class OOIEditView(BaseOOIFormView):
                 # Config OOIs use dicts for their values
                 initial[attr] = value
             else:
-                initial[attr] = str(value)
+                initial[attr] = str(value) if value is not None else None
 
         return initial
 

--- a/rocky/rocky/views/ooi_view.py
+++ b/rocky/rocky/views/ooi_view.py
@@ -120,11 +120,7 @@ class BaseOOIFormView(SingleOOIMixin, FormView):
         return self.ooi.__class__ if hasattr(self, "ooi") else None
 
     def get_form(self, form_class=None) -> BaseRockyForm:
-        if form_class is None:
-            form_class = self.get_form_class()
-
-        kwargs = self.get_form_kwargs()
-        form = form_class(**kwargs)
+        form = super().get_form(form_class)
 
         # Disable natural key attributes
         if self.get_readonly_fields():

--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from inspect import isclass
 from ipaddress import IPv4Address, IPv6Address
-from typing import Dict, Literal, Optional, Type, Union
+from typing import Dict, Literal, Optional, Type, Union, get_args, get_origin, cast
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -40,13 +40,16 @@ class OOIForm(BaseRockyForm):
     ) -> Dict[str, forms.fields.Field]:
         fields = {}
         for name, field in self.ooi_class.model_fields.items():
+            annotation = field.annotation
             default_attrs = default_field_options(name, field)
+            # if annotation is an Union, get the first non-optional type
+            optional_type = get_args(annotation)[0] if get_origin(annotation) == Union else None
 
             if name == "primary_key":
                 continue
 
             # skip literals
-            if hasattr(field.annotation, "__origin__") and field.annotation.__origin__ == Literal:
+            if hasattr(annotation, "__origin__") and annotation.__origin__ == Literal:
                 continue
 
             if hidden_ooi_fields and name in hidden_ooi_fields:
@@ -56,19 +59,19 @@ class OOIForm(BaseRockyForm):
                 fields[name] = generate_select_ooi_field(
                     self.api_connector, name, field, get_relations(self.ooi_class)[name], self.initial.get(name, None)
                 )
-            elif field.annotation in [IPv4Address, IPv6Address]:
+            elif annotation in [IPv4Address, IPv6Address]:
                 fields[name] = generate_ip_field(field)
-            elif field.annotation == AnyUrl:
+            elif annotation == AnyUrl:
                 fields[name] = generate_url_field(field)
-            elif field.annotation == int or (
-                hasattr(field.annotation, "__args__") and int in field.annotation.__args__
+            elif annotation == int or (
+                hasattr(annotation, "__args__") and int in annotation.__args__
             ):
                 fields[name] = forms.IntegerField(**default_attrs)
-            elif isclass(field.annotation) and issubclass(field.annotation, Enum):
-                fields[name] = generate_select_ooi_type(name, field.annotation, field)
-            elif self.ooi_class == Question and issubclass(field.annotation, str) and name == "json_schema":
+            elif isclass(annotation) and issubclass(annotation, Enum):
+                fields[name] = generate_select_ooi_type(name, cast(Enum, annotation), field)
+            elif self.ooi_class == Question and issubclass(annotation, str) and name == "json_schema":
                 fields[name] = forms.CharField(**default_attrs)
-            elif isclass(field.annotation) and issubclass(field.annotation, str):
+            elif isclass(annotation) and issubclass(annotation, str) or optional_type is str:
                 if name in self.ooi_class.__annotations__ and self.ooi_class.__annotations__[name] == Dict[str, str]:
                     fields[name] = forms.JSONField(**default_attrs)
                 else:

--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -75,7 +75,8 @@ class OOIForm(BaseRockyForm):
                 if name in self.ooi_class.__annotations__ and self.ooi_class.__annotations__[name] == Dict[str, str]:
                     fields[name] = forms.JSONField(**default_attrs)
                 else:
-                    fields[name] = forms.CharField(max_length=256, **default_attrs)
+                    fields[name] = forms.CharField(max_length=256, **default_attrs,
+                                                   empty_value=None if not field.is_required() else "")
 
         return fields
 
@@ -113,7 +114,6 @@ def generate_select_ooi_field(
     return forms.CharField(widget=forms.Select(choices=select_options), **default_attrs)
 
 
-# todo: name?
 def generate_select_ooi_type(name: str, enumeration: Enum, field: FieldInfo) -> forms.fields.Field:
     """OOI Type (enum) fields will have a select input"""
     default_attrs = default_field_options(name, field)

--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from inspect import isclass
 from ipaddress import IPv4Address, IPv6Address
-from typing import Dict, Literal, Optional, Type, Union, get_args, get_origin, cast
+from typing import Dict, Literal, Optional, Type, Union, cast, get_args, get_origin
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -63,9 +63,7 @@ class OOIForm(BaseRockyForm):
                 fields[name] = generate_ip_field(field)
             elif annotation == AnyUrl:
                 fields[name] = generate_url_field(field)
-            elif annotation == int or (
-                hasattr(annotation, "__args__") and int in annotation.__args__
-            ):
+            elif annotation == int or (hasattr(annotation, "__args__") and int in annotation.__args__):
                 fields[name] = forms.IntegerField(**default_attrs)
             elif isclass(annotation) and issubclass(annotation, Enum):
                 fields[name] = generate_select_ooi_type(name, cast(Enum, annotation), field)
@@ -75,8 +73,9 @@ class OOIForm(BaseRockyForm):
                 if name in self.ooi_class.__annotations__ and self.ooi_class.__annotations__[name] == Dict[str, str]:
                     fields[name] = forms.JSONField(**default_attrs)
                 else:
-                    fields[name] = forms.CharField(max_length=256, **default_attrs,
-                                                   empty_value=None if not field.is_required() else "")
+                    fields[name] = forms.CharField(
+                        max_length=256, **default_attrs, empty_value=None if not field.is_required() else ""
+                    )
 
         return fields
 


### PR DESCRIPTION
### Changes
This is a fix to enable OOI forms to render `Optional` fields other than `Reference`s.

### Demo
<img width="878" alt="image" src="https://github.com/minvws/nl-kat-coordination/assets/3471807/e360cbc8-5d69-42c8-a079-f9aee6f8f520">

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
