### PR TITLE
Add help functionality texts to xtdb-cli tool

### DIFF
--- a/octopoes/tools/xtdb-cli.py
+++ b/octopoes/tools/xtdb-cli.py
@@ -9,7 +9,6 @@ from xtdb_client import XTDBClient
 
 logger = logging.getLogger(__name__)
 
-
 @click.group(
     context_settings={
         "help_option_names": ["-h", "--help"],
@@ -34,6 +33,7 @@ logger = logging.getLogger(__name__)
 @click.option("-v", "--verbosity", count=True, help="Increase the verbosity level")
 @click.pass_context
 def cli(ctx: click.Context, url: str, node: str, timeout: int, verbosity: int):
+    """This help functionality explains how to query XTDB using the xtdb-cli tool. The help functionality for all default XTDB commands was copied from the official XTDB docs for the HTTP implementation. Not all optional parameters as available on the HTTP docs may be implemented."""
     verbosities = [logging.WARN, logging.INFO, logging.DEBUG]
     try:
         if verbosity:
@@ -48,7 +48,7 @@ def cli(ctx: click.Context, url: str, node: str, timeout: int, verbosity: int):
     ctx.obj["client"] = client
 
 
-@cli.command
+@cli.command(help="Returns the current status information of the node")
 @click.pass_context
 def status(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -84,10 +84,10 @@ def list_values(ctx: click.Context):
     click.echo(json.dumps(client.query("{:query {:find [(pull ?var [*])] :where [[?var :xt/id]]}}")))
 
 
-@cli.command
-@click.option("--tx-id", type=int)
-@click.option("--tx-time", type=click.DateTime())
-@click.option("--valid-time", type=click.DateTime())
+@cli.command(help="Returns the document map for a particular entity.")
+@click.option("--tx-id", type=int, help="Defaulting to latest transaction id (integer)")
+@click.option("--tx-time", type=click.DateTime(), help="Defaulting to latest transaction time (date)")
+@click.option("--valid-time", type=click.DateTime(), help="Defaulting to now (date)")
 @click.argument("key")
 @click.pass_context
 def entity(
@@ -102,9 +102,9 @@ def entity(
     click.echo(json.dumps(client.entity(key, valid_time, tx_time, tx_id)))
 
 
-@cli.command
-@click.option("--with-docs", is_flag=True)
-@click.option("--with-corrections", is_flag=True)
+@cli.command(help="Returns the history of a particular entity.")
+@click.option("--with-docs", is_flag=True, help="Includes the documents in the response sequence, under the doc key (boolean, default: false)")
+@click.option("--with-corrections", is_flag=True, help="Includes bitemporal corrections in the response, inline, sorted by valid-time then tx-id (boolean, default: false)")
 @click.argument("key")
 @click.pass_context
 def history(ctx: click.Context, key: str, with_corrections: bool, with_docs: bool):
@@ -113,10 +113,10 @@ def history(ctx: click.Context, key: str, with_corrections: bool, with_docs: boo
     click.echo(json.dumps(client.history(key, with_corrections, with_docs)))
 
 
-@cli.command
-@click.option("--tx-id", type=int)
-@click.option("--tx-time", type=click.DateTime())
-@click.option("--valid-time", type=click.DateTime())
+@cli.command(help="Returns the transaction details for an entity - returns a map containing the tx-id and tx-time.")
+@click.option("--tx-id", type=int, help="Defaulting to the latest transaction id (integer)")
+@click.option("--tx-time", type=click.DateTime(), help="Defaulting to the latest transaction time (date)")
+@click.option("--valid-time", type=click.DateTime(), help="Defaulting to now (date)")
 @click.argument("key")
 @click.pass_context
 def entity_tx(
@@ -131,7 +131,7 @@ def entity_tx(
     click.echo(json.dumps(client.entity_tx(key, valid_time, tx_time, tx_id)))
 
 
-@cli.command
+@cli.command(help="Returns frequencies of indexed attributes")
 @click.pass_context
 def attribute_stats(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -139,8 +139,8 @@ def attribute_stats(ctx: click.Context):
     click.echo(json.dumps(client.attribute_stats()))
 
 
-@cli.command
-@click.option("--timeout", type=int)
+@cli.command(help="Wait until the Kafka consumer’s lag is back to 0 (i.e. when it no longer has pending transactions to write). Returns the transaction time of the most recent transaction.")
+@click.option("--timeout", type=int, help="Specified in milliseconds (integer)")
 @click.pass_context
 def sync(ctx: click.Context, timeout: int | None):
     client: XTDBClient = ctx.obj["client"]
@@ -148,8 +148,8 @@ def sync(ctx: click.Context, timeout: int | None):
     click.echo(json.dumps(client.sync(timeout)))
 
 
-@cli.command
-@click.option("--timeout", type=int)
+@cli.command(help="Waits until the node has indexed a transaction that is at or past the supplied tx-id. Returns the most recent tx indexed by the node.")
+@click.option("--timeout", type=int, help="Specified in milliseconds, defaulting to 10 seconds (integer)")
 @click.argument("tx-id", type=int)
 @click.pass_context
 def await_tx(ctx: click.Context, tx_id: int, timeout: int | None):
@@ -158,8 +158,8 @@ def await_tx(ctx: click.Context, tx_id: int, timeout: int | None):
     click.echo(json.dumps(client.await_tx(tx_id, timeout)))
 
 
-@cli.command
-@click.option("--timeout", type=int)
+@cli.command(help="Blocks until the node has indexed a transaction that is past the supplied tx-time. The returned date is the latest index time when this node has caught up as of this call.")
+@click.option("--timeout", type=int, help="Specified in milliseconds, defaulting to 10 seconds (integer)")
 @click.argument("tx-time", type=click.DateTime())
 @click.pass_context
 def await_tx_time(
@@ -172,9 +172,9 @@ def await_tx_time(
     click.echo(json.dumps(client.await_tx_time(tx_time, timeout)))
 
 
-@cli.command
-@click.option("--with-ops", is_flag=True)
-@click.option("--after-tx-id", type=int)
+@cli.command(help="Returns a list of all transactions, from oldest to newest transaction time - optionally including documents.")
+@click.option("--with-ops", is_flag=True, help="Should the operations with documents be included? (boolean, default: false)")
+@click.option("--after-tx-id", type=int, help="Transaction id to start after (integer, default: unbounded)")
 @click.pass_context
 def tx_log(ctx: click.Context, after_tx_id: int | None, with_ops: bool):
     client: XTDBClient = ctx.obj["client"]
@@ -190,7 +190,7 @@ def txs(ctx: click.Context):
     click.echo(json.dumps(client.tx_log(None, True)))
 
 
-@cli.command
+@cli.command(help="Takes a vector of transactions (any combination of put, delete, match, evict and fn) and executes them in order. This is the only 'write' endpoint.")
 @click.argument("txs", nargs=-1)
 @click.pass_context
 def submit_tx(ctx: click.Context, txs):
@@ -199,7 +199,7 @@ def submit_tx(ctx: click.Context, txs):
     click.echo(json.dumps(client.submit_tx(txs)))
 
 
-@cli.command
+@cli.command(help="Checks if a submitted tx was successfully committed, returning a map with tx-committed and either true or false (or a NodeOutOfSyncException exception response if the node has not yet indexed the transaction).")
 @click.argument("tx-id", type=int)
 @click.pass_context
 def tx_committed(ctx: click.Context, tx_id: int) -> None:
@@ -208,7 +208,7 @@ def tx_committed(ctx: click.Context, tx_id: int) -> None:
     click.echo(json.dumps(client.tx_committed(tx_id)))
 
 
-@cli.command
+@cli.command(help="Returns the latest transaction to have been indexed by this node.")
 @click.pass_context
 def latest_completed_tx(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -216,7 +216,7 @@ def latest_completed_tx(ctx: click.Context):
     click.echo(json.dumps(client.latest_completed_tx()))
 
 
-@cli.command
+@cli.command(help="Returns the latest transaction to have been submitted to this cluster.")
 @click.pass_context
 def latest_submitted_tx(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -224,7 +224,7 @@ def latest_submitted_tx(ctx: click.Context):
     click.echo(json.dumps(client.latest_submitted_tx()))
 
 
-@cli.command
+@cli.command(help="Returns a list of currently running queries.")
 @click.pass_context
 def active_queries(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -232,7 +232,7 @@ def active_queries(ctx: click.Context):
     click.echo(json.dumps(client.active_queries()))
 
 
-@cli.command
+@cli.command(help="Returns a list of recently completed/failed queries.")
 @click.pass_context
 def recent_queries(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]
@@ -240,7 +240,7 @@ def recent_queries(ctx: click.Context):
     click.echo(json.dumps(client.recent_queries()))
 
 
-@cli.command
+@cli.command(help="Returns a list of slowest completed/failed queries ran on the node.")
 @click.pass_context
 def slowest_queries(ctx: click.Context):
     client: XTDBClient = ctx.obj["client"]


### PR DESCRIPTION
### Changes
This PR adds the help texts to the XTDB cli tool for all commands and optional arguments and a general description for the tool itself. Most of the CLI tool texts were copied and adjusted where necessary based on the XTDB HTTP documentation (https://v1-docs.xtdb.com/clients/1.24.3/http/)


### Issue link
This issue is part of the documentation for: #2866 

The current docs still need to be updated with an example of how to use the xtdb-cli tool. This will be picked up in a different PR. 

### Demo
```
$ ./xtdb-cli.py --help
Usage: xtdb-cli.py [OPTIONS] COMMAND [ARGS]...

  This help functionality explains how to query XTDB using the xtdb-cli tool. The help functionality for all default
  XTDB commands was copied from the official XTDB docs for the HTTP implementation. Not all optional parameters as
  available on the HTTP docs may be implemented.

Options:
  -n, --node TEXT        XTDB node  [default: 0]
  -u, --url TEXT         XTDB server base url  [default: http://localhost:3000]
  -t, --timeout INTEGER  XTDB request timeout (in ms)  [default: 5000]
  -v, --verbosity        Increase the verbosity level  [default: 0]
  -h, --help             Show this message and exit.

Commands:
  active-queries       Returns a list of currently running queries.
  attribute-stats      Returns frequencies of indexed attributes
  await-tx             Waits until the node has indexed a transaction that is at or past the supplied tx-id.
  await-tx-time        Blocks until the node has indexed a transaction that is past the supplied tx-time.
  entity               Returns the document map for a particular entity.
  entity-tx            Returns the transaction details for an entity - returns a map containing the tx-id and...
  history              Returns the history of a particular entity.
  latest-completed-tx  Returns the latest transaction to have been indexed by this node.
  latest-submitted-tx  Returns the latest transaction to have been submitted to this cluster.
  list-keys            List all keys in node
  list-values          List all values in node
  query                EDN Query (default: "{:query {:find [ ?var ] :where [[?var :xt/id ]]}}")
  recent-queries       Returns a list of recently completed/failed queries.
  slowest-queries      Returns a list of slowest completed/failed queries ran on the node.
  status               Returns the current status information of the node
  submit-tx            Takes a vector of transactions (any combination of put, delete, match, evict and fn) and...
  sync                 Wait until the Kafka consumer’s lag is back to 0 (i.e.
  tx-committed         Checks if a submitted tx was successfully committed, returning a map with tx-committed and...
  tx-log               Returns a list of all transactions, from oldest to newest transaction time - optionally...
  txs                  Show all document transactions
```

And now also with the helper text for the optional arguments: 
```
$ ./xtdb-cli.py history --help
Usage: xtdb-cli.py history [OPTIONS] KEY

  Returns the history of a particular entity.

Options:
  --with-docs         Includes the documents in the response sequence, under the doc key (boolean, default: false)
  --with-corrections  Includes bitemporal corrections in the response, inline, sorted by valid-time then tx-id
                      (boolean, default: false)
  -h, --help          Show this message and exit.
```

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication

- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
