### PR TITLE
Fixes text in secondary menu on scan profile detail page

### DIFF
--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -24,7 +24,7 @@
               of objects that inherit from this clearance level will also be recalculated.
             {% endblocktranslate %}
                     </p>
-                    {% if user.acknowledged_clearance_level > -1 and organization_indemnification and user.trusted_clearance_level > -1 %}
+                    {% if organization_member.acknowledged_clearance_level > -1 and organization_indemnification and organization_member.trusted_clearance_level > -1 %}
                         <div class="horizontal-view">
                             <a href="{% ooi_url "scan_profile_reset" ooi.reference organization.code query=mandatory_fields %}"
                                class="button">{% translate "Set clearance level to inherit" %}</a>
@@ -44,7 +44,7 @@
                     {% include "partials/explanations.html" %}
 
                 {% endif %}
-                {% if user.acknowledged_clearance_level > -1 and organization_indemnification and user.trusted_clearance_level > -1 %}
+                {% if organization_member.acknowledged_clearance_level > -1 and organization_indemnification and organization_member.trusted_clearance_level > -1 %}
                     <h2>{% translate "Set clearance level:" %}</h2>
                     <form id="set_clearance_level"
                           novalidate

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,7 +20,6 @@ class ScanProfileDetailView(OOIDetailView, FormView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        context["user"] = self.organization_member
         context["organization_indemnification"] = Indemnification.objects.filter(
             organization=self.organization
         ).exists()


### PR DESCRIPTION
### Changes

I removed to `user` override in `scan_profile.py` and refactored the usage accordingly in `scan_profile_detail.html`. This fixes the text in the "secondary menu" button in the top right corner (using users first letter).

### Issue link

Closes #2959 

### Demo

**Before:**
<img width="597" alt="Screenshot 2024-06-05 at 16 16 15" src="https://github.com/minvws/nl-kat-coordination/assets/16188579/620be0d4-507d-4372-ac7e-6595a3eb3d7a">

**After:**
<img width="597" alt="Screenshot 2024-06-05 at 16 15 25" src="https://github.com/minvws/nl-kat-coordination/assets/16188579/665cc150-94df-43e6-99ad-9feffa9b073f">


---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue; tickets have been created for newly discovered issues.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

### Communication

- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have made corresponding changes to the documentation, if necessary.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
