### PR TITLE
Remove preselection from multireport flow

### DIFF
--- a/rocky/reports/views/multi_report.py
+++ b/rocky/reports/views/multi_report.py
@@ -53,7 +53,7 @@ class LandingMultiReportView(BreadcrumbsMultiReportView, TemplateView):
     """
 
     def get(self, request: HttpRequest, *args: Any, **kwargs: Any) -> HttpResponse:
-        return redirect(reverse("multi_report_select_oois", kwargs=self.get_kwargs()) + self.get_selection())
+        return redirect(reverse("multi_report_select_oois", kwargs=self.get_kwargs()))
 
 
 class OOISelectionMultiReportView(BreadcrumbsMultiReportView, BaseReportView, BaseOOIListView):


### PR DESCRIPTION
### Changes
Muktireport flow had a preselect on declared levels higher than L1, but ReportData OOIs usually are not cleared.

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified;
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
