### PR TITLE
Quick fix for PDF table overflow

### DIFF
--- a/rocky/assets/css/vendor_overrides/weasyprint/pdf-overrides.scss
+++ b/rocky/assets/css/vendor_overrides/weasyprint/pdf-overrides.scss
@@ -23,13 +23,13 @@
 @import "table-of-contents";
 
 :root {
-  --text-set-font-size: 12pt;
+  --text-set-font-size: 9pt;
   --body-text-large-font-size: 15pt;
   --heading-xxl-font-size: 26pt;
   --heading-xl-font-size: 20pt;
   --heading-large-font-size: 18pt;
-  --table-font-size: 10pt;
-  --table-head-cell-font-size: 12pt;
+  --table-font-size: 9pt;
+  --table-head-cell-font-size: 10pt;
 }
 
 body > main > section.dividing-line {

--- a/rocky/reports/report_types/vulnerability_report/report.html
+++ b/rocky/reports/report_types/vulnerability_report/report.html
@@ -57,31 +57,32 @@
                                             <li>
                                                 <button aria-expanded="false">{{ finding }}</button>
                                                 <div aria-labelledby="finding-details">
-                                                    {% for key, value in finding_details.items %}
-                                                        <dl>
+                                                    <dl>
+                                                        {% for key, value in finding_details.items %}
                                                             <div>
                                                                 <dt>{{ key }}</dt>
                                                                 <dd>
                                                                     {% if key == "Evidence" %}
-                                                                    <a href="{% url 'download_task_meta' organization_code=organization.code task_id=value %}"><span class="icon ti-download"></span>
-                                                                {{ value }}</a>
-                                                            {% else %}
-                                                                {{ value }}
-                                                            {% endif %}
-                                                        </dd>
-                                                    </div>
-                                                </dl>
-                                            {% endfor %}
-                                        </div>
-                                    </li>
-                                {% endfor %}
-                            </ul>
-                        </td>
-                    </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-    </div>
-{% endif %}
-{% endfor %}
+                                                                        <a href="{% url 'download_task_meta' organization_code=organization.code task_id=value %}"><span class="icon ti-download"></span>{{ value }}</a>
+                                                                    {% else %}
+                                                                        {{ value }}
+                                                                    {% endif %}
+                                                                </dd>
+                                                            </div>
+                                                        {% endfor %}
+                                                    </dl>
+                                                </div>
+                                            </li>
+                                        {% endfor %}
+                                    </ul>
+                                </td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
+            </div>
+        {% else %}
+            <p>{% translate "No findings have been found on this system." %}</p>
+        {% endif %}
+    {% endfor %}
 {% endif %}

--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -118,7 +118,7 @@ class VulnerabilityReport(Report):
 
                         evidence = origins[0].task_id if origins else "-"
 
-                        filtered_findings[finding.primary_key] = {
+                        filtered_findings[finding.human_readable] = {
                             str(_("Source")): sources,
                             str(_("First seen")): first_seen,
                             str(_("Last seen")): "-",

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-02-22 06:44+0000\n"
+"POT-Creation-Date: 2024-02-26 17:13+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3039,6 +3039,10 @@ msgstr ""
 
 #: reports/report_types/vulnerability_report/report.html
 msgid "Advice"
+msgstr ""
+
+#: reports/report_types/vulnerability_report/report.html
+msgid "No findings have been found on this system."
 msgstr ""
 
 #: reports/report_types/vulnerability_report/report.py


### PR DESCRIPTION
## The problem
Tables in the vulnerability section of the new reporting module flow outside of the PDF-margin, making them unreadable. This happens in both the aggregate report and the normal generate report.

Another thing that is not correct is the font size of the text in the table. Some text appears larger than others.

### Steps to reproduce
1. Have vulnerabilities
2. Create a report and select report type "Vulnerability Report".
3. Press the "Download Report" button (or "Export" -> "Download PDF" for aggregated report flow)
4. You will now see that the text in the table does not fit and that the text in the table has a different size.

### Demo of the problem occuring
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/bb8a92bb-ef4e-4b6e-a270-be726597ef96)

## Possible solutions
* Change the HTML of the table
* Make the PDF page landscape
* Decide what happens when the table overflows (for example, cutting of the sentence)
* Make a few quick changes for the new release and fix the rest later

## Solution
We've chosen for the last solution, which involves the following:
* Making the font size the same for all the text in the table
* Changing the finding.primary_key to finding.human_readable 

It's not a complete solution, but it's better than before. We should concider the other solutions as well, because some parts of the table are still overflowing.

### Demo of the solution
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/c9ece7b9-2878-4364-adff-cc84d56eafb4)

## Issues
### Closes
Closes none, but is a part of issue #2493 

---
## Checks
### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
