### PR TITLE
Fix bug in Generate Report

### DIFF
--- a/rocky/.ci/docker-compose.yml
+++ b/rocky/.ci/docker-compose.yml
@@ -40,6 +40,8 @@ services:
     image: postgres:15
     env_file:
       - .env.test
+    # ports:
+    #   - "127.0.0.1:5432:5432"
 
   ci_octopoes:
     build:

--- a/rocky/.ci/docker-compose.yml
+++ b/rocky/.ci/docker-compose.yml
@@ -40,8 +40,6 @@ services:
     image: postgres:15
     env_file:
       - .env.test
-    # ports:
-    #   - "127.0.0.1:5432:5432"
 
   ci_octopoes:
     build:

--- a/rocky/reports/views/generate_report.py
+++ b/rocky/reports/views/generate_report.py
@@ -156,7 +156,7 @@ class GenerateReportView(BreadcrumbsGenerateReportView, BaseReportView, Template
             if ooi_type not in by_type:
                 by_type[ooi_type] = []
 
-                by_type[ooi_type].append(ooi)
+            by_type[ooi_type].append(ooi)
 
         for report_type in self.report_types:
             oois = {


### PR DESCRIPTION
### Changes
There was a bug in generate_report.py, where there was one tab too much. 
This caused the DNS report to only show the report for one domain, instead of multiple.

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
