### PR TITLE
Render dicts and list ooi attrs as jsonfield

### DIFF
--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -1,7 +1,7 @@
 from enum import Enum
 from inspect import isclass
 from ipaddress import IPv4Address, IPv6Address
-from typing import Dict, Literal, Optional, Type, Union, cast, get_args, get_origin
+from typing import Dict, List, Literal, Optional, Type, Union, cast, get_args, get_origin
 
 from django import forms
 from django.utils.translation import gettext_lazy as _
@@ -63,6 +63,8 @@ class OOIForm(BaseRockyForm):
                 fields[name] = generate_ip_field(field)
             elif annotation == AnyUrl:
                 fields[name] = generate_url_field(field)
+            elif annotation == Dict or annotation == List[str]:
+                fields[name] = forms.JSONField(**default_attrs)
             elif annotation == int or (hasattr(annotation, "__args__") and int in annotation.__args__):
                 fields[name] = forms.IntegerField(**default_attrs)
             elif isclass(annotation) and issubclass(annotation, Enum):

--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -63,7 +63,7 @@ class OOIForm(BaseRockyForm):
                 fields[name] = generate_ip_field(field)
             elif annotation == AnyUrl:
                 fields[name] = generate_url_field(field)
-            elif annotation == Dict or annotation == List[str]:
+            elif annotation == Dict or annotation == Dict[str, str] or annotation == List[str]:
                 fields[name] = forms.JSONField(**default_attrs)
             elif annotation == int or (hasattr(annotation, "__args__") and int in annotation.__args__):
                 fields[name] = forms.IntegerField(**default_attrs)


### PR DESCRIPTION
### Changes
Multiple OOIs could not be added since Dict and List attributes did not render fields in OOI add.

### Issue link
_Please add a link to the issue after "Closes". If there is no issue for this PR, please add it to the project board directly._

Closes: https://github.com/minvws/nl-kat-coordination/issues/2339 

### Demo
<img width="1183" alt="image" src="https://github.com/minvws/nl-kat-coordination/assets/43830693/b8c0df05-4146-4f39-8b68-02deabed4bc8">


---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
