### PR TITLE
Fix normalizer filtering on tasks endpoint

### DIFF
--- a/mula/scheduler/server/server.py
+++ b/mula/scheduler/server/server.py
@@ -360,7 +360,7 @@ class Server:
             elif task_type == "normalizer":
                 f_plugin = storage.filters.Filter(
                     column="p_item",
-                    field="data__raw_data__boefje_meta__id",
+                    field="data__normalizer__id",
                     operator="eq",
                     value=plugin_id,
                 )
@@ -375,7 +375,7 @@ class Server:
                         ),
                         storage.filters.Filter(
                             column="p_item",
-                            field="data__raw_data__boefje_meta__id",
+                            field="data__normalizer__id",
                             operator="eq",
                             value=plugin_id,
                         ),


### PR DESCRIPTION
### Changes

The wrong path was specified when filtering on the `plugin_id` for normalizers. Before this fix the task list on the normalizer detail page would be empty, now it should show the correct tasks for the normalizer.