### PR TITLE
Fixed invalid type usage in `get_rabbit_channel` and `close_rabbit_channel`

### DIFF
--- a/octopoes/octopoes/tasks/tasks.py
+++ b/octopoes/octopoes/tasks/tasks.py
@@ -32,13 +32,13 @@ except FileNotFoundError:
 
 @worker_process_shutdown.connect
 def shutdown_worker(**kwargs):
-    close_rabbit_channel(settings.queue_uri)
+    close_rabbit_channel(str(settings.queue_uri))
 
 
 @worker_process_init.connect
 def init_worker(**kwargs):
     """Set up one RabbitMQ connection and channel on worker startup"""
-    get_rabbit_channel(settings.queue_uri)
+    get_rabbit_channel(str(settings.queue_uri))
 
 
 log = get_task_logger(__name__)


### PR DESCRIPTION
### Changes
This fixes invalid type usage in `get_rabbit_channel` and `close_rabbit_channel` calls.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
