### PR TITLE
Add max fds ulimit to octopoes api worker

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,6 +81,10 @@ services:
       - .env
     volumes:
       - ./octopoes:/app/octopoes
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
 
   boefje:
     restart: unless-stopped


### PR DESCRIPTION
### Changes
Mitigates #2171 caused by upstream issue (in celery/billiard) by imposing ulimits on octopoes-worker for maximum number of file descriptors (fd). See https://github.com/celery/billiard/issues/399 for more information.
In this patch I set the restrictions to `2^18` fd's, I imagine that should be more than plenty but perhaps it is worth some QA testing.

@underdarknl thanks for your help!

### Issue link
#2171

### Demo
Not sure how... but I don't have to wait ~10 minutes anymore to aggregate permissions.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified;
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
