### PR TITLE
Fix fix-poetry-merge-conflict in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ fix-poetry-merge-conflict:
 		git checkout --theirs $$path/poetry.lock $$path/requirements*; \
 		poetry lock --no-update -C $$path; \
 		poetry export -C $$path --only main -f requirements.txt -o $$path/requirements.txt; \
-		if grep -q "tool.poetry.group.dev.dependencies" $$path; then \
+		if grep -q "tool.poetry.group.dev.dependencies" $$path/pyproject.toml; then \
 			poetry export -C $$path --with dev -f requirements.txt -o $$path/requirements-dev.txt; \
 		fi; \
 		git add $$path/poetry.lock $$path/requirements*; \


### PR DESCRIPTION
### Changes
Should run grep on pyproject.toml, not on the directory.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
