### PR TITLE
Fix usage of `SPAN_EXPORT_GRPC_ENDPOINT` variable

### DIFF
--- a/boefjes/boefjes/katalogus/api.py
+++ b/boefjes/boefjes/katalogus/api.py
@@ -35,7 +35,7 @@ if settings.span_export_grpc_endpoint is not None:
 
     resource = Resource(attributes={SERVICE_NAME: "katalogus"})
     provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.span_export_grpc_endpoint))
+    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=str(settings.span_export_grpc_endpoint)))
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
 

--- a/bytes/bytes/api/__init__.py
+++ b/bytes/bytes/api/__init__.py
@@ -32,7 +32,7 @@ if get_settings().span_export_grpc_endpoint is not None:
 
     resource = Resource(attributes={SERVICE_NAME: "bytes"})
     provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=get_settings().span_export_grpc_endpoint))
+    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=str(get_settings().span_export_grpc_endpoint)))
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
 

--- a/keiko/keiko/api.py
+++ b/keiko/keiko/api.py
@@ -35,7 +35,7 @@ def construct_api(settings: Settings) -> FastAPI:
 
         resource = Resource(attributes={SERVICE_NAME: "keiko"})
         provider = TracerProvider(resource=resource)
-        processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.span_export_grpc_endpoint))
+        processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=str(settings.span_export_grpc_endpoint)))
         provider.add_span_processor(processor)
         trace.set_tracer_provider(provider)
 

--- a/octopoes/octopoes/api/api.py
+++ b/octopoes/octopoes/api/api.py
@@ -49,7 +49,7 @@ if settings.span_export_grpc_endpoint is not None:
 
     resource = Resource(attributes={SERVICE_NAME: "octopoes"})
     provider = TracerProvider(resource=resource)
-    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=settings.span_export_grpc_endpoint))
+    processor = BatchSpanProcessor(OTLPSpanExporter(endpoint=str(settings.span_export_grpc_endpoint)))
     provider.add_span_processor(processor)
     trace.set_tracer_provider(provider)
 


### PR DESCRIPTION
### Changes

In some instances of `OTLPSpanExporter` instantiation, a type other than 'str' was passed, leading to a type error when setting up the services with the available `SPAN_EXPORT_GRPC_ENDPOINT` variable.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
