### PR TITLE
Download report JSON and ReportData OOI

### DIFF
--- a/boefjes/boefjes/plugins/kat_report_data/normalize.py
+++ b/boefjes/boefjes/plugins/kat_report_data/normalize.py
@@ -1,0 +1,13 @@
+from typing import Iterable, Union
+
+from boefjes.job_models import NormalizerMeta
+from octopoes.models import OOI
+from octopoes.models.ooi.reports import ReportData
+
+
+def run(normalizer_meta: NormalizerMeta, raw: Union[bytes, str]) -> Iterable[OOI]:
+    ooi = ReportData.model_validate_json(raw)
+    yield {
+        "type": "declaration",
+        "ooi": ooi.dict(),
+    }

--- a/boefjes/boefjes/plugins/kat_report_data/normalizer.json
+++ b/boefjes/boefjes/plugins/kat_report_data/normalizer.json
@@ -1,0 +1,9 @@
+{
+    "id": "kat_report_data",
+    "consumes": [
+        "openkat/report-data"
+    ],
+    "produces": [
+        "ReportData"
+    ]
+}

--- a/boefjes/tests/examples/report-data-normalize.json
+++ b/boefjes/tests/examples/report-data-normalize.json
@@ -1,0 +1,28 @@
+{
+    "id": "f50de284-d3c1-4f87-ba68-07b957b7a48f",
+    "raw_data": {
+        "id": "61962aee-e782-4632-b606-c51c559f425b",
+        "boefje_meta": {
+            "id": "c384d1f1-1bbb-4878-b818-a13bd55daf63",
+            "started_at": "2023-12-17T23:54:10.495434Z",
+            "ended_at": "2023-12-17T23:54:10.495439Z",
+            "boefje": {
+                "id": "manual",
+                "version": null
+            },
+            "input_ooi": null,
+            "arguments": {},
+            "organization": "multi",
+            "runnable_hash": null,
+            "environment": null
+        },
+        "mime_types": [
+            {
+            "value": "openkat/report-data"
+        }
+        ]
+    },
+    "normalizer": {
+        "id": "kat_report_data"
+    }
+}

--- a/boefjes/tests/examples/report-data.json
+++ b/boefjes/tests/examples/report-data.json
@@ -1,0 +1,119 @@
+{
+  "organization_code": "test",
+  "organization_name": "Test",
+  "organization_tags": ["tag1", "tag2"],
+  "data": {
+    "report_data": {
+      "IPAddressV4|internet|192.0.2.0": {
+        "systems-report": {
+          "input_ooi": "IPAddressV4|internet|192.0.2.0",
+          "services": {
+            "IPAddressV4|internet|192.0.2.0": {
+              "hostnames": [
+                "Hostname|internet|example.com"
+              ],
+              "services": [
+                "Other",
+                "Web"
+              ]
+            }
+          },
+          "summary": {
+            "total_systems": 1,
+            "total_domains": 1
+          }
+        }
+      }
+    },
+    "post_processed_data": {
+      "systems": {
+        "services": {
+          "IPAddressV4|internet|192.0.2.0": {
+            "hostnames": [
+              "Hostname|internet|example.com"
+            ],
+            "services": [
+              "Other",
+              "Web"
+            ]
+          }
+        }
+      },
+      "services": {
+        "Other": {
+          "IPAddressV4|internet|192.0.2.0": {
+            "hostnames": [
+              "Hostname|internet|example.com"
+            ],
+            "services": [
+              "Other",
+              "Web"
+            ]
+          }
+        },
+        "Web": {
+          "IPAddressV4|internet|192.0.2.0": {
+            "hostnames": [
+              "Hostname|internet|example.com"
+            ],
+            "services": [
+              "Other",
+              "Web"
+            ]
+          }
+        }
+      },
+      "open_ports": {},
+      "ipv6": {},
+      "vulnerabilities": {},
+      "basic_security": {
+        "rpki": {},
+        "system_specific": {
+          "Mail": [],
+          "Web": [],
+          "DNS": []
+        },
+        "safe_connections": {},
+        "summary": {
+          "Other": {
+            "rpki": {
+              "number_of_compliant": 0,
+              "total": 0
+            },
+            "system_specific": {
+              "number_of_compliant": 0,
+              "total": 0
+            },
+            "safe_connections": {
+              "number_of_compliant": 0,
+              "total": 0
+            }
+          },
+          "Web": {
+            "rpki": {
+              "number_of_compliant": 0,
+              "total": 0
+            },
+            "system_specific": {
+              "number_of_compliant": 0,
+              "total": 0
+            },
+            "safe_connections": {
+              "number_of_compliant": 0,
+              "total": 0
+            }
+          }
+        }
+      },
+      "summary": {
+        "Critical vulnerabilities": 0,
+        "IPs scanned": 1,
+        "Hostnames scanned": 1,
+        "Terms in report": ""
+      },
+      "total_findings": 0,
+      "total_systems": 1,
+      "total_systems_basic_security": 0
+    }
+  }
+}

