### PR TITLE
Add scheduler stats to boefje/normaliser task pages in rocky.

### DIFF
--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-19 13:30+0000\n"
+"POT-Creation-Date: 2023-12-22 12:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -5515,6 +5515,7 @@ msgid "Success"
 msgstr ""
 
 #: rocky/templates/partials/task_history.html
+#: rocky/templates/tasks/partials/stats.html
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "Failed"
 msgstr ""
@@ -5664,28 +5665,56 @@ msgstr ""
 msgid "Boefje input OOI"
 msgstr ""
 
+#: rocky/templates/tasks/partials/stats.html
+msgid "Stats - Last 24 hours"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "All times in UTC, blocks of 1 hour."
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Timeslot"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Pending"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Queued"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Dispatched"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Running"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+#: rocky/templates/tasks/partials/task_filter.html
+msgid "Completed"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Cancelled"
+msgstr ""
+
+#: rocky/templates/tasks/partials/stats.html
+msgid "Could not load stats, Scheduler error."
+msgstr ""
+
 #: rocky/templates/tasks/partials/tab_navigation.html
 msgid "List of tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_filter.html
 msgid "all"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_filter.html
-msgid "Pending"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_filter.html
-msgid "Queued"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_filter.html
-msgid "Dispatched"
-msgstr ""
-
-#: rocky/templates/tasks/partials/task_filter.html
-msgid "Completed"
 msgstr ""
 
 #: rocky/templates/two_factor/_wizard_actions.html

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import datetime
 import uuid
+import json
 from enum import Enum
 from http import HTTPStatus
 from logging import getLogger

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import datetime
-import uuid
 import json
+import uuid
 from enum import Enum
 from http import HTTPStatus
 from logging import getLogger

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -258,8 +258,11 @@ class SchedulerClient:
         return ServiceHealth.model_validate_json(health_endpoint.content)
 
     def get_task_stats(self, organization_code: str, task_type: str) -> Dict:
-        res = self.session.get(f"{self._base_uri}/tasks/stats/{task_type}-{organization_code}")
-        res.raise_for_status()
+        try:
+            res = self.session.get(f"{self._base_uri}/tasks/stats/{task_type}-{organization_code}")
+            res.raise_for_status()
+        except HTTPError as http_error:
+            raise SchedulerError()
         task_stats = json.loads(res.content)
         return task_stats
 

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -256,5 +256,11 @@ class SchedulerClient:
         health_endpoint.raise_for_status()
         return ServiceHealth.model_validate_json(health_endpoint.content)
 
+    def get_task_stats(self, organization_code: str, task_type: str) -> Dict:
+        res = self.session.get(f"{self._base_uri}/tasks/stats/{task_type}-{organization_code}")
+        res.raise_for_status()
+        task_stats = json.loads(res.content)
+        return task_stats
+
 
 client = SchedulerClient(settings.SCHEDULER_API)

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -261,7 +261,7 @@ class SchedulerClient:
         try:
             res = self.session.get(f"{self._base_uri}/tasks/stats/{task_type}-{organization_code}")
             res.raise_for_status()
-        except HTTPError as http_error:
+        except HTTPError:
             raise SchedulerError()
         task_stats = json.loads(res.content)
         return task_stats

--- a/rocky/rocky/templates/tasks/boefjes.html
+++ b/rocky/rocky/templates/tasks/boefjes.html
@@ -28,5 +28,6 @@
                 {% endif %}
             </div>
         </section>
+        {% include "tasks/partials/stats.html" %}
     </main>
 {% endblock content %}

--- a/rocky/rocky/templates/tasks/boefjes.html
+++ b/rocky/rocky/templates/tasks/boefjes.html
@@ -29,5 +29,6 @@
             </div>
         </section>
         {% include "tasks/partials/stats.html" %}
+
     </main>
 {% endblock content %}

--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -29,6 +29,7 @@
                 {% endif %}
             </div>
         </section>
+       {% include "tasks/partials/stats.html" %}
     </main>
 {% endblock content %}
 {% block html_at_end_body %}

--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -29,7 +29,8 @@
                 {% endif %}
             </div>
         </section>
-       {% include "tasks/partials/stats.html" %}
+        {% include "tasks/partials/stats.html" %}
+
     </main>
 {% endblock content %}
 {% block html_at_end_body %}

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -19,27 +19,27 @@
                 <tbody>
                     {% for timestamp, values in  stats.items %}
                         <tr>
