### PR TITLE
Fix empty consumes of boefjes will trigger tasks in scheduler

### DIFF
--- a/mula/scheduler/connectors/services/katalogus.py
+++ b/mula/scheduler/connectors/services/katalogus.py
@@ -26,23 +26,17 @@ class Katalogus(HTTPService):
 
         # For every organisation we cache its plugins, it references the
         # plugin-id as key and the plugin as value.
-        self.organisations_plugin_cache: dict_utils.ExpiringDict = (
-            dict_utils.ExpiringDict(lifetime=cache_ttl)
-        )
+        self.organisations_plugin_cache: dict_utils.ExpiringDict = dict_utils.ExpiringDict(lifetime=cache_ttl)
 
         # For every organisation we cache on which type of object (consumes)
         # the boefjes consume, it references the object type (consumes)
         # as the key and a dict of boefjes as value.
-        self.organisations_boefje_type_cache: dict_utils.ExpiringDict = (
-            dict_utils.ExpiringDict(lifetime=cache_ttl)
-        )
+        self.organisations_boefje_type_cache: dict_utils.ExpiringDict = dict_utils.ExpiringDict(lifetime=cache_ttl)
 
         # For every organisation we cache on which type of object (consumes)
         # the normalizers consume, it references the object type (consumes)
         # as the key and a dict of normalizers as value.
-        self.organisations_normalizer_type_cache: dict_utils.ExpiringDict = (
-            dict_utils.ExpiringDict(lifetime=cache_ttl)
-        )
+        self.organisations_normalizer_type_cache: dict_utils.ExpiringDict = dict_utils.ExpiringDict(lifetime=cache_ttl)
 
         # For every organisation we cache which new boefjes for an organisation
         # have been enabled.
@@ -71,9 +65,7 @@ class Katalogus(HTTPService):
                     self.organisations_new_boefjes_cache[org.id] = {}
 
                 plugins = self.get_plugins_by_organisation(org.id)
-                self.organisations_plugin_cache[org.id] = {
-                    plugin.id: plugin for plugin in plugins if plugin.enabled
-                }
+                self.organisations_plugin_cache[org.id] = {plugin.id: plugin for plugin in plugins if plugin.enabled}
 
             self.organisations_plugin_cache.expiration_enabled = True
 
@@ -105,15 +97,11 @@ class Katalogus(HTTPService):
                     # NOTE: backwards compatibility, when it is a boefje the
                     # consumes field is a string field.
                     if isinstance(plugin.consumes, str):
-                        self.organisations_boefje_type_cache[org.id].setdefault(
-                            plugin.consumes, []
-                        ).append(plugin)
+                        self.organisations_boefje_type_cache[org.id].setdefault(plugin.consumes, []).append(plugin)
                         continue
 
                     for type_ in plugin.consumes:
-                        self.organisations_boefje_type_cache[org.id].setdefault(
-                            type_, []
-                        ).append(plugin)
+                        self.organisations_boefje_type_cache[org.id].setdefault(type_, []).append(plugin)
 
             self.organisations_boefje_type_cache.expiration_enabled = True
 
@@ -121,9 +109,7 @@ class Katalogus(HTTPService):
 
     def flush_organisations_normalizer_type_cache(self) -> None:
         """normalizer.consumes -> plugin type normalizer"""
-        self.logger.debug(
-            "Flushing the katalogus normalizer type cache for organisations"
-        )
+        self.logger.debug("Flushing the katalogus normalizer type cache for organisations")
 
         with self.lock:
             # First, we reset the cache, to make sure we won't get any ExpiredError
@@ -145,15 +131,11 @@ class Katalogus(HTTPService):
                         continue
 
                     for type_ in plugin.consumes:
-                        self.organisations_normalizer_type_cache[org.id].setdefault(
-                            type_, []
-                        ).append(plugin)
+                        self.organisations_normalizer_type_cache[org.id].setdefault(type_, []).append(plugin)
 
             self.organisations_normalizer_type_cache.expiration_enabled = True
 
