### PR TITLE
use oois instead of references

### DIFF
--- a/rocky/reports/report_types/mail_report/report.py
+++ b/rocky/reports/report_types/mail_report/report.py
@@ -36,12 +36,9 @@ class MailReport(Report):
         if ooi.reference.class_type == Hostname:
             hostnames = [ooi]
         elif ooi.reference.class_type in (IPAddressV4, IPAddressV6):
-            hostnames = [
-                x.reference
-                for x in self.octopoes_api_connector.query(
-                    "IPAddress.<address[is ResolvedHostname].hostname", valid_time, ooi.reference
-                )
-            ]
+            hostnames = self.octopoes_api_connector.query(
+                "IPAddress.<address[is ResolvedHostname].hostname", valid_time, ooi.reference
+            )
 
         number_of_hostnames = len(hostnames)
         number_of_spf = number_of_hostnames


### PR DESCRIPTION
### Changes
We used the references of references, now we use the reference of an OOI

### Demo
_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