--- a/boefjes/tests/test_report_data.py
+++ b/boefjes/tests/test_report_data.py
@@ -1,0 +1,29 @@
+import json
+from pathlib import Path
+
+from boefjes.job_models import NormalizerDeclaration, NormalizerMeta
+from boefjes.katalogus.local_repository import LocalPluginRepository
+from boefjes.local import LocalNormalizerJobRunner
+from tests.loading import get_dummy_data
+
+
+def test_report_data():
+    local_repository = LocalPluginRepository(Path(__file__).parent.parent / "boefjes" / "plugins")
+    runner = LocalNormalizerJobRunner(local_repository)
+    meta = NormalizerMeta.model_validate_json(get_dummy_data("report-data-normalize.json"))
+
+    raw = get_dummy_data("report-data.json")
+    output = runner.run(meta, raw)
+    ooi_dict = json.loads(raw)
+
+    declaration = NormalizerDeclaration(
+        ooi={
+            "object_type": "ReportData",
+            "scan_profile": None,
+            "primary_key": "ReportData|test",
+            **ooi_dict,
+        }
+    )
+
+    assert output.observations == []
+    assert output.declarations == [declaration]

--- a/octopoes/octopoes/models/ooi/reports.py
+++ b/octopoes/octopoes/models/ooi/reports.py
@@ -1,0 +1,17 @@
+from typing import Dict, List, Literal
+
+from octopoes.models import OOI, Reference
+
+
+class ReportData(OOI):
+    object_type: Literal["ReportData"] = "ReportData"
+    organization_code: str
+    organization_name: str
+    organization_tags: List[str]
+    data: Dict
+
+    _natural_key_attrs = ["organization_code"]
+
+    @classmethod
+    def format_reference_human_readable(cls, reference: Reference) -> str:
+        return f"Report data of organization {reference.tokenized.organization_code}"

--- a/octopoes/octopoes/models/types.py
+++ b/octopoes/octopoes/models/types.py
@@ -56,6 +56,7 @@ from octopoes.models.ooi.network import (
     Network,
 )
 from octopoes.models.ooi.question import Question
