### PR TITLE
Ignore certificate errors in security txt boefje

### DIFF
--- a/boefjes/boefjes/plugins/kat_security_txt_downloader/main.py
+++ b/boefjes/boefjes/plugins/kat_security_txt_downloader/main.py
@@ -41,7 +41,7 @@ def run(boefje_meta: BoefjeMeta) -> List[Tuple[set, Union[bytes, str]]]:
         # we can not force the ip anymore
         elif response.status_code in [301, 302, 307, 308]:
             uri = response.headers["Location"]
-            response = requests.get(uri, stream=True, timeout=30)
+            response = requests.get(uri, stream=True, timeout=30, verify=False)  # noqa: S501
             ip = response.raw._connection.sock.getpeername()[0]
             results[path] = {
                 "content": response.content.decode(),


### PR DESCRIPTION
### Changes
In the security txt boefje the first get request correctly had `verify=False`, but if it returns a redirect we fetch the redirect target which didn't have `verify=False`. This causes the boefje to fail, this PR adds `verify=False` so we download security.txt even if there is a certificate error.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
