### PR TITLE
Fix HTML in DNS report

### DIFF
--- a/rocky/reports/report_types/dns_report/report.html
+++ b/rocky/reports/report_types/dns_report/report.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
+<h2>{% translate "Records found" %}</h2>
 {% if data.records %}
-    <h2>{% translate "Records found" %}</h2>
     <p>
         {% blocktranslate trimmed %}
             The table below gives an overview of the DNS records that were found for the abovementioned DNSZone.
@@ -46,130 +46,132 @@
             </tbody>
         </table>
     </div>
-    <h2>{% translate "Security measures" %}</h2>
-    <div class="horizontal-scroll">
-        <div class="column-3">
-            <table>
-                <caption class="visually-hidden">{% translate "Security measures" %}</caption>
-                <thead>
-                    <tr>
-                        <th>{% translate "Enabled" %}</th>
-                        <th>{% translate "Type" %}</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td>
-                            {% if data.security.spf %}
-                                <i class="icon positive"></i>{% translate "Yes" %}
-                            {% else %}
-                                <i class="icon alert"></i>{% translate "No" %}
-                            {% endif %}
-                        </td>
-                        <td>SPF</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            {% if data.security.dmarc %}
-                                <i class="icon positive"></i>{% translate "Yes" %}
-                            {% else %}
-                                <i class="icon alert"></i>{% translate "No" %}
-                            {% endif %}
-                        </td>
-                        <td>DMARC</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            {% if data.security.dkim %}
-                                <i class="icon positive"></i>{% translate "Yes" %}
-                            {% else %}
-                                <i class="icon alert"></i>{% translate "No" %}
-                            {% endif %}
-                        </td>
-                        <td>DKIM</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            {% if data.security.dnssec %}
-                                <i class="icon positive"></i>{% translate "Yes" %}
-                            {% else %}
-                                <i class="icon alert"></i>{% translate "No" %}
-                            {% endif %}
-                        </td>
-                        <td>DNSSEC</td>
-                    </tr>
-                    <tr>
-                        <td>
-                            {% if data.security.caa %}
-                                <i class="icon positive"></i>{% translate "Yes" %}
-                            {% else %}
-                                <i class="icon alert"></i>{% translate "No" %}
-                            {% endif %}
-                        </td>
-                        <td>CAA</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+{% else %}
+    <p>{% translate "No records have been found." %}</p>
+{% endif %}
+<h2>{% translate "Security measures" %}</h2>
+<div class="horizontal-scroll">
+    <div class="column-3">
+        <table>
+            <caption class="visually-hidden">{% translate "Security measures" %}</caption>
+            <thead>
+                <tr>
+                    <th>{% translate "Enabled" %}</th>
+                    <th>{% translate "Type" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td>
+                        {% if data.security.spf %}
+                            <i class="icon positive"></i>{% translate "Yes" %}
+                        {% else %}
+                            <i class="icon alert"></i>{% translate "No" %}
+                        {% endif %}
+                    </td>
+                    <td>SPF</td>
+                </tr>
+                <tr>
+                    <td>
+                        {% if data.security.dmarc %}
+                            <i class="icon positive"></i>{% translate "Yes" %}
+                        {% else %}
+                            <i class="icon alert"></i>{% translate "No" %}
+                        {% endif %}
+                    </td>
+                    <td>DMARC</td>
+                </tr>
+                <tr>
+                    <td>
+                        {% if data.security.dkim %}
+                            <i class="icon positive"></i>{% translate "Yes" %}
+                        {% else %}
+                            <i class="icon alert"></i>{% translate "No" %}
+                        {% endif %}
+                    </td>
+                    <td>DKIM</td>
+                </tr>
+                <tr>
+                    <td>
+                        {% if data.security.dnssec %}
+                            <i class="icon positive"></i>{% translate "Yes" %}
+                        {% else %}
+                            <i class="icon alert"></i>{% translate "No" %}
+                        {% endif %}
+                    </td>
+                    <td>DNSSEC</td>
+                </tr>
+                <tr>
+                    <td>
+                        {% if data.security.caa %}
+                            <i class="icon positive"></i>{% translate "Yes" %}
+                        {% else %}
+                            <i class="icon alert"></i>{% translate "No" %}
+                        {% endif %}
+                    </td>
+                    <td>CAA</td>
+                </tr>
+            </tbody>
+        </table>
     </div>
-    {% if data.finding_types %}
-        <h2>{% translate "Other findings found" %}</h2>
-        <div class="horizontal-scroll">
-            <table>
-                <caption class="visually-hidden">{% translate "Other findings found:" %}</caption>
-                <thead>
+</div>
+{% if data.finding_types %}
+    <h2>{% translate "Other findings found" %}</h2>
+    <div class="horizontal-scroll">
+        <table>
+            <caption class="visually-hidden">{% translate "Other findings found:" %}</caption>
+            <thead>
+                <tr>
+                    <th scope="col">{% translate "Severity" %}</th>
+                    <th scope="col">{% translate "Finding" %}</th>
+                    <th scope="col">{% translate "Details" %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for info in data.finding_types %}
                     <tr>
-                        <th scope="col">{% translate "Severity" %}</th>
-                        <th scope="col">{% translate "Finding" %}</th>
-                        <th scope="col">{% translate "Details" %}</th>
+                        <td>
+                            <span class="{{ info.finding_type.risk_severity }}">{{ info.finding_type.risk_severity }}</span>
+                        </td>
+                        <td>{{ info.finding_type }}</td>
+                        <td class="actions">
+                            <button class="expando-button"
+                                    data-icon-open-class="icon ti-chevron-down"
+                                    data-icon-close-class="icon ti-chevron-up"
+                                    data-close-label="{% translate "Close details" %}">
+                                {% translate "Open details" %}
+                            </button>
+                        </td>
                     </tr>
-                </thead>
-                <tbody>
-                    {% for info in data.finding_types %}
-                        <tr>
-                            <td>
-                                <span class="{{ info.finding_type.risk_severity }}">{{ info.finding_type.risk_severity }}</span>
-                            </td>
-                            <td>{{ info.finding_type }}</td>
-                            <td class="actions">
-                                <button class="expando-button"
-                                        data-icon-open-class="icon ti-chevron-down"
-                                        data-icon-close-class="icon ti-chevron-up"
-                                        data-close-label="{% translate "Close details" %}">
-                                    {% translate "Open details" %}
-                                </button>
-                            </td>
-                        </tr>
-                        <tr class="expando-row">
-                            <td colspan="5">
-                                <h3>{{ info.finding_type }}</h3>
-                                <h4>{% translate "Findings information" %}</h4>
-                                <dl>
-                                    <div>
-                                        <dt>{% translate "Finding" %}</dt>
-                                        <dd>
-                                            {{ info.finding_type.id }}
-                                        </dd>
-                                    </div>
-                                    <div>
-                                        <dt>{% translate "Description" %}</dt>
-                                        <dd>
-                                            {{ info.finding_type.description }}
-                                        </dd>
-                                    </div>
-                                </dl>
-                                <h4>{% translate "Occurrences" %}</h4>
-                                {% for occurrence in info.occurrences %}
-                                    <div>
-                                        <strong>{{ occurrence.ooi.human_readable }}</strong>
-                                        <p>{{ occurrence.description }}</p>
-                                    </div>
-                                {% endfor %}
-                            </td>
-                        </tr>
-                    {% endfor %}
-                </tbody>
-            </table>
-        </div>
-    {% endif %}
+                    <tr class="expando-row">
+                        <td colspan="5">
+                            <h3>{{ info.finding_type }}</h3>
+                            <h4>{% translate "Findings information" %}</h4>
+                            <dl>
+                                <div>
+                                    <dt>{% translate "Finding" %}</dt>
+                                    <dd>
+                                        {{ info.finding_type.id }}
+                                    </dd>
+                                </div>
+                                <div>
+                                    <dt>{% translate "Description" %}</dt>
+                                    <dd>
+                                        {{ info.finding_type.description }}
+                                    </dd>
+                                </div>
+                            </dl>
+                            <h4>{% translate "Occurrences" %}</h4>
+                            {% for occurrence in info.occurrences %}
+                                <div>
+                                    <strong>{{ occurrence.ooi.human_readable }}</strong>
+                                    <p>{{ occurrence.description }}</p>
+                                </div>
+                            {% endfor %}
+                        </td>
+                    </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
 {% endif %}


### PR DESCRIPTION
### Changes
Small changes in the HTML of the DNS report, that makes sure the "Security measures" table will always be shown, even if there no records have been found.

### Demo
Before (empty report): 
<img width="958" alt="dns report 1" src="https://github.com/minvws/nl-kat-coordination/assets/99282220/568c09f1-76a2-468c-849d-c3838361221f">

After ("Security measures" visible):
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/9c2378c1-0294-447e-bbe1-4367e9761685)


---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
