### PR TITLE
Improve system identification

### DIFF
--- a/rocky/poetry.lock
+++ b/rocky/poetry.lock
@@ -3733,6 +3733,22 @@ doc = ["sphinx"]
 test = ["pytest", "pytest-cov"]
 
 [[package]]
+name = "strenum"
+version = "0.4.15"
+description = "An Enum that inherits from str."
+optional = false
+python-versions = "*"
+files = [
+    {file = "StrEnum-0.4.15-py3-none-any.whl", hash = "sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659"},
+    {file = "StrEnum-0.4.15.tar.gz", hash = "sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff"},
+]
+
+[package.extras]
+docs = ["myst-parser[linkify]", "sphinx", "sphinx-rtd-theme"]
+release = ["twine"]
+test = ["pylint", "pytest", "pytest-black", "pytest-cov", "pytest-pylint"]
+
+[[package]]
 name = "svglib"
 version = "1.5.1"
 description = "A pure-Python library for reading and converting SVG"
@@ -4353,4 +4369,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "49e52560f0b2b6ef240d1f8c1fa2367af3abe370a7226a0103a4a167e4bef54f"
+content-hash = "60a99332287296e565e8db78fc694fc04144ccdee1eef09339fec3e065683174"

--- a/rocky/pyproject.toml
+++ b/rocky/pyproject.toml
@@ -45,6 +45,7 @@ django-tagulous = "^1.3.3"
 drf-standardized-errors = "^0.12.5"
 django-compressor = { git = "https://github.com/dekkers/django-compressor", rev = "620bc0ab86590f8981dd24456a70951c9bdbf91f" }
 django-weasyprint = "^2.2.1"
+strenum = "^0.4.15"
 
 # temp fix to pass build, remove later when https://github.com/xhtml2pdf/xhtml2pdf/issues/589 is solved
 reportlab = "^3.6.13"

--- a/rocky/reports/report_types/systems_report/report.py
+++ b/rocky/reports/report_types/systems_report/report.py
@@ -1,10 +1,10 @@
 from dataclasses import dataclass
 from datetime import datetime
-from enum import StrEnum
 from logging import getLogger
 from typing import Any, Dict
 
 from django.utils.translation import gettext_lazy as _
+from strenum import StrEnum
 
 from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname

--- a/rocky/requirements-dev.txt
+++ b/rocky/requirements-dev.txt
@@ -1701,6 +1701,9 @@ soupsieve==2.4.1 ; python_version >= "3.8" and python_version < "4.0" \
 sqlparse==0.4.4 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
+strenum==0.4.15 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff \
+    --hash=sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659
 svglib==1.5.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:3ae765d3a9409ee60c0fb4d24c2deb6a80617aa927054f5bcd7fc98f0695e587
 tinycss2==1.2.1 ; python_version >= "3.8" and python_version < "4.0" \

--- a/rocky/requirements.txt
+++ b/rocky/requirements.txt
@@ -1188,6 +1188,9 @@ soupsieve==2.4.1 ; python_version >= "3.8" and python_version < "4.0" \
 sqlparse==0.4.4 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:5430a4fe2ac7d0f93e66f1efc6e1338a41884b7ddf2a350cedd20ccc4d9d28f3 \
     --hash=sha256:d446183e84b8349fa3061f0fe7f06ca94ba65b426946ffebe6e3e8295332420c
+strenum==0.4.15 ; python_version >= "3.8" and python_version < "4.0" \
+    --hash=sha256:878fb5ab705442070e4dd1929bb5e2249511c0bcf2b0eeacf3bcd80875c82eff \
+    --hash=sha256:a30cda4af7cc6b5bf52c8055bc4bf4b2b6b14a93b574626da33df53cf7740659
 svglib==1.5.1 ; python_version >= "3.8" and python_version < "4.0" \
     --hash=sha256:3ae765d3a9409ee60c0fb4d24c2deb6a80617aa927054f5bcd7fc98f0695e587
 tinycss2==1.2.1 ; python_version >= "3.8" and python_version < "4.0" \

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-15 14:25+0000\n"
+"POT-Creation-Date: 2023-12-17 20:19+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2872,26 +2872,6 @@ msgstr ""
 
 #: reports/report_types/systems_report/report.py
 msgid "Combine IP addresses, hostnames and services into systems."
-msgstr ""
-
-#: reports/report_types/systems_report/report.py
-msgid "Web"
-msgstr ""
-
-#: reports/report_types/systems_report/report.py
-msgid "Mail"
-msgstr ""
-
-#: reports/report_types/systems_report/report.py
-msgid "Dicom"
-msgstr ""
-
-#: reports/report_types/systems_report/report.py
-msgid "DNS"
-msgstr ""
-
-#: reports/report_types/systems_report/report.py
-msgid "Other"
 msgstr ""
 
 #: reports/report_types/tls_report/report.html


### PR DESCRIPTION
### Changes
This is partly some changes already done on the aggregate report branch. I've also pushed those changes there, but I'm opening a seperate PR so we can have discussion about it if necessary.

This adds some more service mappings. HTTP was missing, meaning that every website was classified as both "other" via services and as "web" via Website OOI. It also doesn't classify the system as "other" if it isn't listed in software mapping, because classifying everything that isn't dicom as "other" doesn't make much sense to me.

I've also removed some services that I either can't find in the nmap services file (tsdns, smtp-stats, smtp-proxy, mail-admin), can't find what it is so probably old and irrelevant (mailq) or is something different than normal DNS (mdns).

I also sort the list of services so they are always in the same order.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
