### PR TITLE
Set katalogus limit to 200

### DIFF
--- a/boefjes/boefjes/katalogus/types.py
+++ b/boefjes/boefjes/katalogus/types.py
@@ -6,7 +6,7 @@ from pydantic import BaseModel
 KATALOGUS_DIR = Path(__file__).parent
 STATIC_DIR = KATALOGUS_DIR / "static"
 
-LIMIT = 100
+LIMIT = 200
 
 
 class PaginationParameters(BaseModel):


### PR DESCRIPTION
### Changes
This is a quick fix so katalogus works with up to 200 normalizers/boefjes until we fix this properly

### Issue link
Temporary fix for #2724

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
