### PR TITLE
Rename list method to prevent conflict with builtin

### DIFF
--- a/docs/source/developer_documentation/octopoes.md
+++ b/docs/source/developer_documentation/octopoes.md
@@ -377,7 +377,7 @@ It provides several methods for doing CRUD operations for the objects/entities.
 
 In particular, for querying objects we have:
 
--  `OctopoesAPIConnector.list()` to filter on OOIs `type`, `scan_level`, `scan_profile_type` and `valid_time`.
+-  `OctopoesAPIConnector.list_objects()` to filter on OOIs `type`, `scan_level`, `scan_profile_type` and `valid_time`.
 
 This is used for example in the object overview page. Returns a paginated list of OOIs.
 
@@ -438,7 +438,7 @@ class TagExample(OOI):
 
 
 # Query abstract class
-OctopoesAPIConnector('http://octopoes', '_dev').list({IPAddress})
+OctopoesAPIConnector('http://octopoes', '_dev').list_objects({IPAddress})
 ```
 
 ## Querying

--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -250,7 +250,7 @@ def list_origins(
     task_id: Optional[uuid.UUID] = Query(None),
     origin_type: Optional[OriginType] = Query(None),
 ) -> List[Origin]:
-    return octopoes.origin_repository.list(
+    return octopoes.origin_repository.list_origins(
         valid_time,
         task_id=task_id,
         source=source,
@@ -307,7 +307,7 @@ def list_scan_profiles(
     valid_time: datetime = Depends(extract_valid_time),
     scan_profile_type: Optional[str] = Query(None),
 ) -> List[ScanProfileBase]:
-    return octopoes.scan_profile_repository.list(scan_profile_type, valid_time)
+    return octopoes.scan_profile_repository.list_scan_profiles(scan_profile_type, valid_time)
 
 
 @router.put("/scan_profiles", tags=["Scan Profiles"])

--- a/octopoes/octopoes/connector/octopoes.py
+++ b/octopoes/octopoes/connector/octopoes.py
@@ -88,7 +88,7 @@ class OctopoesAPIConnector:
     def health(self) -> ServiceHealth:
         return ServiceHealth.model_validate_json(self.session.get(f"/{self.client}/health").content)
 
-    def list(
+    def list_objects(
         self,
         types: Set[Type[OOI]],
         valid_time: Optional[datetime] = None,

--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -89,7 +89,7 @@ class OOIRepository(Repository):
     ) -> Dict[Path, List[OOI]]:
         raise NotImplementedError
 
-    def list(
+    def list_oois(
         self,
         types: Set[Type[OOI]],
         valid_time: datetime,
@@ -266,7 +266,7 @@ class XTDBOOIRepository(OOIRepository):
         oois = [self.deserialize(x[0]) for x in res]
         return {ooi.primary_key: ooi for ooi in oois}
 
-    def list(
+    def list_oois(
         self,
         types: Set[Type[OOI]],
         valid_time: datetime,

--- a/octopoes/octopoes/repositories/origin_repository.py
+++ b/octopoes/octopoes/repositories/origin_repository.py
@@ -30,7 +30,7 @@ class OriginRepository(Repository):
     def save(self, origin: Origin, valid_time: datetime) -> None:
         raise NotImplementedError
 
-    def list(
+    def list_origins(
         self,
         valid_time: datetime,
         *,
@@ -66,7 +66,7 @@ class XTDBOriginRepository(OriginRepository):
     def deserialize(cls, data: Dict[str, Any]) -> Origin:
         return Origin.parse_obj(data)
 
-    def list(
+    def list_orgins(
         self,
         valid_time: datetime,
         *,

--- a/octopoes/octopoes/repositories/origin_repository.py
+++ b/octopoes/octopoes/repositories/origin_repository.py
@@ -66,7 +66,7 @@ class XTDBOriginRepository(OriginRepository):
     def deserialize(cls, data: Dict[str, Any]) -> Origin:
         return Origin.parse_obj(data)
 
-    def list_orgins(
+    def list_origins(
         self,
         valid_time: datetime,
         *,

--- a/octopoes/octopoes/repositories/scan_profile_repository.py
+++ b/octopoes/octopoes/repositories/scan_profile_repository.py
@@ -35,7 +35,7 @@ class ScanProfileRepository(Repository):
     ) -> None:
         raise NotImplementedError
 
-    def list(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
+    def list_scan_profiles(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
         raise NotImplementedError
 
     def delete(self, scan_profile: ScanProfileBase, valid_time: datetime) -> None:
@@ -71,7 +71,7 @@ class XTDBScanProfileRepository(ScanProfileRepository):
     def deserialize(cls, data: Dict[str, Any]) -> ScanProfileBase:
         return parse_obj_as(ScanProfile, data)
 
-    def list(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
+    def list_scan_profiles(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
         where = {"type": self.object_type}
         if scan_profile_type is not None:
             where["scan_profile_type"] = scan_profile_type

--- a/octopoes/tests/conftest.py
+++ b/octopoes/tests/conftest.py
@@ -58,7 +58,7 @@ class MockScanProfileRepository(ScanProfileRepository):
     ) -> None:
         self.profiles[new_scan_profile.reference] = new_scan_profile
 
-    def list(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
+    def list_scan_profiles(self, scan_profile_type: Optional[str], valid_time: datetime) -> List[ScanProfileBase]:
         if scan_profile_type:
             return [profile for profile in self.profiles.values() if profile.scan_profile_type == scan_profile_type]
         else:

--- a/octopoes/tests/integration/test_api_connector.py
+++ b/octopoes/tests/integration/test_api_connector.py
@@ -45,9 +45,9 @@ def test_bulk_operations(octopoes_api_connector: OctopoesAPIConnector, valid_tim
         [DeclaredScanProfile(reference=ooi.reference, level=ScanLevel.L2) for ooi in hostnames + [network]], valid_time
     )
 
-    assert octopoes_api_connector.list(types={Network}).count == 1
-    assert octopoes_api_connector.list(types={Hostname}).count == 10
-    assert octopoes_api_connector.list(types={Network, Hostname}).count == 11
+    assert octopoes_api_connector.list_objects(types={Network}).count == 1
+    assert octopoes_api_connector.list_objects(types={Hostname}).count == 10
+    assert octopoes_api_connector.list_objects(types={Network, Hostname}).count == 11
 
     assert len(octopoes_api_connector.list_origins(task_id=uuid.uuid4())) == 0
     origins = octopoes_api_connector.list_origins(task_id=task_id)
@@ -64,7 +64,7 @@ def test_bulk_operations(octopoes_api_connector: OctopoesAPIConnector, valid_tim
 
     # Delete even-numbered test hostnames
     octopoes_api_connector.delete_many([Reference.from_str(f"Hostname|test|test{i}") for i in range(0, 10, 2)])
-    assert octopoes_api_connector.list(types={Network, Hostname}).count == 6
+    assert octopoes_api_connector.list_objects(types={Network, Hostname}).count == 6
 
 
 def test_history(octopoes_api_connector: OctopoesAPIConnector):

--- a/octopoes/tests/integration/test_ooi_repository.py
+++ b/octopoes/tests/integration/test_ooi_repository.py
@@ -14,9 +14,9 @@ if os.environ.get("CI") != "1":
 def test_list_oois(xtdb_ooi_repository: XTDBOOIRepository, valid_time: datetime):
     xtdb_ooi_repository.save(Network(name="test"), valid_time)
 
-    assert xtdb_ooi_repository.list({Network}, valid_time) == Paginated(count=0, items=[])
+    assert xtdb_ooi_repository.list_oois({Network}, valid_time) == Paginated(count=0, items=[])
 
     xtdb_ooi_repository.session.commit()
 
     # list() does not return any OOI without a scan profile
-    assert xtdb_ooi_repository.list({Network}, valid_time) == Paginated(count=0, items=[])
+    assert xtdb_ooi_repository.list_oois({Network}, valid_time) == Paginated(count=0, items=[])

--- a/octopoes/tests/test_octopoes_service.py
+++ b/octopoes/tests/test_octopoes_service.py
@@ -93,7 +93,7 @@ def test_on_update_origin(octopoes_service, valid_time):
     )
 
     # and the deferenced ooi is no longer referred to by any origins
-    octopoes_service.origin_repository.list.return_value = []
+    octopoes_service.origin_repository.list_origins.return_value = []
     octopoes_service.process_event(event)
 
     # the ooi should be deleted
@@ -105,7 +105,7 @@ def test_on_update_origin(octopoes_service, valid_time):
 @pytest.mark.parametrize("new_data", [EmptyScanProfile(reference="test_reference"), None])
 @pytest.mark.parametrize("old_data", [EmptyScanProfile(reference="test_reference"), None])
 def test_on_create_scan_profile(octopoes_service, new_data, old_data, bit_runner: MagicMock):
-    octopoes_service.origin_repository.list.return_value = [
+    octopoes_service.origin_repository.list_origins.return_value = [
         Origin(
             origin_type=OriginType.INFERENCE,
             method="check-csp-header",

--- a/rocky/katalogus/views/plugin_detail.py
+++ b/rocky/katalogus/views/plugin_detail.py
@@ -221,7 +221,7 @@ class BoefjeDetailView(BoefjeMixin, PluginDetailView):
 
     def get_form_consumable_oois(self):
         """Get all available OOIS that plugin can consume."""
-        return self.octopoes_api_connector.list(self.plugin.consumes, limit=self.limit_ooi_list).items
+        return self.octopoes_api_connector.list_objects(self.plugin.consumes, limit=self.limit_ooi_list).items
 
     def get_form_filtered_consumable_oois(self):
         """Return a list of oois that is filtered for oois that meets clearance level."""

--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -394,7 +394,7 @@ class AggregateOrganisationReport(AggregateReport):
                 for finding_key in vulnerability_data.get("findings", {}):
                     all_findings.add(finding_key)
 
-        config_oois = self.octopoes_api_connector.list(types={Config}, valid_time=valid_time).items
+        config_oois = self.octopoes_api_connector.list_objects(types={Config}, valid_time=valid_time).items
 
         flattened_health = flatten_health(get_rocky_health(self.octopoes_api_connector))
 

--- a/rocky/reports/views/base.py
+++ b/rocky/reports/views/base.py
@@ -88,7 +88,7 @@ class BaseReportView(OOIFilterView):
 
     def get_oois(self) -> List[OOI]:
         if "all" in self.selected_oois:
-            return self.octopoes_api_connector.list(
+            return self.octopoes_api_connector.list_objects(
                 self.get_ooi_types(),
                 valid_time=self.valid_time,
                 limit=OOIList.HARD_LIMIT,

--- a/rocky/rocky/views/finding_add.py
+++ b/rocky/rocky/views/finding_add.py
@@ -128,7 +128,7 @@ class FindingAddView(BaseOOIFormView):
     def get_ooi_options(self) -> List[Dict[str, str]]:
         # Query to render form options
         ooi_set = set(OOI_TYPES.values()).difference({Finding, FindingType})
-        objects = self.octopoes_api_connector.list(ooi_set).items
+        objects = self.octopoes_api_connector.list_objects(ooi_set).items
 
         # generate options
         options = [(o.primary_key, o.get_ooi_type()) for o in objects]

--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -163,7 +163,7 @@ class OOIList:
 
     @cached_property
     def count(self) -> int:
-        return self.octopoes_connector.list(
+        return self.octopoes_connector.list_objects(
             self.ooi_types,
             valid_time=self.valid_time,
             limit=0,
@@ -181,7 +181,7 @@ class OOIList:
             if key.stop:
                 limit = key.stop - offset
 
-            return self.octopoes_connector.list(
+            return self.octopoes_connector.list_objects(
                 self.ooi_types,
                 valid_time=self.valid_time,
                 offset=offset,
@@ -191,7 +191,7 @@ class OOIList:
             ).items
 
         elif isinstance(key, int):
-            return self.octopoes_connector.list(
+            return self.octopoes_connector.list_objects(
                 self.ooi_types,
                 valid_time=self.valid_time,
                 offset=key,

--- a/rocky/tests/objects/test_objects.py
+++ b/rocky/tests/objects/test_objects.py
@@ -24,14 +24,14 @@ def test_ooi_list(rf, client_member, mock_organization_view_octopoes):
 
     setup_request(request, client_member.user)
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
     response = OOIListView.as_view()(request, organization_code=client_member.organization.code)
 
     assert response.status_code == 200
-    assert mock_organization_view_octopoes().list.call_count == 2
+    assert mock_organization_view_octopoes().list_objects.call_count == 2
     assertContains(response, "testnetwork")
 
 
@@ -48,21 +48,21 @@ def test_ooi_list_with_clearance_type_filter_and_clearance_level_filter(
 
     setup_request(request, client_member.user)
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
     response = OOIListView.as_view()(request, organization_code=client_member.organization.code)
 
     assert response.status_code == 200
-    assert mock_organization_view_octopoes().list.call_count == 2
+    assert mock_organization_view_octopoes().list_objects.call_count == 2
 
-    list_call_0 = mock_organization_view_octopoes().list.call_args_list[0]
+    list_call_0 = mock_organization_view_octopoes().list_objects.call_args_list[0]
     assert list_call_0.kwargs["limit"] == 0
     assert list_call_0.kwargs["scan_level"] == {ScanLevel.L0, ScanLevel.L1}
     assert list_call_0.kwargs["scan_profile_type"] == {ScanProfileType.DECLARED, ScanProfileType.INHERITED}
 
-    list_call_1 = mock_organization_view_octopoes().list.call_args_list[1]
+    list_call_1 = mock_organization_view_octopoes().list_objects.call_args_list[1]
     assert list_call_1.kwargs["limit"] == 150
     assert list_call_1.kwargs["offset"] == 0
     assert list_call_1.kwargs["scan_level"] == {ScanLevel.L0, ScanLevel.L1}
@@ -91,7 +91,7 @@ def test_ooi_list_delete_multiple(rf, client_member, mock_organization_view_octo
     response = OOIListView.as_view()(request, organization_code=client_member.organization.code)
 
     assert response.status_code == 200
-    assert mock_organization_view_octopoes().list.call_count == 2
+    assert mock_organization_view_octopoes().list_objects.call_count == 2
     assert mock_organization_view_octopoes().delete_many.call_count == 1
 
 
@@ -389,7 +389,7 @@ def test_ooi_list_export_json(rf, client_member, mock_organization_view_octopoes
 
     setup_request(request, client_member.user)
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
@@ -397,7 +397,7 @@ def test_ooi_list_export_json(rf, client_member, mock_organization_view_octopoes
 
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "application/json"
-    assert mock_organization_view_octopoes().list.call_count == 1
+    assert mock_organization_view_octopoes().list_objects.call_count == 1
 
     exported_objects = json.loads(response.content.decode())
     assert len(exported_objects) == 151
@@ -416,7 +416,7 @@ def test_ooi_list_export_csv(rf, client_member, mock_organization_view_octopoes)
 
     setup_request(request, client_member.user)
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
@@ -424,7 +424,7 @@ def test_ooi_list_export_csv(rf, client_member, mock_organization_view_octopoes)
 
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/csv"
-    assert mock_organization_view_octopoes().list.call_count == 1
+    assert mock_organization_view_octopoes().list_objects.call_count == 1
 
     exported_objects = list(csv.DictReader(io.StringIO(response.content.decode()), delimiter=",", quotechar='"'))
 
@@ -443,7 +443,7 @@ def test_ooi_list_filtered_export_csv(rf, client_member, mock_organization_view_
 
     setup_request(request, client_member.user)
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
@@ -451,9 +451,9 @@ def test_ooi_list_filtered_export_csv(rf, client_member, mock_organization_view_
 
     assert response.status_code == 200
     assert response.headers["Content-Type"] == "text/csv"
-    assert mock_organization_view_octopoes().list.call_count == 1
+    assert mock_organization_view_octopoes().list_objects.call_count == 1
 
-    mock_calls = mock_organization_view_octopoes().list.mock_calls
+    mock_calls = mock_organization_view_octopoes().list_objects.mock_calls
     assert list(mock_calls[0].kwargs["scan_level"])[0].value == 3
     assert mock_calls[0].args[0].pop() == Network
     assert list(mock_calls[0].kwargs["scan_profile_type"])[0].value == "inherited"
@@ -462,7 +462,7 @@ def test_ooi_list_filtered_export_csv(rf, client_member, mock_organization_view_
 @pytest.mark.parametrize("member", ["superuser_member", "admin_member", "redteam_member"])
 def test_delete_perms_object_list(request, member, rf, mock_organization_view_octopoes):
     member = request.getfixturevalue(member)
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 
@@ -480,7 +480,7 @@ def test_delete_perms_object_list(request, member, rf, mock_organization_view_oc
 
 
 def test_delete_perms_object_list_clients(rf, client_member, mock_organization_view_octopoes):
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](
         count=200, items=[Network(name="testnetwork")] * 150
     )
 

--- a/rocky/tests/test_groups_and_permissions.py
+++ b/rocky/tests/test_groups_and_permissions.py
@@ -60,7 +60,7 @@ def test_plugin_settings_list_perms(
     mock_scheduler_client = mocker.patch("katalogus.views.plugin_detail.scheduler")
     mock_scheduler_client.client.get_lazy_task_list.return_value = lazy_task_list_with_boefje
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](count=1, items=[network])
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](count=1, items=[network])
     mock_mixins_katalogus().get_plugin.return_value = plugin_details
     mock_mixins_katalogus().get_plugin_schema.return_value = plugin_schema
 
@@ -94,7 +94,7 @@ def test_plugin_settings_list_perms_2(
     mock_scheduler_client = mocker.patch("katalogus.views.plugin_detail.scheduler")
     mock_scheduler_client.client.get_lazy_task_list.return_value = lazy_task_list_with_boefje
 
-    mock_organization_view_octopoes().list.return_value = Paginated[OOIType](count=1, items=[network])
+    mock_organization_view_octopoes().list_objects.return_value = Paginated[OOIType](count=1, items=[network])
     mock_mixins_katalogus().get_plugin.return_value = plugin_details
     mock_mixins_katalogus().get_plugin_schema.return_value = plugin_schema
 

--- a/rocky/tools/forms/ooi_form.py
+++ b/rocky/tools/forms/ooi_form.py
@@ -104,7 +104,7 @@ def generate_select_ooi_field(
     if initial:
         select_options.append((initial, initial))
 
-    oois = api_connector.list({related_ooi_type}).items
+    oois = api_connector.list_objects({related_ooi_type}).items
     select_options.extend([(ooi.primary_key, ooi.primary_key) for ooi in oois])
 
     if is_multiselect:


### PR DESCRIPTION
### Changes
This renames the `list` method to `list_objects`, `list_oois`, `list_origins` or `list_scan_profiles` depending on the context. This removes the conflict with the builtin `list` so that we can use that when specifying the Python 3.10 style typing.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
