### PR TITLE
Filter out undeserializable objects from xtdb query in `construct_neighbour_query_multi`

### DIFF
--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -500,12 +500,11 @@ class XTDBOOIRepository(OOIRepository):
                         :query {{
                             :find [
                                 (pull ?e [
-                                    :xt/id
                                     {related_fields}
                                 ])
                             ]
                             :in [[ _xt_id ... ]]
-                            :where [[?e :xt/id _xt_id]]
+                            :where [[?e :xt/id _xt_id] [?e :object_type]]
                         }}
                         :in-args [[{reference}]]
                     }}""".format(
@@ -548,17 +547,12 @@ class XTDBOOIRepository(OOIRepository):
         for row in response:
             col = row[0]
             for value in col.values():
-                try:
-                    if value:
-                        if isinstance(value, list):
-                            for serialized in value:
-                                neighbours.add(self.deserialize(serialized))
-                        else:
-                            neighbours.add(self.deserialize(value))
-                except ValueError:
-                    # Is not an error, XTDB returns the foreign key as a string,
-                    # when related object is not found
-                    logger.info("Could not deserialize value [value=%s]", value)
+                if value:
+                    if isinstance(value, list):
+                        for serialized in value:
+                            neighbours.add(self.deserialize(serialized))
+                    else:
+                        neighbours.add(self.deserialize(value))
 
         return neighbours
 


### PR DESCRIPTION
Filter out undeserializable objects from xtdb query in `construct_neighbour_query_multi`

### Changes
Filter out undeserializable objects from xtdb query in `construct_neighbour_query_multi` so that we do not get any warnings.

### Issue link
Closes #2568 

### Demo
N/A

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
