### PR TITLE
Replace `black` with `ruff`s formatter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,10 +55,11 @@ repos:
     exclude: |
       /tests/
 
-- repo: https://github.com/charliermarsh/ruff-pre-commit
-  rev: 'v0.3.4'
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: 'v0.3.5'
   hooks:
   - id: ruff
+  - id: ruff-format
 
 - repo: https://github.com/asottile/pyupgrade
   rev: v3.15.2
@@ -71,11 +72,6 @@ repos:
   hooks:
   - id: django-upgrade
     args: [--target-version, "4.2"]
-
-- repo: https://github.com/psf/black
-  rev: "24.3.0"
-  hooks:
-  - id: black
 
 - repo: https://github.com/pre-commit/mirrors-mypy
   rev: v1.9.0
@@ -145,7 +141,7 @@ repos:
     exclude: '^rocky/rocky/templates/admin/.*\.html$'
 
 - repo: https://github.com/thibaudcolas/pre-commit-stylelint
-  rev: v16.3.0
+  rev: v16.3.1
   hooks:
     - id: stylelint
       args: [ --fix ]

--- a/boefjes/pyproject.toml
+++ b/boefjes/pyproject.toml
@@ -77,10 +77,6 @@ build-backend = "setuptools.build_meta:__legacy__"
 line-length = 120
 transform-concats = true
 
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120
-
 [tool.pytest.ini_options]
 env = [
     "KATALOGUS_DB_URI=postgresql://postgres:postgres@ci_katalogus-db:5432/ci_katalogus",

--- a/bytes/pyproject.toml
+++ b/bytes/pyproject.toml
@@ -40,7 +40,3 @@ pytest-env = "^1.1.3"
 [build-system]
 requires = ["setuptools>=65", "wheel"]
 build-backend = "setuptools.build_meta:__legacy__"
-
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120

--- a/cveapi/pyproject.toml
+++ b/cveapi/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120
-
 [tool.poetry]
 name = "cveapi"
 version = "0.0.1.dev1"

--- a/keiko/keiko/keiko.py
+++ b/keiko/keiko/keiko.py
@@ -36,7 +36,7 @@ LATEX_SPECIAL_CHARS = str.maketrans(
         "\\": r"\textbackslash{}",
         "\n": "\\newline%\n",
         "-": r"{-}",
-        "\xA0": "~",  # Non-breaking space
+        "\xa0": "~",  # Non-breaking space
         "[": r"{[}",
         "]": r"{]}",
     }

--- a/keiko/pyproject.toml
+++ b/keiko/pyproject.toml
@@ -30,7 +30,3 @@ httpx = "^0.27.0"
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
-
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120

--- a/mula/pyproject.toml
+++ b/mula/pyproject.toml
@@ -50,7 +50,3 @@ omit = [
     "scheduler/utils/*",
     "scheduler/__main__.py",
 ]
-
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120

--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -477,9 +477,7 @@ class XTDBOOIRepository(OOIRepository):
                         :where [[?e :xt/id _xt_id]]
                     }}
                     :in-args [["{reference}"]]
-                }}""".format(
-            reference=reference, related_fields=" ".join(segment_query_sections)
-        )
+                }}""".format(reference=reference, related_fields=" ".join(segment_query_sections))
 
         return query
 

--- a/octopoes/pyproject.toml
+++ b/octopoes/pyproject.toml
@@ -44,10 +44,6 @@ pytest-env = "^1.1.3"
 pytest-timeout = "^2.1.0"
 pytest-httpx = "^0.30.0"
 
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120
-
 [tool.pytest.ini_options]
 addopts = "--cov --cov-branch --cov-report=term-missing:skip-covered"
 env = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120
-
 [tool.mypy]
 python_version = "3.10"
 plugins = ["pydantic.mypy"]
@@ -56,7 +52,6 @@ exclude = [
 
 ]
 
-# Same as Black.
 line-length = 120
 
 # Support Python 3.10 and higher

--- a/rocky/account/forms/account_setup.py
+++ b/rocky/account/forms/account_setup.py
@@ -238,9 +238,9 @@ class OrganizationMemberEditForm(BaseRockyModelForm, TrustedClearanceLevelRadioP
             self.fields["trusted_clearance_level"].disabled = True
         self.fields["acknowledged_clearance_level"].label = _("Accepted clearance level")
         self.fields["acknowledged_clearance_level"].required = False
-        self.fields["acknowledged_clearance_level"].widget.attrs[
-            "fixed_paws"
-        ] = self.instance.acknowledged_clearance_level
+        self.fields["acknowledged_clearance_level"].widget.attrs["fixed_paws"] = (
+            self.instance.acknowledged_clearance_level
+        )
         self.fields["acknowledged_clearance_level"].widget.attrs["class"] = "level-indicator-form"
         if self.instance.user.is_superuser:
             self.fields["trusted_clearance_level"].disabled = True

--- a/rocky/katalogus/forms/plugin_settings.py
+++ b/rocky/katalogus/forms/plugin_settings.py
@@ -43,7 +43,9 @@ class PluginSchemaForm(forms.Form):
 
         # The form assigns "" and in some scenario's null to all unfilled (optional) fields
         cleaned_data = {
-            key: value for key, value in cleaned_data.items() if value is not None and value != ""  # noqa: PLC1901
+            key: value
+            for key, value in cleaned_data.items()
+            if value is not None and value != ""  # noqa: PLC1901
         }
 
         validator = Draft202012Validator(self.plugin_schema)

--- a/rocky/manage.py
+++ b/rocky/manage.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 """Django's command-line utility for administrative tasks."""
+
 import os
 import sys
 

--- a/rocky/pyproject.toml
+++ b/rocky/pyproject.toml
@@ -79,7 +79,3 @@ max_line_length = 120
 blank_line_after_tag = "load,extends,include"
 # https://www.djlint.com/docs/linter/#rules
 ignore = "H006,H016,H017,H030,H031"
-
-[tool.black]
-target-version = ["py310", "py311"]
-line-length = 120

--- a/rocky/tests/reports/test_web_systems_report.py
+++ b/rocky/tests/reports/test_web_systems_report.py
@@ -66,8 +66,7 @@ def test_web_report_all_findings(
         "Hostname.<hostname[is Website].<website[is SecurityTXT]": {
             hostname.reference: [],
         },
-        "Hostname.<hostname[is ResolvedHostname].address.<address[is IPPort]."
-        "<ooi[is Finding].finding_type": {
+        "Hostname.<hostname[is ResolvedHostname].address.<address[is IPPort].<ooi[is Finding].finding_type": {
             hostname.reference: web_report_finding_types,
         },
         "Hostname.<hostname[is Website].certificate.<ooi[is Finding].finding_type": {


### PR DESCRIPTION
### Changes
This PR replaces the formatter `black` with `ruff`s formatter. The Ruff formatter is an extremely fast code formatter designed as a drop-in replacement for Black and is available as part of Ruff.

I removed all the references to black. For those who still prefer to use Black, this won't be a problem since this formatter is almost fully compatible with Black.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [ x This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
