### PR TITLE
Fix mail report json

### DIFF
--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -6,6 +6,7 @@ from django.utils.translation import gettext_lazy as _
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import Reference
+from octopoes.models.exception import ObjectNotFoundException
 from octopoes.models.ooi.config import Config
 from reports.report_types.definitions import AggregateReport, ReportType
 from reports.report_types.ipv6_report.report import IPv6Report
@@ -460,7 +461,8 @@ def aggregate_reports(
                         report = report_type(connector)
                         data = report.generate_data(ooi, valid_time=valid_time)
                         report_data[ooi][report_type.id] = data
-        except Exception:
+        except ObjectNotFoundException:
+            logger.error("Object not found: %s", ooi)
             error_oois.append(ooi)
     post_processed_data = aggregate_report.post_process_data(report_data, valid_time=valid_time)
 

--- a/rocky/reports/report_types/mail_report/report.py
+++ b/rocky/reports/report_types/mail_report/report.py
@@ -49,17 +49,29 @@ class MailReport(Report):
         number_of_dkim = number_of_hostnames
 
         for hostname in hostnames:
-            measures = self._get_measures(valid_time, hostname)
-            mail_security_measures[hostname] = measures
+            measures = self._get_measures(valid_time, hostname.reference)
+            mail_security_measures[hostname.primary_key] = measures
 
             number_of_spf -= (
-                1 if list(filter(lambda finding: finding.id == "KAT-NO-SPF", mail_security_measures[hostname])) else 0
+                1
+                if list(
+                    filter(lambda finding: finding.id == "KAT-NO-SPF", mail_security_measures[hostname.primary_key])
+                )
+                else 0
             )
             number_of_dmarc -= (
-                1 if list(filter(lambda finding: finding.id == "KAT-NO-DMARC", mail_security_measures[hostname])) else 0
+                1
+                if list(
+                    filter(lambda finding: finding.id == "KAT-NO-DMARC", mail_security_measures[hostname.primary_key])
+                )
+                else 0
             )
             number_of_dkim -= (
-                1 if list(filter(lambda finding: finding.id == "KAT-NO-DKIM", mail_security_measures[hostname])) else 0
+                1
+                if list(
+                    filter(lambda finding: finding.id == "KAT-NO-DKIM", mail_security_measures[hostname.primary_key])
+                )
+                else 0
             )
 
         return {


### PR DESCRIPTION
### Changes
We caught all Exceptions in report, therefore we could not see the real exception in the mail report which caused the "No data" bug. Now we only catch ObjectNotFoundExceptions. Also I have included two bug fixes in the mail report itself:

1. Previously it always showed compliance
2. It was not json serializable


### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