+from octopoes.models.ooi.reports import ReportData
 from octopoes.models.ooi.service import IPService, Service, TLSCipher
 from octopoes.models.ooi.software import Software, SoftwareInstance
 from octopoes.models.ooi.web import (
@@ -142,6 +143,7 @@ EmailSecurityType = Union[
 ]
 MonitoringType = Union[Application, Incident]
 ConfigType = Union[Config]
+ReportsType = Union[ReportData]
 
 OOIType = Union[
     CertificateType,
@@ -162,6 +164,7 @@ OOIType = Union[
     FindingTypeType,
     ConfigType,
     Question,
+    ReportsType,
 ]
 
 

--- a/rocky/reports/report_types/aggregate_organisation_report/introduction.html
+++ b/rocky/reports/report_types/aggregate_organisation_report/introduction.html
@@ -4,20 +4,27 @@
     <div>
         <div class="horizontal-view toolbar">
             <h1>{% translate "OpenKAT Aggregate Report" %}</h1>
-        <a href="{{ report_download_url }}"
-           target="_blank"
-           rel="noopener noreferrer"
-           class="button">{% translate "Download report" %} <span class="icon ti-chevron-down">Chevron down icoon</span>
-    </a>
-</div>
-<div>
-    <p>{% translate "This is the OpenKAT report for organization" %} {{ organization.name }}</p>
-    <p>
-        {% translate "Observed at:" %} <strong>{{ observed_at }} {{ TIME_ZONE }}</strong>
-    </p>
-    <p>
-        {% translate "Created by:" %} <strong>{{ organization_member.user.full_name }}</strong>
-    </p>
-</div>
-</div>
+            <a href="{{ report_download_pdf_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="button">
+                {% translate "Download PDF" %} <span class="icon ti-chevron-down">Chevron down icoon</span>
+            </a>
+            <a href="{{ report_download_json_url }}"
+               target="_blank"
+               rel="noopener noreferrer"
+               class="button">
+                {% translate "Download JSON" %} <span class="icon ti-chevron-down">Chevron down icoon</span>
+            </a>
+        </div>
+        <div>
+            <p>{% translate "This is the OpenKAT report for organization" %} {{ organization.name }}</p>
+            <p>
+                {% translate "Observed at:" %} <strong>{{ observed_at }} {{ TIME_ZONE }}</strong>
+            </p>
+            <p>
+                {% translate "Created by:" %} <strong>{{ organization_member.user.full_name }}</strong>
+            </p>
+        </div>
+    </div>
 </section>

--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -143,7 +143,8 @@ class AggregateOrganisationReport(AggregateReport):
         for ip, compliance in rpki["rpki_ips"].items():
             ip_services = systems["services"][str(ip)]["services"]
 
-            for service in ip_services:
+            for service in services:
+                service = str(service)
                 if service not in basic_security["rpki"]:  # Set initial value
                     basic_security["rpki"][service] = {
                         "rpki_ips": {},
@@ -338,16 +339,16 @@ class AggregateOrganisationReport(AggregateReport):
 
         summary = {
             # _("General recommendations"): "",
-            _("Critical vulnerabilities"): total_criticals,
-            _("IPs scanned"): total_ips,
-            _("Hostnames scanned"): total_hostnames,
+            str(_("Critical vulnerabilities")): total_criticals,
+            str(_("IPs scanned")): total_ips,
+            str(_("Hostnames scanned")): total_hostnames,
             # _("Systems found"): total_systems,
             # _("Sector of organisation"): "",
             # _("Basic security score compared to sector"): "",
             # _("Sector defined"): "",
             # _("Lowest security score in organisation"): "",
             # _("Newly discovered items since last week, october 8th 2023"): "",
-            _("Terms in report"): ", ".join(sorted(terms)),
+            str(_("Terms in report")): ", ".join(sorted(terms)),
         }
 
         all_findings = set()

--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -112,10 +112,10 @@ class VulnerabilityReport(Report):
                         evidence = origins[0].task_id if origins else "-"
 
                         filtered_findings[finding.primary_key] = {
-                            _("Source"): sources,
-                            _("First seen"): first_seen,
-                            _("Last seen"): last_seen,
-                            _("Evidence"): evidence,
+                            str(_("Source")): sources,
+                            str(_("First seen")): first_seen,
+                            str(_("Last seen")): last_seen,
+                            str(_("Evidence")): evidence,
                         }
 
                 vulnerabilities[finding_type.id] = {

--- a/rocky/reports/urls.py
+++ b/rocky/reports/urls.py
@@ -46,5 +46,5 @@ urlpatterns += [
     ),
     path("aggregate-report/setup-scan/", SetupScanAggregateReportView.as_view(), name="aggregate_report_setup_scan"),
     path("aggregate-report/view/", AggregateReportView.as_view(), name="aggregate_report_view"),
-    path("aggregate-report/view/pdf", AggregateReportPDFView.as_view(), name="aggregate_report_pdf"),
+    path("aggregate-report/view/pdf/", AggregateReportPDFView.as_view(), name="aggregate_report_pdf"),
 ]

--- a/rocky/reports/utils.py
+++ b/rocky/reports/utils.py
@@ -1,0 +1,27 @@
+import dataclasses
+import logging
+from typing import Dict, List
+
+from django.core.serializers.json import DjangoJSONEncoder
+
+from octopoes.models import OOI
+
+logger = logging.getLogger(__name__)
+
+
+def debug_json_keys(data: Dict, path: List) -> None:
+    for key, value in data.items():
+        if not isinstance(key, (str, int)):
+            logger.error("Key %s is type %s, path is %s", key, type(key), path)
+        if isinstance(value, dict):
+            debug_json_keys(value, path + [key])
+
+
+class JSONEncoder(DjangoJSONEncoder):
+    def default(self, o):
+        if isinstance(o, OOI):
+            return str(o)
+        elif dataclasses.is_dataclass(o):
+            return dataclasses.asdict(o)
+        else:
+            return super().default(o)

--- a/rocky/reports/views/aggregate_report.py
+++ b/rocky/reports/views/aggregate_report.py
@@ -1,7 +1,8 @@
 from typing import Any, Dict, Tuple
 
+from django.conf import settings
 from django.contrib import messages
-from django.http import HttpRequest, HttpResponse
+from django.http import HttpRequest, HttpResponse, JsonResponse
 from django.shortcuts import redirect
 from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
@@ -16,6 +17,7 @@ from reports.report_types.helpers import (
     get_plugins_for_report_ids,
     get_report_types_from_aggregate_report,
 )
+from reports.utils import JSONEncoder, debug_json_keys
 from reports.views.base import (
     BaseReportView,
     ReportBreadcrumbs,
@@ -134,6 +136,35 @@ class AggregateReportView(BreadcrumbsAggregateReportView, BaseReportView, Templa
     template_name = "aggregate_report.html"
     current_step = 6
 
+    def get(self, request, *args, **kwargs):
+        if "json" in self.request.GET and self.request.GET["json"] == "true":
+            template, post_processed_data, report_data = self.generate_reports_for_oois()
+
+            response = {
+                "organization_code": self.organization.code,
+                "organization_name": self.organization.name,
+                "organization_tags": list(self.organization.tags.all()),
+                "data": {
+                    "report_data": report_data,
+                    "post_processed_data": post_processed_data,
+                },
+            }
+
+            try:
+                response = JsonResponse(response, encoder=JSONEncoder)
+            except TypeError:
+                # We can't use translated strings as keys in JSON. This
+                # debugging code makes it easy to spot where the problem is.
+                if settings.DEBUG:
+                    debug_json_keys(report_data, [])
+                    debug_json_keys(post_processed_data, [])
+                raise
+            else:
+                response["Content-Disposition"] = f"attachment; filename=report-{self.organization.code}.json"
+                return response
+
+        return super().get(request, *args, **kwargs)
+
     def generate_reports_for_oois(self) -> Tuple[Any, Any, Dict[Any, Dict[Any, Any]]]:
         report_data = {}
         aggregate_report = AggregateOrganisationReport(self.octopoes_api_connector)
@@ -159,10 +190,15 @@ class AggregateReportView(BreadcrumbsAggregateReportView, BaseReportView, Templa
         context["template"] = template
         context["post_processed_data"] = post_processed_data
         context["report_data"] = report_data
-        context["report_download_url"] = url_with_querystring(
+        context["report_download_pdf_url"] = url_with_querystring(
             reverse("aggregate_report_pdf", kwargs={"organization_code": self.organization.code}),
             True,
             **self.request.GET,
+        )
+        context["report_download_json_url"] = url_with_querystring(
+            reverse("aggregate_report_view", kwargs={"organization_code": self.organization.code}),
+            True,
+            **dict(json="true", **self.request.GET),
         )
         return context
 

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-12-19 13:30+0000\n"
+"POT-Creation-Date: 2023-12-22 13:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2756,8 +2756,13 @@ msgid "OpenKAT Aggregate Report"
 msgstr ""
 
 #: reports/report_types/aggregate_organisation_report/introduction.html
-#: reports/templates/generate_report.html
-msgid "Download report"
+#: rocky/templates/oois/ooi_report.html
+#: rocky/templates/partials/findings_list_toolbar.html
+msgid "Download PDF"
+msgstr ""
+
+#: reports/report_types/aggregate_organisation_report/introduction.html
+msgid "Download JSON"
 msgstr ""
 
 #: reports/report_types/aggregate_organisation_report/introduction.html
@@ -3379,6 +3384,10 @@ msgstr ""
 
 #: reports/report_types/web_system_report/report.py
 msgid "Web system reports check web systems on basic security standards."
+msgstr ""
+
+#: reports/templates/generate_report.html
+msgid "Download report"
 msgstr ""
 
 #: reports/templates/generate_report.html
@@ -4851,11 +4860,6 @@ msgstr ""
 msgid ""
 "You will not be able to add Findings or other OOI's, this object has been "
 "deleted and is no longer available."
-msgstr ""
-
-#: rocky/templates/oois/ooi_report.html
-#: rocky/templates/partials/findings_list_toolbar.html
-msgid "Download PDF"
 msgstr ""
 
 #: rocky/templates/oois/ooi_report.html


### PR DESCRIPTION
### Changes
This adds the functionality to download the report data as JSON. The Download JSON button is quick&dirty copy of the Download PDF button and will probably need some UX improvement.

It also adds a ReportData OOI and normalizer so we can upload the JSON as raw file with type `openkat/report-data`. 

The `str()` calls are necessary because the JSON encoder wants strings as keys and not the translation proxy objects.

Closes #1970

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