-                            <th scope="row"> {{timestamp}}: </th> 
-                            <td style="--size: calc({{ values.pending}} / 150);">
-                                <span class="data">{{ values.pending}}</span>
+                            <th scope="row">{{timestamp}}:</th> 
+                            <td style="--size: calc({{ values.pending }} / 150);">
+                                <span class="data">{{ values.pending }}</span>
                             </td>
-                            <td style="--size: calc({{ values.queued}} / 150);">
-                                <span class="data">{{ values.queued}}</span>
+                            <td style="--size: calc({{ values.queued }} / 150);">
+                                <span class="data">{{ values.queued }}</span>
                             </td>
-                            <td style="--size: calc({{ values.dispatched}} / 150);">
-                                <span class="data">{{ values.dispatched}}</span>
+                            <td style="--size: calc({{ values.dispatched }} / 150);">
+                                <span class="data">{{ values.dispatched }}</span>
                             </td>
-                            <td style="--size: calc({{ values.running}} / 150);">
-                                <span class="data">{{ values.running}}</span>
+                            <td style="--size: calc({{ values.running }} / 150);">
+                                <span class="data">{{ values.running }}</span>
                             </td>
-                            <td style="--size: calc({{ values.completed}} / 150);">
-                                <span class="data">{{ values.completed}}</span>
+                            <td style="--size: calc({{ values.completed }} / 150);">
+                                <span class="data">{{ values.completed }}</span>
                             </td>
-                            <td style="--size: calc({{ values.failed}} / 150);">
-                                <span class="data">{{ values.failed}}</span>
+                            <td style="--size: calc({{ values.failed }} / 150);">
+                                <span class="data">{{ values.failed }}</span>
                             </td>
-                            <td style="--size: calc({{ values.cancelled}} / 150);">
-                                <span class="data">{{ values.cancelled}}</span>
+                            <td style="--size: calc({{ values.cancelled }} / 150);">
+                                <span class="data">{{ values.cancelled }}</span>
                             </td>
                         </tr>
                     {% endfor %}

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -1,50 +1,56 @@
+{% load i18n %}
+
 <section>
     <div>
-        <h2>Stats - Last 24 hours</h2>
-        <div id="stats-graph">
-            <table class="charts-css column hide-data show-heading show-labels show-primary-axis show-3-secondary-axes data-spacing-10 multiple stacked">
-                <caption>All times in UTC, blocks of 1 hour.</caption>
-                <thead>
-                    <tr>
-                        <th scope="col">Timeslot</th>
-                        <th scope="col">Pending</th>
-                        <th scope="col">Queued</th>
-                        <th scope="col">Dispatched</th>
-                        <th scope="col">Running</th>
-                        <th scope="col">Completed</th>
-                        <th scope="col">Failed</th>
-                        <th scope="col">Cancelled</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    {% for timestamp, values in  stats.items %}
+        <h2>{% translate "Stats - Last 24 hours" %}</h2>
+        {% if stats %}
+            <div id="stats-graph">
+                <table class="charts-css column hide-data show-heading show-labels show-primary-axis show-3-secondary-axes data-spacing-10 multiple stacked">
+                    <caption>{% translate "All times in UTC, blocks of 1 hour." %}</caption>
+                    <thead>
                         <tr>
-                            <th scope="row">{{timestamp}}:</th> 
-                            <td style="--size: calc({{ values.pending }} / 150);">
-                                <span class="data">{{ values.pending }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.queued }} / 150);">
-                                <span class="data">{{ values.queued }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.dispatched }} / 150);">
-                                <span class="data">{{ values.dispatched }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.running }} / 150);">
-                                <span class="data">{{ values.running }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.completed }} / 150);">
-                                <span class="data">{{ values.completed }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.failed }} / 150);">
-                                <span class="data">{{ values.failed }}</span>
-                            </td>
-                            <td style="--size: calc({{ values.cancelled }} / 150);">
-                                <span class="data">{{ values.cancelled }}</span>
-                            </td>
+                            <th scope="col">{% translate "Timeslot" %}</th>
+                            <th scope="col">{% translate "Pending" %}</th>
+                            <th scope="col">{% translate "Queued" %}</th>
+                            <th scope="col">{% translate "Dispatched" %}</th>
+                            <th scope="col">{% translate "Running" %}</th>
+                            <th scope="col">{% translate "Completed" %}</th>
+                            <th scope="col">{% translate "Failed" %}</th>
+                            <th scope="col">{% translate "Cancelled" %}</th>
                         </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
