### PR TITLE
Fix wrong type in save_raw and list_origin_parameters httpx params

### DIFF
--- a/boefjes/boefjes/clients/bytes_client.py
+++ b/boefjes/boefjes/clients/bytes_client.py
@@ -5,7 +5,7 @@ from functools import wraps
 from typing import Any
 from uuid import UUID
 
-from httpx import Client, HTTPError, HTTPStatusError, HTTPTransport, Response
+from httpx import Client, HTTPStatusError, HTTPTransport, Response
 
 from boefjes.job_models import BoefjeMeta, NormalizerMeta, RawDataMeta
 
@@ -51,7 +51,7 @@ class BytesAPIClient:
     def _verify_response(response: Response) -> None:
         try:
             response.raise_for_status()
-        except HTTPError as error:
+        except HTTPStatusError as error:
             if error.response.status_code != 401:
                 logger.error(response.text)
             else:

--- a/mula/scheduler/connectors/services/services.py
+++ b/mula/scheduler/connectors/services/services.py
@@ -77,7 +77,7 @@ class HTTPService(Connector):
         self.source: str = source
 
         if self.source:
-            self.headers["User-Agent"] = self.source
+            self.session.headers["User-Agent"] = self.source
 
         self._do_checks()
 
@@ -149,7 +149,7 @@ class HTTPService(Connector):
         return response
 
     @property
-    def headers(self) -> MutableMapping[str, str | bytes]:
+    def headers(self) -> MutableMapping[str, str]:
         return self.session.headers
 
     def _do_checks(self) -> None:

--- a/octopoes/octopoes/connector/octopoes.py
+++ b/octopoes/octopoes/connector/octopoes.py
@@ -199,7 +199,7 @@ class OctopoesAPIConnector:
         self.session.post(f"/{self.client}/objects/delete_many", params=params, json=[str(ref) for ref in references])
 
     def list_origin_parameters(self, origin_id: set[str], valid_time: datetime) -> list[OriginParameter]:
-        params = {"origin_id": origin_id, "valid_time": str(valid_time)}
+        params = {"origin_id": list(origin_id), "valid_time": str(valid_time)}
         res = self.session.get(f"/{self.client}/origin_parameters", params=params)
         return TypeAdapter(list[OriginParameter]).validate_json(res.content)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,9 @@ disallow_untyped_defs = false
 no_implicit_reexport = false
 warn_return_any = false
 
+[[tool.mypy.overrides]]
+module = ["httpx.*"]
+follow_imports = "normal"
 
 [tool.setuptools_scm]
 write_to = "_version.py"

--- a/rocky/rocky/bytes_client.py
+++ b/rocky/rocky/bytes_client.py
@@ -106,7 +106,7 @@ class BytesClient:
             "/bytes/raw",
             content=raw,
             headers={"content-type": "application/octet-stream"},
-            params={"mime_types": mime_types, "boefje_meta_id": str(boefje_meta_id)},
+            params={"mime_types": list(mime_types), "boefje_meta_id": str(boefje_meta_id)},
         )
 
         response.raise_for_status()


### PR DESCRIPTION
### Changes
This fixes `save_raw` of the bytes client so that is converts the set to a list before doing the request. Httpx doesn't covert a set to a list and will instead send the string representation of the set.

It also fixes the same issue for octopoes connector `list_origin_parameters`.

This wasn't catched by mypy because the "follow_imports" is still set to "skip" instead of "normal". I've whitelisted following httpx imports and fixed the resulting typing errors.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
