### PR TITLE
Unit tests to Name Server Report

### DIFF
--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -631,6 +631,59 @@ def finding_type_kat_no_dkim():
 
 
 @pytest.fixture
+def finding_type_kat_uncommon_open_port():
+    return KATFindingType(
+        id="KAT-UNCOMMON-OPEN-PORT",
+        description="Fake description...",
+        recommendation="Fake recommendation...",
+        risk_score=9.5,
+        risk_severity=RiskLevelSeverity.CRITICAL,
+    )
+
+
+@pytest.fixture
+def finding_type_kat_open_sysadmin_port():
+    return KATFindingType(
+        id="KAT-OPEN-SYSADMIN-PORT",
+        description="Fake description...",
+        recommendation="Fake recommendation...",
+        risk_score=8.5,
+        risk_severity=RiskLevelSeverity.HIGH,
+    )
+
+
+@pytest.fixture
+def finding_type_kat_open_database_port():
+    return KATFindingType(
+        id="KAT-OPEN-DATABASE-PORT",
+        description="Fake description...",
+        recommendation="Fake recommendation...",
+        risk_score=6.5,
+        risk_severity=RiskLevelSeverity.MEDIUM,
+    )
+
+
+@pytest.fixture
+def finding_type_kat_no_dnssec():
+    return KATFindingType(
+        id="KAT-NO-DNSSEC",
+        description="Fake description...",
+        recommendation="Fake recommendation...",
+        risk_severity=RiskLevelSeverity.PENDING,
+    )
+
+
+@pytest.fixture
+def finding_type_kat_invalid_dnssec():
+    return KATFindingType(
+        id="KAT-INVALID-DNSSEC",
+        recommendation="Fake recommendation...",
+        risk_score=3.0,
+        risk_severity=RiskLevelSeverity.LOW,
+    )
+
+
+@pytest.fixture
 def plugin_details():
     return parse_plugin(
         {

--- a/rocky/tests/reports/test_name_server_report.py
+++ b/rocky/tests/reports/test_name_server_report.py
@@ -1,0 +1,103 @@
+from reports.report_types.name_server_report.report import NameServerSystemReport
+
+
+def test_name_server_report_no_hostname(mock_octopoes_api_connector, valid_time, ipaddressv4):
+    mock_octopoes_api_connector.oois = {
+        ipaddressv4.reference: ipaddressv4,
+    }
+
+    mock_octopoes_api_connector.queries = {
+        "IPAddress.<address[is ResolvedHostname].hostname": {
+            ipaddressv4.reference: [],
+        },
+    }
+
+    report = NameServerSystemReport(mock_octopoes_api_connector)
+
+    data = report.generate_data(str(ipaddressv4.reference), valid_time)
+
+    assert len(data["name_server_checks"].checks) == 0
+    assert data["name_server_checks"].has_dnssec == 0
+    assert data["name_server_checks"].has_valid_dnssec == 0
+    assert data["name_server_checks"].no_uncommon_ports == 0
+    assert data["finding_types"] == []
+
+
+def test_name_server_report_no_finding_types(mock_octopoes_api_connector, valid_time, hostname):
+    mock_octopoes_api_connector.oois = {
+        hostname.reference: hostname,
+    }
+    mock_octopoes_api_connector.queries = {
+        "Hostname.<hostname[is ResolvedHostname].address.<address[is IPPort].<ooi[is Finding].finding_type": {
+            hostname.reference: [],
+        },
+        "Hostname.<ooi[is Finding].finding_type": {
+            hostname.reference: [],
+        },
+    }
+
+    report = NameServerSystemReport(mock_octopoes_api_connector)
+
+    data = report.generate_data(str(hostname.reference), valid_time)
+
+    assert len(data["name_server_checks"].checks) == 1
+    assert data["name_server_checks"].has_dnssec == 1
+    assert data["name_server_checks"].has_valid_dnssec == 1
+    assert data["name_server_checks"].no_uncommon_ports == 1
+    assert data["finding_types"] == []
+
+    assert data["name_server_checks"].checks[0].has_dnssec is True
+    assert data["name_server_checks"].checks[0].has_valid_dnssec is True
+    assert data["name_server_checks"].checks[0].no_uncommon_ports is True
+
+
+def test_name_server_report_multiple_finding_types(
+    mock_octopoes_api_connector,
+    valid_time,
+    hostname,
+    ipaddressv4,
+    finding_type_kat_uncommon_open_port,
+    finding_type_kat_open_sysadmin_port,
+    finding_type_kat_open_database_port,
+    finding_type_kat_no_dnssec,
+    finding_type_kat_invalid_dnssec,
+    finding_types,
+):
+    mock_octopoes_api_connector.oois = {
+        ipaddressv4.reference: ipaddressv4,
+    }
+
+    mock_octopoes_api_connector.queries = {
+        "IPAddress.<address[is ResolvedHostname].hostname": {
+            ipaddressv4.reference: [hostname],
+        },
+        "Hostname.<hostname[is ResolvedHostname].address.<address[is IPPort].<ooi[is Finding].finding_type": {
+            hostname.reference: [
+                finding_type_kat_uncommon_open_port,
+                finding_type_kat_open_sysadmin_port,
+                finding_type_kat_open_database_port,
+            ]
+            + finding_types,
+        },
+        "Hostname.<ooi[is Finding].finding_type": {
+            hostname.reference: [finding_type_kat_no_dnssec, finding_type_kat_invalid_dnssec] + finding_types,
+        },
+    }
+
+    report = NameServerSystemReport(mock_octopoes_api_connector)
+
+    data = report.generate_data(str(ipaddressv4.reference), valid_time)
+
+    assert len(data["name_server_checks"].checks) == 1
+    assert data["name_server_checks"].has_dnssec == 0
+    assert data["name_server_checks"].has_valid_dnssec == 0
+    assert data["name_server_checks"].no_uncommon_ports == 0
+
+    assert data["name_server_checks"].checks[0].has_dnssec is False
+    assert data["name_server_checks"].checks[0].has_valid_dnssec is False
+    assert data["name_server_checks"].checks[0].no_uncommon_ports is False
+    assert data["finding_types"] == [
+        finding_type_kat_uncommon_open_port,
+        finding_type_kat_open_sysadmin_port,
+        finding_type_kat_open_database_port,
+    ]


### PR DESCRIPTION
## The problem
Unit tests were still missing for the Name Server Report.

## Solution 
This PR adds unit tests to cover this report. 

## Issues
### Closes
Issue #2477 

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