+                    </thead>
+                    <tbody>
+                        {% for timestamp, values in  stats.items %}
+                            <tr>
+                                <th scope="row">{{timestamp}}:</th> 
+                                <td style="--size: calc({{ values.pending }} / 150);">
+                                    <span class="data">{{ values.pending }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.queued }} / 150);">
+                                    <span class="data">{{ values.queued }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.dispatched }} / 150);">
+                                    <span class="data">{{ values.dispatched }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.running }} / 150);">
+                                    <span class="data">{{ values.running }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.completed }} / 150);">
+                                    <span class="data">{{ values.completed }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.failed }} / 150);">
+                                    <span class="data">{{ values.failed }}</span>
+                                </td>
+                                <td style="--size: calc({{ values.cancelled }} / 150);">
+                                    <span class="data">{{ values.cancelled }}</span>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p class="error">{% translate "Could not load stats, Scheduler error." %}</p>
+        {% endif %}
     </div>
 </section>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -6,48 +6,42 @@
                 <caption>All times in UTC, blocks of 1 hour.</caption>
                 <thead>
                     <tr>
-                        <th scope="col"> Timeslot </th>
-                        <th scope="col"> pending </th>
-                        <th scope="col"> queued </th>
-                        <th scope="col"> dispatched </th>
-                        <th scope="col"> running </th>
-                        <th scope="col"> completed </th>
-                        <th scope="col"> failed </th>
-                        <th scope="col"> cancelled </th>
+                        <th scope="col">Timeslot</th>
+                        <th scope="col">Pending</th>
+                        <th scope="col">Queued</th>
+                        <th scope="col">Dispatched</th>
+                        <th scope="col">Running</th>
+                        <th scope="col">Completed</th>
+                        <th scope="col">Failed</th>
+                        <th scope="col">Cancelled</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for timestamp, values in  stats.items %}
-                    <tr>
-                        <th scope="row"> {{timestamp}}: </th> 
-                        <td style="--size: calc({{ values.pending}} / 150);">
-                            <span class="data"> {{ values.pending}} </span>
-                        </td>
-                        
-                        <td style="--size: calc({{ values.queued}} / 150);">
-                            <span class="data"> {{ values.queued}} </span>
-                        </td>
-
-                        <td style="--size: calc({{ values.dispatched}} / 150);">
-                            <span class="data"> {{ values.dispatched}} </span>
-                        </td>
-
-                        <td style="--size: calc({{ values.running}} / 150);">
-                            <span class="data"> {{ values.running}} </span>
-                        </td>
-
-                        <td style="--size: calc({{ values.completed}} / 150);">
-                            <span class="data"> {{ values.completed}} </span>
-                        </td>
-
-                        <td style="--size: calc({{ values.failed}} / 150);">
-                            <span class="data"> {{ values.failed}} </span>
-                        </td>
-
-                        <td style="--size: calc({{ values.cancelled}} / 150);">
-                            <span class="data"> {{ values.cancelled}} </span>
-                        </td>
-                    </tr>
+                      <tr>
+                          <th scope="row"> {{timestamp}}: </th> 
+                          <td style="--size: calc({{ values.pending}} / 150);">
+                              <span class="data">{{ values.pending}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.queued}} / 150);">
+                              <span class="data">{{ values.queued}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.dispatched}} / 150);">
+                              <span class="data">{{ values.dispatched}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.running}} / 150);">
+                              <span class="data">{{ values.running}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.completed}} / 150);">
+                              <span class="data">{{ values.completed}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.failed}} / 150);">
+                              <span class="data">{{ values.failed}}</span>
+                          </td>
+                          <td style="--size: calc({{ values.cancelled}} / 150);">
+                              <span class="data">{{ values.cancelled}}</span>
+                          </td>
+                      </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -22,7 +22,7 @@
                     <tbody>
                         {% for timestamp, values in  stats.items %}
                             <tr>
-                                <th scope="row">{{ timestamp }}:</th> 
+                                <th scope="row">{{ timestamp }}:</th>
                                 <td style="--size: calc({{ values.pending }} / 150);">
                                     <span class="data">{{ values.pending }}</span>
                                 </td>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -5,7 +5,8 @@
             <table class="charts-css column hide-data show-heading show-labels show-primary-axis show-3-secondary-axes data-spacing-10 multiple stacked">
                 <caption>All times in UTC, blocks of 1 hour.</caption>
                 <thead>
