### PR TITLE
Fix critical vulnerability counter

### DIFF
--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -369,6 +369,7 @@ class AggregateOrganisationReport(AggregateReport):
         recommendations = list(set(filter(None, recommendations)))
         total_ips = len(unique_ips)
         total_hostnames = len(unique_hostnames)
+        total_criticals = sum(vulnerability["summary"]["total_criticals"] for vulnerability in vulnerabilities.values())
 
         summary = {
             # _("General recommendations"): "",

--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -502,6 +502,18 @@ def software() -> Software:
 
 
 @pytest.fixture
+def cve_finding_type_2023_38408() -> CVEFindingType:
+    return CVEFindingType(
+        id="CVE-2023-38408",
+        description="The PKCS#11 feature in ssh-agent in OpenSSH before 9.3p2 has an insufficiently "
+        "trustworthy search path, leading to remote code execution if an agent is forwarded to an attacker-controlled system. ",
+        source="https://cve.circl.lu/cve/CVE-2023-38408",
+        risk_score=9.8,
+        risk_severity=RiskLevelSeverity.CRITICAL,
+    )
+
+
+@pytest.fixture
 def cve_finding_type_2019_8331() -> CVEFindingType:
     return CVEFindingType(
         id="CVE-2019-8331",
@@ -524,6 +536,19 @@ def cve_finding_type_2019_2019() -> CVEFindingType:
         source="https://cve.circl.lu/cve/CVE-2019-2019",
         risk_score=6.5,
         risk_severity=RiskLevelSeverity.MEDIUM,
+    )
+
+
+@pytest.fixture
+def cve_finding_2023_38408() -> Finding:
+    return Finding(
+        finding_type=Reference.from_str("CVEFindingType|CVE-2023-38408"),
+        ooi=Reference.from_str(
+            "Finding|SoftwareInstance|HostnameHTTPURL|https|internet|mispo.es|443|/|Software|Bootstrap|3.3.7|cpe:/a:getbootstrap:bootstrap|CVE-2023-38408"
+        ),
+        proof=None,
+        description="Vulnerability CVE-2023-38408 detected",
+        reproduce=None,
     )
 
 
@@ -557,7 +582,7 @@ def cve_finding_2019_2019() -> Finding:
 def cve_finding_type_no_score() -> CVEFindingType:
     return CVEFindingType(
         id="CVE-0000-0001",
-        description="CVE Finding without scopre",
+        description="CVE Finding without score",
         source="https://cve.circl.lu/cve/CVE-0000-0001",
         risk_severity=RiskLevelSeverity.UNKNOWN,
     )

--- a/rocky/tests/reports/test_vulnerability_report.py
+++ b/rocky/tests/reports/test_vulnerability_report.py
@@ -70,8 +70,8 @@ def test_vulnerability_report_finding_no_score(
     valid_time,
     ipaddressv4,
     hostname,
-    cve_finding_2019_8331,
-    cve_finding_type_2019_8331,
+    cve_finding_2023_38408,
+    cve_finding_type_2023_38408,
     cve_finding_no_score,
     cve_finding_type_no_score,
 ):
@@ -90,11 +90,11 @@ def test_vulnerability_report_finding_no_score(
         },
         "IPAddress.<address [is ResolvedHostname]"
         ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding]": {
-            ipaddressv4.reference: [cve_finding_2019_8331, cve_finding_no_score],
+            ipaddressv4.reference: [cve_finding_2023_38408, cve_finding_no_score],
         },
         "IPAddress.<address [is ResolvedHostname]"
         ".hostname.<netloc [is HostnameHTTPURL].<ooi [is SoftwareInstance].<ooi [is Finding].finding_type": {
-            ipaddressv4.reference: [cve_finding_type_2019_8331, cve_finding_type_no_score],
+            ipaddressv4.reference: [cve_finding_type_2023_38408, cve_finding_type_no_score],
         },
     }
 
@@ -102,8 +102,9 @@ def test_vulnerability_report_finding_no_score(
 
     data = report.collect_data([str(hostname.reference)], valid_time)[str(hostname.reference)]
 
-    assert data[str(ipaddressv4.reference)]["vulnerabilities"]["CVE-2019-8331"]["cvss"]["score"] == 6.1
-    assert data[str(ipaddressv4.reference)]["summary"]["total_criticals"] == 0
+    assert data[str(ipaddressv4.reference)]["vulnerabilities"]["CVE-2023-38408"]["cvss"]["score"] == 9.8
+    assert data[str(ipaddressv4.reference)]["vulnerabilities"]["CVE-0000-0001"]["cvss"]["score"] == None
+    assert data[str(ipaddressv4.reference)]["summary"]["total_criticals"] == 1
     assert data[str(ipaddressv4.reference)]["summary"]["total_findings"] == 2
 
 


### PR DESCRIPTION
### Changes
Fix for the vulnerability counter. As seen in the screenshot below, the critical vulnerability counter in the summary of the Aggregate Report was always 0. 

This PR fixes this bug and updates the vulnerability report's unit test to verify that the critical_vulnerability variable is set correctly.

![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/0dc07a81-a555-4bb2-91ce-09ec44ac2ec2)

### Issue link
Closes #2664 

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [x] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
