### PR TITLE
Temporary fix for wappalyzer image architecture

### DIFF
--- a/boefjes/boefjes/plugins/kat_website_software/main.py
+++ b/boefjes/boefjes/plugins/kat_website_software/main.py
@@ -1,10 +1,15 @@
+import platform
 from typing import List, Tuple, Union
 
 import docker
 
 from boefjes.job_models import BoefjeMeta
 
-WAPPALYZER_IMAGE = "noamblitz/wappalyzer:latest"
+# FIXME: We should build a multi-platform image
+if platform.processor() == "arm":
+    WAPPALYZER_IMAGE = "noamblitz/wappalyzer:MacM1"
+else:
+    WAPPALYZER_IMAGE = "noamblitz/wappalyzer:latest"
 
 
 def run_wappalyzer(url: str) -> str:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ paths = ["."]
 # To be extended with DJ, PT, RUF, C90, D, PL, RET
 select = ["E", "F", "ERA", "W", "TID", "I", "G", "INP", "T20", "UP", "ISC", "PTH", "SIM", "PLC", "A"]
 # non-pep585-annotation and non-pep604-annotation are not actually compatible with 3.8
-ignore = ["UP006", "UP007", "A003"]
+ignore = ["UP006", "UP007", "A003", "SIM108"]
 fix = true
 
 # Exclude a variety of commonly ignored directories.


### PR DESCRIPTION
### Changes
This sets the wappalyzer image to `noamblitz/wappalyzer:MacM1` if the architecture is arm. We should have a multi-platform image, but that should be part of more extensive work on wappalyzer, so I created this temporary fix.

Ruff complained that the ternary operator should be used, but I chose to disable the rule. In my opinion the ternary operator often makes code harder to read and ruff also can't fix it automatically which is also annoying.

### Issue link
Closes #1542 

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
