### PR TITLE
Set no limit by default in the KATalogus plugin API

### DIFF
--- a/boefjes/boefjes/katalogus/dependencies/plugins.py
+++ b/boefjes/boefjes/katalogus/dependencies/plugins.py
@@ -18,7 +18,7 @@ from boefjes.katalogus.storage.interfaces import (
     SettingsNotConformingToSchema,
     SettingsStorage,
 )
-from boefjes.katalogus.types import LIMIT, FilterParameters, PaginationParameters
+from boefjes.katalogus.types import FilterParameters, PaginationParameters
 from boefjes.sql.db import session_managed_iterator
 from boefjes.sql.plugin_enabled_storage import create_plugin_enabled_storage
 from boefjes.sql.repository_storage import create_repository_storage
@@ -205,7 +205,7 @@ def get_plugin_service(organisation_id: str) -> Iterator[PluginService]:
     yield from session_managed_iterator(closure)
 
 
-def get_pagination_parameters(offset: int = 0, limit: int | None = LIMIT) -> PaginationParameters:
+def get_pagination_parameters(offset: int = 0, limit: int | None = None) -> PaginationParameters:
     return PaginationParameters(offset=offset, limit=limit)
 
 

--- a/boefjes/boefjes/katalogus/routers/plugins.py
+++ b/boefjes/boefjes/katalogus/routers/plugins.py
@@ -57,12 +57,13 @@ def list_plugins(
         plugins = filter(lambda x: x.enabled is filter_params.state, plugins)
 
     # filter plugins by scan level for boefje plugins
-    plugins = filter(lambda x: x.type != "boefje" or x.scan_level >= filter_params.scan_level, plugins)
+    plugins = list(filter(lambda x: x.type != "boefje" or x.scan_level >= filter_params.scan_level, plugins))
+
+    if pagination_params.limit is None:
+        return plugins[pagination_params.offset :]
 
     # paginate plugins
-    plugins = list(plugins)[pagination_params.offset : pagination_params.offset + pagination_params.limit]
-
-    return plugins
+    return plugins[pagination_params.offset : pagination_params.offset + pagination_params.limit]
 
 
 @router.get("/plugins/{plugin_id}", response_model=PluginType)

--- a/boefjes/boefjes/katalogus/types.py
+++ b/boefjes/boefjes/katalogus/types.py
@@ -6,12 +6,10 @@ from pydantic import BaseModel
 KATALOGUS_DIR = Path(__file__).parent
 STATIC_DIR = KATALOGUS_DIR / "static"
 
-LIMIT = 200
-
 
 class PaginationParameters(BaseModel):
     offset: int = 0
-    limit: int = LIMIT
+    limit: int | None = None
 
 
 class FilterParameters(BaseModel):


### PR DESCRIPTION
### Changes
A small default change to resolve the issue of not seeing all boefjes in a more future proof way.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/2724

### Demo and QA notes

Should not change any current behavior and is therefore hard to QA. We should verify if the KATalogus is still working properly in Rocky perhaps.

---

### Code Checklist
- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [x] I have written unit tests for the changes or fixes I made.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have made corresponding changes to the documentation, if necessary.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---
## Checklist for code reviewers:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---
## Checklist for QA:
Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