-        self.logger.debug(
-            "Flushed the katalogus normalizer type cache for organisations"
-        )
+        self.logger.debug("Flushed the katalogus normalizer type cache for organisations")
 
     @exception_handler
     def get_boefjes(self) -> list[Boefje]:
@@ -177,9 +159,7 @@ class Katalogus(HTTPService):
     def get_organisations(self) -> list[Organisation]:
         url = f"{self.host}/v1/organisations"
         response = self.get(url)
-        return [
-            Organisation(**organisation) for organisation in response.json().values()
-        ]
+        return [Organisation(**organisation) for organisation in response.json().values()]
 
     def get_plugins_by_organisation(self, organisation_id: str) -> list[Plugin]:
         url = f"{self.host}/v1/organisations/{organisation_id}/plugins"
@@ -189,46 +169,28 @@ class Katalogus(HTTPService):
     def get_plugins_by_org_id(self, organisation_id: str) -> list[Plugin]:
         try:
             with self.lock:
-                return dict_utils.deep_get(
-                    self.organisations_plugin_cache, [organisation_id]
-                )
+                return dict_utils.deep_get(self.organisations_plugin_cache, [organisation_id])
         except dict_utils.ExpiredError:
             self.flush_organisations_plugin_cache()
-            return dict_utils.deep_get(
-                self.organisations_plugin_cache, [organisation_id]
-            )
+            return dict_utils.deep_get(self.organisations_plugin_cache, [organisation_id])
 
-    def get_plugin_by_id_and_org_id(
-        self, plugin_id: str, organisation_id: str
-    ) -> Plugin:
+    def get_plugin_by_id_and_org_id(self, plugin_id: str, organisation_id: str) -> Plugin:
         try:
             with self.lock:
-                return dict_utils.deep_get(
-                    self.organisations_plugin_cache, [organisation_id, plugin_id]
-                )
+                return dict_utils.deep_get(self.organisations_plugin_cache, [organisation_id, plugin_id])
         except dict_utils.ExpiredError:
             self.flush_organisations_plugin_cache()
-            return dict_utils.deep_get(
-                self.organisations_plugin_cache, [organisation_id, plugin_id]
-            )
+            return dict_utils.deep_get(self.organisations_plugin_cache, [organisation_id, plugin_id])
 
-    def get_boefjes_by_type_and_org_id(
-        self, boefje_type: str, organisation_id: str
-    ) -> list[Plugin]:
+    def get_boefjes_by_type_and_org_id(self, boefje_type: str, organisation_id: str) -> list[Plugin]:
         try:
             with self.lock:
-                return dict_utils.deep_get(
-                    self.organisations_boefje_type_cache, [organisation_id, boefje_type]
-                )
+                return dict_utils.deep_get(self.organisations_boefje_type_cache, [organisation_id, boefje_type])
         except dict_utils.ExpiredError:
             self.flush_organisations_boefje_type_cache()
-            return dict_utils.deep_get(
-                self.organisations_boefje_type_cache, [organisation_id, boefje_type]
-            )
+            return dict_utils.deep_get(self.organisations_boefje_type_cache, [organisation_id, boefje_type])
 