-                    <tr><th scope="col"> Timeslot </th>
+                    <tr>
+                        <th scope="col"> Timeslot </th>
                         <th scope="col"> pending </th>
                         <th scope="col"> queued </th>
                         <th scope="col"> dispatched </th>
@@ -13,7 +14,8 @@
                         <th scope="col"> completed </th>
                         <th scope="col"> failed </th>
                         <th scope="col"> cancelled </th>
-                    </tr></thead>
+                    </tr>
+                </thead>
                 <tbody>
                     {% for timestamp, values in  stats.items %}
                     <tr>
@@ -49,6 +51,6 @@
                     {% endfor %}
                 </tbody>
             </table>
-        </div>            
+        </div>
     </div>
 </section>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -1,0 +1,54 @@
+<section>
+    <div>
+        <h2>Stats - Last 24 hours</h2>
+        <div id="stats-graph">
+            <table class="charts-css column hide-data show-heading show-labels show-primary-axis show-3-secondary-axes data-spacing-10 multiple stacked">
+                <caption>All times in UTC, blocks of 1 hour.</caption>
+                <thead>
+                    <tr><th scope="col"> Timeslot </th>
+                        <th scope="col"> pending </th>
+                        <th scope="col"> queued </th>
+                        <th scope="col"> dispatched </th>
+                        <th scope="col"> running </th>
+                        <th scope="col"> completed </th>
+                        <th scope="col"> failed </th>
+                        <th scope="col"> cancelled </th>
+                    </tr></thead>
+                <tbody>
+                    {% for timestamp, values in  stats.items %}
+                    <tr>
+                        <th scope="row"> {{timestamp}}: </th> 
+                        <td style="--size: calc({{ values.pending}} / 150);">
+                            <span class="data"> {{ values.pending}} </span>
+                        </td>
+                        
+                        <td style="--size: calc({{ values.queued}} / 150);">
+                            <span class="data"> {{ values.queued}} </span>
+                        </td>
+
+                        <td style="--size: calc({{ values.dispatched}} / 150);">
+                            <span class="data"> {{ values.dispatched}} </span>
+                        </td>
+
+                        <td style="--size: calc({{ values.running}} / 150);">
+                            <span class="data"> {{ values.running}} </span>
+                        </td>
+
+                        <td style="--size: calc({{ values.completed}} / 150);">
+                            <span class="data"> {{ values.completed}} </span>
+                        </td>
+
+                        <td style="--size: calc({{ values.failed}} / 150);">
+                            <span class="data"> {{ values.failed}} </span>
+                        </td>
+
+                        <td style="--size: calc({{ values.cancelled}} / 150);">
+                            <span class="data"> {{ values.cancelled}} </span>
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+        </div>            
+    </div>
+</section>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -22,7 +22,7 @@
                     <tbody>
                         {% for timestamp, values in  stats.items %}
                             <tr>
-                                <th scope="row">{{timestamp}}:</th> 
+                                <th scope="row">{{ timestamp }}:</th> 
                                 <td style="--size: calc({{ values.pending }} / 150);">
                                     <span class="data">{{ values.pending }}</span>
                                 </td>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -18,30 +18,30 @@
                 </thead>
                 <tbody>
                     {% for timestamp, values in  stats.items %}
-                      <tr>
-                          <th scope="row"> {{timestamp}}: </th> 
-                          <td style="--size: calc({{ values.pending}} / 150);">
-                              <span class="data">{{ values.pending}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.queued}} / 150);">
-                              <span class="data">{{ values.queued}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.dispatched}} / 150);">
-                              <span class="data">{{ values.dispatched}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.running}} / 150);">
-                              <span class="data">{{ values.running}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.completed}} / 150);">
-                              <span class="data">{{ values.completed}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.failed}} / 150);">
-                              <span class="data">{{ values.failed}}</span>
-                          </td>
-                          <td style="--size: calc({{ values.cancelled}} / 150);">
-                              <span class="data">{{ values.cancelled}}</span>
-                          </td>
-                      </tr>
+                        <tr>
+                            <th scope="row"> {{timestamp}}: </th> 
+                            <td style="--size: calc({{ values.pending}} / 150);">
+                                <span class="data">{{ values.pending}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.queued}} / 150);">
+                                <span class="data">{{ values.queued}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.dispatched}} / 150);">
+                                <span class="data">{{ values.dispatched}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.running}} / 150);">
+                                <span class="data">{{ values.running}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.completed}} / 150);">
+                                <span class="data">{{ values.completed}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.failed}} / 150);">
+                                <span class="data">{{ values.failed}}</span>
+                            </td>
+                            <td style="--size: calc({{ values.cancelled}} / 150);">
+                                <span class="data">{{ values.cancelled}}</span>
+                            </td>
+                        </tr>
                     {% endfor %}
                 </tbody>
             </table>

