### PR TITLE
Fix plugins overview

### DIFF
--- a/rocky/reports/report_types/aggregate_organisation_report/appendix.html
+++ b/rocky/reports/report_types/aggregate_organisation_report/appendix.html
@@ -48,18 +48,20 @@
         <tbody>
             {% for option, plugins in plugins.items %}
                 {% for plugin in plugins %}
-                    <tr>
-                        <td>{{ option }}</td>
-                        <td>{{ plugin.name }}</td>
-                        <td>
-                            {% include "partials/scan_level_indicator.html" with value=plugin.scan_level.value custom_class="left" %}
+                    {% if plugin.enabled %}
+                        <tr>
+                            <td>{{ option }}</td>
+                            <td>{{ plugin.name }}</td>
+                            <td>
+                                {% include "partials/scan_level_indicator.html" with value=plugin.scan_level.value custom_class="left" %}
 
-                        </td>
-                        <td>
-                            <span class="label-plugin-type {{ plugin.type }}">{{ plugin.type|title }}</span>
-                        </td>
-                        <td>{{ plugin.description }}</td>
-                    </tr>
+                            </td>
+                            <td>
+                                <span class="label-plugin-type {{ plugin.type }}">{{ plugin.type|title }}</span>
+                            </td>
+                            <td>{{ plugin.description }}</td>
+                        </tr>
+                    {% endif %}
                 {% endfor %}
             {% endfor %}
         </tbody>

--- a/rocky/reports/templates/summary/report_summary.html
+++ b/rocky/reports/templates/summary/report_summary.html
@@ -39,18 +39,20 @@
             <tbody>
                 {% for option, plugins in plugins.items %}
                     {% for plugin in plugins %}
-                        <tr>
-                            <td>{{ option }}</td>
-                            <td>{{ plugin.name }}</td>
-                            <td>
-                                {% include "partials/scan_level_indicator.html" with value=plugin.scan_level.value custom_class="left" %}
+                        {% if plugin.enabled %}
+                            <tr>
+                                <td>{{ option }}</td>
+                                <td>{{ plugin.name }}</td>
+                                <td>
+                                    {% include "partials/scan_level_indicator.html" with value=plugin.scan_level.value custom_class="left" %}
 
-                            </td>
-                            <td>
-                                <span class="label-plugin-type {{ plugin.type }}">{{ plugin.type|title }}</span>
-                            </td>
-                            <td>{{ plugin.description }}</td>
-                        </tr>
+                                </td>
+                                <td>
+                                    <span class="label-plugin-type {{ plugin.type }}">{{ plugin.type|title }}</span>
+                                </td>
+                                <td>{{ plugin.description }}</td>
+                            </tr>
+                        {% endif %}
                     {% endfor %}
                 {% endfor %}
             </tbody>

--- a/rocky/reports/views/aggregate_report.py
+++ b/rocky/reports/views/aggregate_report.py
@@ -214,7 +214,8 @@ class AggregateReportView(BreadcrumbsAggregateReportView, BaseReportView, Templa
         )
 
         context["oois"] = self.get_oois()
-        context["plugins"] = self.get_required_optional_plugins(get_plugins_for_report_ids(self.selected_report_types))
+        plugins, _ = self.get_required_optional_plugins(get_plugins_for_report_ids(self.selected_report_types))
+        context["plugins"] = plugins
         return context
 
 


### PR DESCRIPTION
### Changes
Plugins overview missing in appendix because of tuple object being passed in template, where we need only the plugins part and not the boolean if plugins are enabled or not.

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/2693

Closes https://github.com/minvws/nl-kat-coordination/issues/2693

### Demo
_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

---

### Code Checklist
- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
