### PR TITLE
fix rpki delete_on_close, can be just delete

### DIFF
--- a/boefjes/boefjes/plugins/kat_rpki/main.py
+++ b/boefjes/boefjes/plugins/kat_rpki/main.py
@@ -24,10 +24,10 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
     ip = input_["address"]
     now = datetime.utcnow()
 
-    if not RPKI_META_PATH.exists() or not validate_age():
+    if not RPKI_PATH.exists() or not validate_age():
         rpki_json = refresh_rpki()
     else:
-        with RPKI_META_PATH.open() as json_file:
+        with RPKI_PATH.open() as json_file:
             rpki_json = json.load(json_file)
 
     exists = False

--- a/boefjes/boefjes/plugins/kat_rpki/main.py
+++ b/boefjes/boefjes/plugins/kat_rpki/main.py
@@ -58,7 +58,7 @@ def refresh_rpki() -> Dict:
     source_url = getenv("RPKI_SOURCE_URL", RPKI_SOURCE_URL)
     response = requests.get(source_url, allow_redirects=True)
     response.raise_for_status()
-    with tempfile.NamedTemporaryFile(mode="w", delete_on_close=False) as temp_rpki_file:
+    with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_rpki_file:
         temp_rpki_file.write(response.content)
         os.rename(temp_rpki_file.name, RPKI_PATH)
     metadata = {"timestamp": datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%SZ"), "source": source_url}


### PR DESCRIPTION
### Changes
change delete_on_close into just delete

https://docs.python.org/3/library/tempfile.html#tempfile.NamedTemporaryFile states we can just use delete:
`Therefore to use the name of the temporary file to reopen the file after closing it, either make sure not to delete the file upon closure (set the delete parameter to be false)`

We for some reason saw the following error when running the previous version:
`TypeError: NamedTemporaryFile() got an unexpected keyword argument 'delete_on_close'`


### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
