### PR TITLE
Use --diff-filter=U instead of --staged in fix-poetry-merge-conflict

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ poetry-dependencies:
 	done
 
 fix-poetry-merge-conflict:
-	for path in `git diff --staged --name-only | grep "pyproject.toml" | cut -d / -f 1`; do \
+	for path in `git diff --diff-filter=U --name-only | grep "poetry.lock" | cut -d / -f 1`; do \
 		echo $$path; \
 		git restore --staged $$path/poetry.lock $$path/requirements*; \
 		git checkout --theirs $$path/poetry.lock $$path/requirements*; \


### PR DESCRIPTION
### Changes
The `--staged` option will list all files with changes in the merge, but we only want to have the ones with a merge conflict, so should use `--diff-filter=U` for that. The pyproject.toml file also isn't the one with the conflict so we should filter on poetry.lock.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