--- a/rocky/rocky/templates/tasks/partials/stats.html
+++ b/rocky/rocky/templates/tasks/partials/stats.html
@@ -20,7 +20,7 @@
                         </tr>
                     </thead>
                     <tbody>
-                        {% for timestamp, values in  stats.items %}
+                        {% for timestamp, values in stats.items %}
                             <tr>
                                 <th scope="row">{{ timestamp }}:</th>
                                 <td style="--size: calc({{ values.pending }} / 150);">

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -83,6 +83,7 @@ class TaskListView(OrganizationView, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
+        context["stats"] = client.get_task_stats( self.organization.code, self.plugin_type)
         context["breadcrumbs"] = [
             {"url": reverse("task_list", kwargs={"organization_code": self.organization.code}), "text": _("Tasks")},
         ]

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -14,8 +14,6 @@ from tools.view_helpers import reschedule_task
 
 from rocky.scheduler import TaskNotFoundError, client
 
-TASK_LIMIT = 50
-
 
 class PageActions(Enum):
     RESCHEDULE_TASK = "reschedule_task"

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -12,7 +12,7 @@ from katalogus.views.mixins import BoefjeMixin, NormalizerMixin
 from requests import HTTPError
 from tools.view_helpers import reschedule_task
 
-from rocky.scheduler import TaskNotFoundError, client
+from rocky.scheduler import TaskNotFoundError, SchedulerError, client
 
 
 class PageActions(Enum):
@@ -81,7 +81,10 @@ class TaskListView(OrganizationView, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["stats"] = client.get_task_stats(self.organization.code, self.plugin_type)
+        try:
+            context["stats"] = client.get_task_stats(self.organization.code, self.plugin_type)
+        except SchedulerError:
+            context["stats"] = False
         context["breadcrumbs"] = [
             {"url": reverse("task_list", kwargs={"organization_code": self.organization.code}), "text": _("Tasks")},
         ]

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -12,7 +12,7 @@ from katalogus.views.mixins import BoefjeMixin, NormalizerMixin
 from requests import HTTPError
 from tools.view_helpers import reschedule_task
 
-from rocky.scheduler import TaskNotFoundError, SchedulerError, client
+from rocky.scheduler import SchedulerError, TaskNotFoundError, client
 
 
 class PageActions(Enum):

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -81,7 +81,7 @@ class TaskListView(OrganizationView, ListView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["stats"] = client.get_task_stats( self.organization.code, self.plugin_type)
+        context["stats"] = client.get_task_stats(self.organization.code, self.plugin_type)
         context["breadcrumbs"] = [
             {"url": reverse("task_list", kwargs={"organization_code": self.organization.code}), "text": _("Tasks")},
         ]

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -84,7 +84,7 @@ class TaskListView(OrganizationView, ListView):
         try:
             context["stats"] = client.get_task_stats(self.organization.code, self.plugin_type)
         except SchedulerError:
-            context["stats"] = False
+            context["stats"] = None
         context["breadcrumbs"] = [
             {"url": reverse("task_list", kwargs={"organization_code": self.organization.code}), "text": _("Tasks")},
         ]


### PR DESCRIPTION
### Changes
Adds statistics tables to task page for boefjes and normalizers based on the stats available in the scheduler.

Optionally we can use ChartCSS for fancy graphical stacked bar charts:
https://chartscss.org/components/stacked/

Translations need to be added still.

### Issue link
Related:
https://github.com/minvws/nl-kat-coordination/pull/1846
https://github.com/minvws/nl-kat-coordination/issues/1768

### Demo

![image](https://github.com/minvws/nl-kat-coordination/assets/1902670/97061461-a523-48ba-9be0-039547c0b843)
---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