-    def get_normalizers_by_org_id_and_type(
-        self, organisation_id: str, normalizer_type: str
-    ) -> list[Plugin]:
+    def get_normalizers_by_org_id_and_type(self, organisation_id: str, normalizer_type: str) -> list[Plugin]:
         try:
             with self.lock:
                 return dict_utils.deep_get(
@@ -254,9 +216,7 @@ class Katalogus(HTTPService):
         # Check if there are new boefjes
         new_boefjes = []
         for boefje_id, boefje in enabled_boefjes.items():
-            if boefje_id in self.organisations_new_boefjes_cache.get(
-                organisation_id, {}
-            ):
+            if boefje_id in self.organisations_new_boefjes_cache.get(organisation_id, {}):
                 continue
 
             new_boefjes.append(boefje)

--- a/mula/scheduler/schedulers/boefje.py
+++ b/mula/scheduler/schedulers/boefje.py
@@ -215,9 +215,7 @@ class BoefjeScheduler(Scheduler):
         boefjes can run on, and create tasks for it."""
         new_boefjes = None
         try:
-            new_boefjes = self.ctx.services.katalogus.get_new_boefjes_by_org_id(
-                self.organisation.id
-            )
+            new_boefjes = self.ctx.services.katalogus.get_new_boefjes_by_org_id(self.organisation.id)
         except ExternalServiceError:
             self.logger.error(
                 "Failed to get new boefjes for organisation: %s from katalogus",
@@ -249,12 +247,10 @@ class BoefjeScheduler(Scheduler):
 
             oois_by_object_type: list[OOI] = []
             try:
-                oois_by_object_type = (
-                    self.ctx.services.octopoes.get_objects_by_object_types(
-                        self.organisation.id,
-                        boefje.consumes,
-                        list(range(boefje.scan_level, 5)),
-                    )
+                oois_by_object_type = self.ctx.services.octopoes.get_objects_by_object_types(
+                    self.organisation.id,
+                    boefje.consumes,
+                    list(range(boefje.scan_level, 5)),
                 )
             except ExternalServiceError as exc:
                 self.logger.error(
@@ -483,8 +479,7 @@ class BoefjeScheduler(Scheduler):
             and (
                 task_db.modified_at is not None
                 and task_db.modified_at
-                > datetime.now(timezone.utc)
-                - timedelta(seconds=self.ctx.config.pq_grace_period)
+                > datetime.now(timezone.utc) - timedelta(seconds=self.ctx.config.pq_grace_period)
             )
         ):
             self.logger.error(
@@ -497,11 +492,7 @@ class BoefjeScheduler(Scheduler):
             )
             raise RuntimeError("Task has been finished, but no results found in bytes")
 
-        if (
-            task_bytes is not None
-            and task_bytes.ended_at is None
-            and task_bytes.started_at is not None
-        ):
+        if task_bytes is not None and task_bytes.ended_at is None and task_bytes.started_at is not None:
             self.logger.debug(
                 "Task is still running, according to bytes",
                 task_id=task_bytes.id,
@@ -542,8 +533,7 @@ class BoefjeScheduler(Scheduler):
             and (
                 task_db.modified_at is not None
                 and datetime.now(timezone.utc)
-                > task_db.modified_at
-                + timedelta(seconds=self.ctx.config.pq_grace_period)
+                > task_db.modified_at + timedelta(seconds=self.ctx.config.pq_grace_period)
             )
         ):
             return True
@@ -615,9 +605,7 @@ class BoefjeScheduler(Scheduler):
                 )
 
                 # Update task in datastore to be failed
-                task_db = self.ctx.datastores.task_store.get_latest_task_by_hash(
-                    task.hash
-                )
+                task_db = self.ctx.datastores.task_store.get_latest_task_by_hash(task.hash)
                 task_db.status = TaskStatus.FAILED
                 self.ctx.datastores.task_store.update_task(task_db)
         except Exception as exc_stalled:
@@ -752,9 +740,9 @@ class BoefjeScheduler(Scheduler):
             raise exc_db
 
         # Has grace period passed according to datastore?
-        if task_db is not None and datetime.now(
-            timezone.utc
-        ) - task_db.modified_at < timedelta(seconds=self.ctx.config.pq_grace_period):
+        if task_db is not None and datetime.now(timezone.utc) - task_db.modified_at < timedelta(
+            seconds=self.ctx.config.pq_grace_period
+        ):
             self.logger.debug(
                 "Task has not passed grace period, according to the datastore",
                 task_id=task_db.id,
@@ -784,8 +772,7 @@ class BoefjeScheduler(Scheduler):
         if (
             task_bytes is not None
             and task_bytes.ended_at is not None
-            and datetime.now(timezone.utc) - task_bytes.ended_at
-            < timedelta(seconds=self.ctx.config.pq_grace_period)
+            and datetime.now(timezone.utc) - task_bytes.ended_at < timedelta(seconds=self.ctx.config.pq_grace_period)
         ):
             self.logger.debug(
                 "Task has not passed grace period, according to bytes",

--- a/mula/scheduler/schedulers/boefje.py
+++ b/mula/scheduler/schedulers/boefje.py
@@ -234,6 +234,13 @@ class BoefjeScheduler(Scheduler):
             )
             return
 
+        self.logger.debug(
+            "Received new boefjes",
+            boefjes=[boefje.name for boefje in new_boefjes],
+            organisation_id=self.organisation.id,
+            scheduler_id=self.scheduler_id,
+        )
+
         for boefje in new_boefjes:
             if not boefje.consumes:
                 self.logger.debug(

--- a/mula/scheduler/schedulers/boefje.py
+++ b/mula/scheduler/schedulers/boefje.py
@@ -215,7 +215,9 @@ class BoefjeScheduler(Scheduler):
         boefjes can run on, and create tasks for it."""
         new_boefjes = None
         try:
-            new_boefjes = self.ctx.services.katalogus.get_new_boefjes_by_org_id(self.organisation.id)
+            new_boefjes = self.ctx.services.katalogus.get_new_boefjes_by_org_id(
+                self.organisation.id
+            )
         except ExternalServiceError:
             self.logger.error(
                 "Failed to get new boefjes for organisation: %s from katalogus",
@@ -234,20 +236,25 @@ class BoefjeScheduler(Scheduler):
             )
             return
 
-        self.logger.debug(
-            "Received new boefjes",
-            boefjes=[boefje.name for boefje in new_boefjes],
-            organisation_id=self.organisation.id,
-            scheduler_id=self.scheduler_id,
-        )
-
         for boefje in new_boefjes:
+            if not boefje.consumes:
+                self.logger.debug(
+                    "No consumes found for boefje: %s",
+                    boefje.name,
+                    boefje_id=boefje.id,
+                    organisation_id=self.organisation.id,
+                    scheduler_id=self.scheduler_id,
+                )
+                continue
+
             oois_by_object_type: list[OOI] = []
             try:
-                oois_by_object_type = self.ctx.services.octopoes.get_objects_by_object_types(
-                    self.organisation.id,
-                    boefje.consumes,
-                    list(range(boefje.scan_level, 5)),
+                oois_by_object_type = (
+                    self.ctx.services.octopoes.get_objects_by_object_types(
+                        self.organisation.id,
+                        boefje.consumes,
+                        list(range(boefje.scan_level, 5)),
+                    )
                 )
             except ExternalServiceError as exc:
                 self.logger.error(
@@ -476,7 +483,8 @@ class BoefjeScheduler(Scheduler):
             and (
                 task_db.modified_at is not None
                 and task_db.modified_at
-                > datetime.now(timezone.utc) - timedelta(seconds=self.ctx.config.pq_grace_period)
+                > datetime.now(timezone.utc)
+                - timedelta(seconds=self.ctx.config.pq_grace_period)
             )
         ):
             self.logger.error(
@@ -489,7 +497,11 @@ class BoefjeScheduler(Scheduler):
             )
             raise RuntimeError("Task has been finished, but no results found in bytes")
 
-        if task_bytes is not None and task_bytes.ended_at is None and task_bytes.started_at is not None:
+        if (
+            task_bytes is not None
+            and task_bytes.ended_at is None
+            and task_bytes.started_at is not None
+        ):
             self.logger.debug(
                 "Task is still running, according to bytes",
                 task_id=task_bytes.id,
@@ -530,7 +542,8 @@ class BoefjeScheduler(Scheduler):
             and (
                 task_db.modified_at is not None
                 and datetime.now(timezone.utc)
-                > task_db.modified_at + timedelta(seconds=self.ctx.config.pq_grace_period)
+                > task_db.modified_at
+                + timedelta(seconds=self.ctx.config.pq_grace_period)
             )
         ):
             return True
@@ -602,7 +615,9 @@ class BoefjeScheduler(Scheduler):
                 )
 
                 # Update task in datastore to be failed
-                task_db = self.ctx.datastores.task_store.get_latest_task_by_hash(task.hash)
+                task_db = self.ctx.datastores.task_store.get_latest_task_by_hash(
+                    task.hash
+                )
                 task_db.status = TaskStatus.FAILED
                 self.ctx.datastores.task_store.update_task(task_db)
         except Exception as exc_stalled:
@@ -737,9 +752,9 @@ class BoefjeScheduler(Scheduler):
             raise exc_db
 
         # Has grace period passed according to datastore?
-        if task_db is not None and datetime.now(timezone.utc) - task_db.modified_at < timedelta(
-            seconds=self.ctx.config.pq_grace_period
-        ):
+        if task_db is not None and datetime.now(
+            timezone.utc
+        ) - task_db.modified_at < timedelta(seconds=self.ctx.config.pq_grace_period):
             self.logger.debug(
                 "Task has not passed grace period, according to the datastore",
                 task_id=task_db.id,
@@ -769,7 +784,8 @@ class BoefjeScheduler(Scheduler):
         if (
             task_bytes is not None
             and task_bytes.ended_at is not None
-            and datetime.now(timezone.utc) - task_bytes.ended_at < timedelta(seconds=self.ctx.config.pq_grace_period)
+            and datetime.now(timezone.utc) - task_bytes.ended_at
+            < timedelta(seconds=self.ctx.config.pq_grace_period)
         ):
             self.logger.debug(
                 "Task has not passed grace period, according to bytes",

--- a/mula/tests/integration/test_boefje_scheduler.py
+++ b/mula/tests/integration/test_boefje_scheduler.py
@@ -1332,8 +1332,6 @@ class NewBoefjesTestCase(BoefjeSchedulerBaseTestCase):
 
     def test_push_tasks_for_new_boefjes_empty_consumes_no_ooi(self):
         # Arrange
-        scan_profile = ScanProfileFactory(level=0)
-        ooi = OOIFactory(scan_profile=scan_profile)
         boefje = PluginFactory(scan_level=0, consumes=[])
 
         # Mocks

--- a/mula/tests/integration/test_boefje_scheduler.py
+++ b/mula/tests/integration/test_boefje_scheduler.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import mock
 
-from scheduler import config, connectors, models, schedulers, storage
 from structlog.testing import capture_logs
 
+from scheduler import config, connectors, models, schedulers, storage
 from tests.factories import (
     BoefjeFactory,
     BoefjeMetaFactory,
@@ -59,7 +59,9 @@ class BoefjeSchedulerBaseTestCase(unittest.TestCase):
         self.mock_ctx.datastores = SimpleNamespace(
             **{
                 storage.TaskStore.name: storage.TaskStore(self.dbconn),
-                storage.PriorityQueueStore.name: storage.PriorityQueueStore(self.dbconn),
+                storage.PriorityQueueStore.name: storage.PriorityQueueStore(
+                    self.dbconn
+                ),
             }
         )
 
@@ -109,7 +111,9 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
 
         # Act
         with capture_logs() as cm:
-            allowed_to_run = self.scheduler.is_task_allowed_to_run(ooi=ooi, boefje=boefje)
+            allowed_to_run = self.scheduler.is_task_allowed_to_run(
+                ooi=ooi, boefje=boefje
+            )
 
         # Assert
         self.assertFalse(allowed_to_run)
@@ -256,7 +260,9 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         )
 
         # Mock
-        self.mock_get_latest_task_by_hash.side_effect = Exception("Something went wrong")
+        self.mock_get_latest_task_by_hash.side_effect = Exception(
+            "Something went wrong"
+        )
         self.mock_get_last_run_boefje.return_value = None
 
         # Act
@@ -398,7 +404,8 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
             p_item=p_item,
             status=models.TaskStatus.DISPATCHED,
             created_at=datetime.now(timezone.utc),
-            modified_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            modified_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         # Mock
@@ -477,7 +484,8 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
             p_item=p_item,
             status=models.TaskStatus.COMPLETED,
             created_at=datetime.now(timezone.utc),
-            modified_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            modified_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         # Mock
@@ -513,7 +521,8 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
             p_item=p_item,
             status=models.TaskStatus.COMPLETED,
             created_at=datetime.now(timezone.utc),
-            modified_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            modified_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         # Mock
@@ -591,13 +600,15 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
             p_item=p_item,
             status=models.TaskStatus.COMPLETED,
             created_at=datetime.now(timezone.utc),
-            modified_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            modified_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         last_run_boefje = BoefjeMetaFactory(
             boefje=boefje,
             input_ooi=ooi.primary_key,
-            ended_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            ended_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         # Mock
@@ -636,7 +647,8 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
             p_item=p_item,
             status=models.TaskStatus.COMPLETED,
             created_at=datetime.now(timezone.utc),
-            modified_at=datetime.now(timezone.utc) - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
+            modified_at=datetime.now(timezone.utc)
+            - timedelta(seconds=self.mock_ctx.config.pq_grace_period),
         )
 
         last_run_boefje = BoefjeMetaFactory(
@@ -693,7 +705,9 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         with capture_logs() as cm:
             self.scheduler.push_task(boefje, ooi)
 
-        self.assertIn("Could not add task to queue, queue was full", cm[-1].get("event"))
+        self.assertIn(
+            "Could not add task to queue, queue was full", cm[-1].get("event")
+        )
         self.assertEqual(1, self.scheduler.queue.qsize())
 
     @mock.patch("scheduler.schedulers.BoefjeScheduler.is_task_stalled")
@@ -891,7 +905,9 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         self.assertEqual(0, self.scheduler.queue.qsize())
 
         # All tasks on queue should be set to CANCELLED
-        tasks, _ = self.mock_ctx.datastores.task_store.get_tasks(self.scheduler.scheduler_id)
+        tasks, _ = self.mock_ctx.datastores.task_store.get_tasks(
+            self.scheduler.scheduler_id
+        )
         for task in tasks:
             self.assertEqual(task.status, models.TaskStatus.CANCELLED)
 
@@ -1049,7 +1065,9 @@ class ScanProfileTestCase(BoefjeSchedulerBaseTestCase):
     def test_push_tasks_for_scan_profile_mutations_value_empty(self):
         """When the value of a mutation is empty it should not push any tasks"""
         # Arrange
-        mutation = models.ScanProfileMutation(operation="create", primary_key="123", value=None).model_dump_json()
+        mutation = models.ScanProfileMutation(
+            operation="create", primary_key="123", value=None
+        ).model_dump_json()
 
         # Act
         self.scheduler.push_tasks_for_scan_profile_mutations(mutation)
@@ -1287,8 +1305,12 @@ class NewBoefjesTestCase(BoefjeSchedulerBaseTestCase):
 
         # Mocks
         self.mock_get_objects_by_object_types.side_effect = [
-            connectors.errors.ExternalServiceError("External service is not available."),
-            connectors.errors.ExternalServiceError("External service is not available."),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
         ]
         self.mock_get_new_boefjes_by_org_id.return_value = [boefje]
 
@@ -1307,6 +1329,38 @@ class NewBoefjesTestCase(BoefjeSchedulerBaseTestCase):
         # Mocks
         self.mock_get_objects_by_object_types.return_value = [ooi]
         self.mock_get_new_boefjes_by_org_id.return_value = []
+
+        # Act
+        self.scheduler.push_tasks_for_new_boefjes()
+
+        # Task should not be on priority queue
+        self.assertEqual(0, self.scheduler.queue.qsize())
+
+    def test_push_tasks_for_new_boefjes_empty_consumes(self):
+        # Arrange
+        scan_profile = ScanProfileFactory(level=0)
+        ooi = OOIFactory(scan_profile=scan_profile)
+        boefje = PluginFactory(scan_level=0, consumes=[])
+
+        # Mocks
+        self.mock_get_objects_by_object_types.return_value = [ooi]
+        self.mock_get_new_boefjes_by_org_id.return_value = [boefje]
+
+        # Act
+        self.scheduler.push_tasks_for_new_boefjes()
+
+        # Task should not be on priority queue
+        self.assertEqual(0, self.scheduler.queue.qsize())
+
+    def test_push_tasks_for_new_boefjes_empty_consumes_no_ooi(self):
+        # Arrange
+        scan_profile = ScanProfileFactory(level=0)
+        ooi = OOIFactory(scan_profile=scan_profile)
+        boefje = PluginFactory(scan_level=0, consumes=[])
+
+        # Mocks
+        self.mock_get_objects_by_object_types.return_value = []
+        self.mock_get_new_boefjes_by_org_id.return_value = [boefje]
 
         # Act
         self.scheduler.push_tasks_for_new_boefjes()
@@ -1338,8 +1392,12 @@ class NewBoefjesTestCase(BoefjeSchedulerBaseTestCase):
 
         # Mocks
         self.mock_get_objects_by_object_types.side_effect = [
-            connectors.errors.ExternalServiceError("External service is not available."),
-            connectors.errors.ExternalServiceError("External service is not available."),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
         ]
         self.mock_get_new_boefjes_by_org_id.return_value = [boefje]
 
@@ -1435,7 +1493,9 @@ class RandomObjectsTestCase(BoefjeSchedulerBaseTestCase):
             return_value=True,
         ).start()
 
-        self.mock_get_boefjes_for_ooi = mock.patch("scheduler.schedulers.BoefjeScheduler.get_boefjes_for_ooi").start()
+        self.mock_get_boefjes_for_ooi = mock.patch(
+            "scheduler.schedulers.BoefjeScheduler.get_boefjes_for_ooi"
+        ).start()
 
         self.mock_get_random_objects = mock.patch(
             "scheduler.context.AppContext.services.octopoes.get_random_objects"
@@ -1491,8 +1551,12 @@ class RandomObjectsTestCase(BoefjeSchedulerBaseTestCase):
 
         # Mocks
         self.mock_get_random_objects.side_effect = [
-            connectors.errors.ExternalServiceError("External service is not available."),
-            connectors.errors.ExternalServiceError("External service is not available."),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
+            connectors.errors.ExternalServiceError(
+                "External service is not available."
+            ),
         ]
 
         # Act


### PR DESCRIPTION
### Changes

When a boefje gets enabled the scheduler will check whether this boefje can run on ooi's that allow this boefje to run on. To do that the scheduler checks what types a boefje can consume. The scheduler will ask octopoes to return those ooi's. When the `consumes` field of a boefje is empty it will ask octopoes to return ooi's and it will do so when an empty list is provided.

This PR adds a check before the scheduler will ask octopoes to return ooi's, it will check if the `consumes` field is empty or not and will not request octopoes for ooi's when it is.

### Issue link

Closes [#3015](https://github.com/minvws/nl-kat-coordination/issues/3015)

### QA steps

From what I can see it is not possible to set the consumes of a boefje to an empty list from the webapp. In order to make sure that everything should be working as intended, is to enable a boefje and make sure that the types the ooi's consumes, tasks are being created for ooi's of that type.
