### PR TITLE
fix: openssl boefje stuck on port 80 (1.15)

### DIFF
--- a/boefjes/boefjes/plugins/kat_ssl_certificates/main.py
+++ b/boefjes/boefjes/plugins/kat_ssl_certificates/main.py
@@ -9,8 +9,12 @@ def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
     client = docker.from_env()
     input_ = boefje_meta.arguments["input"]
     hostname = input_["hostname"]["name"]
+    scheme = input_["ip_service"]["service"]["name"]
     ip_address = input_["ip_service"]["ip_port"]["address"]["address"]
     port = input_["ip_service"]["ip_port"]["port"]
+
+    if scheme != "https":
+        return [({"info/boefje"}, "Skipping check due to non-TLS scheme")]
 
     try:
         output = client.containers.run(


### PR DESCRIPTION
Backport of #2600 to release 1.15