### PR TITLE
split output into two raw files, and fix no-output mimetype in main.py

### DIFF
--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -74,8 +74,12 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
 
     results = []
     if top_ports_tcp:
-        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S"))))
+        results.append(
+            (set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S")))
+        )
     if top_ports_udp:
-        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="U"))))
+        results.append(
+            (set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="U")))
+        )
 
     return results

--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -58,7 +58,14 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
             min_mask,
             ip_range.prefixlen,
         )
-        return [(set("info/boefje", ), "Skipping range due to unaccepted VSLM.")]
+        return [
+            (
+                set(
+                    "info/boefje",
+                ),
+                "Skipping range due to unaccepted VSLM.",
+            )
+        ]
 
     top_ports_tcp = int(getenv("TOP_PORTS_TCP", 250))
     top_ports_udp = int(getenv("TOP_PORTS_UDP", 10))
@@ -67,8 +74,8 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
 
     results = []
     if top_ports_tcp:
-        results.append(set('boefje/nmap-tcp',), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S")))
+        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S"))
     if top_ports_udp:
-        results.append(set('boefje/nmap-udp',), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_udp, protocol_str="U")))
+        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="U"))
 
     return results

--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -74,8 +74,8 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
 
     results = []
     if top_ports_tcp:
-        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S"))
+        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S"))))
     if top_ports_udp:
-        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="U"))
+        results.append((set(), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="U"))))
 
     return results

--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -58,8 +58,7 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
             min_mask,
             ip_range.prefixlen,
         )
-        infomimetype = set(("info/boefje",))
-        return [(infomimetype, "Skipping range due to unaccepted VSLM.")]
+        return [({"info/boefje"}, "Skipping range due to unaccepted VSLM.")]
 
     top_ports_tcp = int(getenv("TOP_PORTS_TCP", 250))
     top_ports_udp = int(getenv("TOP_PORTS_UDP", 10))

--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -58,14 +58,8 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
             min_mask,
             ip_range.prefixlen,
         )
-        return [
-            (
-                set(
-                    "info/boefje",
-                ),
-                "Skipping range due to unaccepted VSLM.",
-            )
-        ]
+        infomimetype = set(("info/boefje",))
+        return [(infomimetype, "Skipping range due to unaccepted VSLM.")]
 
     top_ports_tcp = int(getenv("TOP_PORTS_TCP", 250))
     top_ports_udp = int(getenv("TOP_PORTS_UDP", 10))

--- a/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
+++ b/boefjes/boefjes/plugins/kat_nmap_ip_range/main.py
@@ -58,7 +58,7 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
             min_mask,
             ip_range.prefixlen,
         )
-        return [(set("info/boefje"), "Skipping range due to unaccepted VSLM.")]
+        return [(set("info/boefje", ), "Skipping range due to unaccepted VSLM.")]
 
     top_ports_tcp = int(getenv("TOP_PORTS_TCP", 250))
     top_ports_udp = int(getenv("TOP_PORTS_UDP", 10))
@@ -67,8 +67,8 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
 
     results = []
     if top_ports_tcp:
-        results.append(run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S")))
+        results.append(set('boefje/nmap-tcp',), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_tcp, protocol_str="S")))
     if top_ports_udp:
-        results.append(run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_udp, protocol_str="U")))
+        results.append(set('boefje/nmap-udp',), run_nmap(build_nmap_arguments(ip_range=ip_range, top_ports=top_ports_udp, protocol_str="U")))
 
-    return [(set(), "\n\n".join(results))]
+    return results


### PR DESCRIPTION
### Changes
The output for the 'no action' situation was invalid, it was a set of single chars, not a set of one item.
The raw files can be split into two with distinct mime-types for each. Not sure about the mimetype of each however.


### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
