### PR TITLE
Fix WEASYPRINT_BASEURL default value and change ports in docker-compose.yml (1.14)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,14 +134,14 @@ services:
     depends_on:
       - postgres
     ports:
-      - "127.0.0.1:8000:80"
+      - "127.0.0.1:8000:8000"
     build:
       context: .
       dockerfile: rocky/Dockerfile
       target: dev
       args:
         ENVIRONMENT: dev
-    command: python3 manage.py runserver 0.0.0.0:80
+    command: python3 manage.py runserver 0.0.0.0:8000
     volumes:
       - ./rocky:/app/rocky
       - ./octopoes/octopoes:/app/rocky/octopoes

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -459,4 +459,4 @@ TAG_BORDER_TYPES = [
     ("dotted", _("Dotted")),
 ]
 
-WEASYPRINT_BASEURL = env("WEASYPRINT_BASEURL", default="http://127.0.0.1:80/")
+WEASYPRINT_BASEURL = env("WEASYPRINT_BASEURL", default="http://127.0.0.1:8000/")


### PR DESCRIPTION
Backport of #2373 to release 1.14