### PR TITLE
Fix missing cipher csv in Debian package

### DIFF
--- a/octopoes/MANIFEST.in
+++ b/octopoes/MANIFEST.in
@@ -1,1 +1,1 @@
-recursive-include bits/ *.json
+recursive-include bits/ *.json *.csv


### PR DESCRIPTION
### Changes
The cipher csv was not included in the Debian package because `*.csv` wasn't listed in the MANIFEST.in.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
