### PR TITLE
Update RabbitMQ to the latest version

### DIFF
--- a/bytes/.ci/docker-compose.yml
+++ b/bytes/.ci/docker-compose.yml
@@ -45,7 +45,7 @@ services:
       - .ci/.env.test
 
   ci_rabbitmq:
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     volumes:
       - ./.ci/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     healthcheck:

--- a/docker-compose.release-example.yml
+++ b/docker-compose.release-example.yml
@@ -6,7 +6,7 @@ version: "3.9"
 services:
   rabbitmq:
     restart: on-failure
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3.9"
 services:
   rabbitmq:
     restart: unless-stopped
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     ports:
       - "127.0.0.1:5672:5672"
       - "127.0.0.1:15672:15672"

--- a/mula/.ci/docker-compose.yml
+++ b/mula/.ci/docker-compose.yml
@@ -43,7 +43,7 @@ services:
       - ../init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh
 
   ci_rabbitmq:
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     volumes:
       - ./.ci/rabbitmq.conf:/etc/rabbitmq/rabbitmq.conf
     healthcheck:

--- a/octopoes/.ci/docker-compose.yml
+++ b/octopoes/.ci/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   rabbitmq:
     restart: on-failure
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     ports:
       - "127.0.0.1:29003:15672"
       - "127.0.0.1:29004:5672"

--- a/rocky/.ci/docker-compose.yml
+++ b/rocky/.ci/docker-compose.yml
@@ -58,7 +58,7 @@ services:
 
   rabbitmq:
     restart: on-failure
-    image: "rabbitmq:3.11-management"
+    image: "rabbitmq:3.12-management"
     healthcheck:
       test: [ "CMD", "rabbitmqctl", "status" ]
       interval: 5s


### PR DESCRIPTION
### Changes
RabbitMQ 3.11 is out of support, 3.12 is the current version, this PR upgrades RabbitMQ to 3.12.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
