### PR TITLE
Fix multiple Debian issues

### DIFF
--- a/boefjes/Makefile
+++ b/boefjes/Makefile
@@ -111,8 +111,8 @@ ubuntu22.04:
 clean:
 	rm -rf build
 	rm -rf debian/kat-*/ debian/.debhelper debian/files *.egg-info/ dist/
-	rm debian/debhelper-build-stamp
-	rm debian/*.*.debhelper
-	rm debian/*.substvars
-	rm debian/*.debhelper.log
-	rm debian/changelog
+	rm -f debian/debhelper-build-stamp
+	rm -f debian/*.*.debhelper
+	rm -f debian/*.substvars
+	rm -f debian/*.debhelper.log
+	rm -f debian/changelog

--- a/boefjes/boefjes/api.py
+++ b/boefjes/boefjes/api.py
@@ -42,7 +42,7 @@ class UvicornServer(multiprocessing.Process):
 
 
 def run():
-    config = Config(app, host=settings.boefje_api_host, port=settings.boefje_api_port)
+    config = Config(app, host=settings.api_host, port=settings.api_port)
     instance = UvicornServer(config=config)
     instance.start()
     return instance
@@ -101,7 +101,7 @@ async def boefje_input(
 
     boefje_meta = create_boefje_meta(task, local_repository)
 
-    output_url = str(settings.boefje_api).rstrip("/") + f"/api/v0/tasks/{task_id}"
+    output_url = str(settings.api).rstrip("/") + f"/api/v0/tasks/{task_id}"
     return BoefjeInput(task_id=task_id, output_url=output_url, boefje_meta=boefje_meta)
 
 

--- a/boefjes/boefjes/config.py
+++ b/boefjes/boefjes/config.py
@@ -16,6 +16,10 @@ if os.getenv("DOCS"):
 
 class BackwardsCompatibleEnvSettings(EnvSettingsSource):
     backwards_compatibility_mapping = {
+        "BOEFJES_BOEFJE_API_HOST": "BOEFJES_API_HOST",
+        "BOEFJES_BOEFJE_API_PORT": "BOEFJES_API_PORT",
+        "BOEFJE_API": "BOEFJES_API",
+        "BOEFJE_DOCKER_NETWORK": "BOEFJES_DOCKER_NETWORK",
         "LOG_CFG": "BOEFJES_LOG_CFG",
     }
 
@@ -67,22 +71,23 @@ class Settings(BaseSettings):
     octopoes_api: AnyHttpUrl = Field(
         ..., examples=["http://localhost:8001"], description="Octopoes API URL", validation_alias="OCTOPOES_API"
     )
-    boefje_api: AnyHttpUrl = Field(
-        ..., examples=["http://boefje:8000"], description="Boefje API URL", validation_alias="BOEFJE_API"
+    api: AnyHttpUrl = Field(
+        ...,
+        examples=["http://boefje:8000"],
+        description="The URL on which the boefjes API is available",
     )
     # Boefje server settings
-    boefje_api_host: str = Field(
+    api_host: str = Field(
         "0.0.0.0",
         description="Host address of the Boefje API server",
     )
-    boefje_api_port: int = Field(
+    api_port: int = Field(
         8000,
         description="Host port of the Boefje API server",
     )
-    boefje_docker_network: str = Field(
+    docker_network: str = Field(
         "bridge",
         description="Docker network to run Boefjes in",
-        env="BOEFJE_DOCKER_NETWORK",
     )
     bytes_api: AnyHttpUrl = Field(
         ..., examples=["http://localhost:8002"], description="Bytes API URL", validation_alias="BYTES_API"

--- a/boefjes/boefjes/docker_boefjes_runner.py
+++ b/boefjes/boefjes/docker_boefjes_runner.py
@@ -40,7 +40,7 @@ class DockerBoefjesRunner:
         self.boefje_meta.started_at = datetime.now(timezone.utc)
 
         try:
-            input_url = settings.boefje_api + "/api/v0/tasks/" + task_id
+            input_url = str(settings.api).rstrip("/") + f"/api/v0/tasks/{task_id}"
             container_logs = self.docker_client.containers.run(
                 image=self.boefje_resource.oci_image,
                 name="kat_boefje_" + task_id,
@@ -48,7 +48,7 @@ class DockerBoefjesRunner:
                 stdout=False,
                 stderr=True,
                 remove=True,
-                network=settings.boefje_docker_network,
+                network=settings.docker_network,
             )
 
             # save container log (stderr) to bytes

--- a/boefjes/packaging/deb/data/usr/lib/kat/boefjes.defaults
+++ b/boefjes/packaging/deb/data/usr/lib/kat/boefjes.defaults
@@ -1,6 +1,6 @@
-BOEFJE_API_HOST=localhost
-BOEFJE_API_PORT=8006
-BOEFJE_API=http://localhost:8006
+BOEFJES_API_HOST=localhost
+BOEFJES_API_PORT=8006
+BOEFJES_API=http://localhost:8006
 OCTOPOES_API=http://localhost:8001
 BYTES_API=http://localhost:8002
 KATALOGUS_API=http://localhost:8003

--- a/docs/source/release_notes/1.14.rst
+++ b/docs/source/release_notes/1.14.rst
@@ -56,6 +56,14 @@ Upgrading
 The normal instructions for upgrading :ref:`Debian packages<Upgrading Debian>`
 or upgrading :ref:`containers <Upgrading_Containers>` should be followed.
 
+Debian packages
+---------------
+
+Because of the switch to Granian, we can't listen on both 8000 and 8443 anymore,
+and we will default listen only on port 8000 on 127.0.0.1. If you were
+previously accessing OpenKAT using https on port 8443 you need to change the
+configuration as described on the :ref:`Debian installation page<Configure
+reverse proxy>`.
 
 Full Changelog
 ==============

--- a/rocky/debian/control
+++ b/rocky/debian/control
@@ -7,6 +7,6 @@ Section: python
 Priority: optional
 Architecture: any
 Pre-Depends: ${misc:Pre-Depends}
-Depends: ${python}, openssl, ${misc:Depends}, ${shlibs:Depends}
+Depends: ${python}, openssl, ${misc:Depends}, ${shlibs:Depends}, libpango-1.0-0, libpangoft2-1.0-0
 Description: Rocky web interface for KAT
   This is the web interface component of the KAT project.


### PR DESCRIPTION
### Changes
Fix naming of boefje env vars. The Debian package used `BOEFJE_API_PORT` and `BOEFJES_API_HOST`, but that didn't work because it was missing the `BOEFJES_` prefix. I've renamed the config settings so it `BOEFJES_API_PORT` and `BOEFJES_API_HOST` now. I also changed `BOEFJE_API` to `BOEFJES_API` for consistency. Backwards compatibility for the env vars have been added.

Missing rocky dependencies in Debian package for weasyprint have been added.

Add a note to the 1.14 release notes that the Debian packages don't listen on port 8443 by default anymore.

Add missing -f to rm in boefjes clean Makefile target.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
