### PR TITLE
Update renderNormalizerOutputOOIs.js

### DIFF
--- a/rocky/assets/js/renderNormalizerOutputOOIs.js
+++ b/rocky/assets/js/renderNormalizerOutputOOIs.js
@@ -3,6 +3,7 @@ import { language, organization_code } from "./utils.js";
 const buttons = document.querySelectorAll(
   ".expando-button.normalizer-list-table-row",
 );
+const asyncoffset = 5; // time to allow for the database to actually safe the OOI's
 
 buttons.forEach((button) => {
   const raw_task_id = button.closest("tr").getAttribute("data-task-id");
@@ -80,10 +81,12 @@ buttons.forEach((button) => {
             "/" +
             escapeHTMLEntities(encodeURIComponent(organization_code));
           let object_list = "";
-
+          // set the observed at time a fews seconds into the future, as the job finish time is not the same as the ooi-creation time. Due to async reasons the object might be a bit slow.
+          data["timestamp"] = Date.parse(data["valid_time"]);
+          data["valid_time_async"] = new Date(data["timestamp"] + asyncoffset).toISOString().substring(0, 22);
           // Build HTML snippet for every yielded object.
           data["oois"].forEach((object) => {
-            object_list += `<li><a href='${url}/objects/detail/?observed_at=${data["valid_time"]}&ooi_id=${escapeHTMLEntities(encodeURIComponent(object))}'>${escapeHTMLEntities(object)}</a></li>`;
+            object_list += `<li><a href='${url}/objects/detail/?observed_at=${data["valid_time_async"]}&ooi_id=${escapeHTMLEntities(encodeURIComponent(object))}'>${escapeHTMLEntities(object)}</a></li>`;
           });
           element.innerHTML = `<ul>${object_list}</ul>`;
         } else {
@@ -107,4 +110,24 @@ function escapeHTMLEntities(input) {
   output = output.replace(/"/g, "&quot;");
   output = output.replace(/</g, "&lt;");
   return output.replace(/>/g, "&gt;");
+}
+
+function padTo2Digits(num) {
+  return num.toString().padStart(2, '0');
+}
+
+function formatDate(date) {
+  return (
+    [
+      date.getFullYear(),
+      padTo2Digits(date.getMonth() + 1),
+      padTo2Digits(date.getDate()),
+    ].join('-') +
+    'T' +
+    [
+      padTo2Digits(date.getHours()),
+      padTo2Digits(date.getMinutes()),
+      padTo2Digits(date.getSeconds()),
+    ].join(':')
+  );
 }


### PR DESCRIPTION
Adds a 5 second interval for the async mismatch between the job succes time and the possible OOI-creation/OOI-valid time.

### Changes

This change adds a 5 second offset to the normalizer OOI creation links. This is an ugly fix to hide the fact that we dont use the OOI-creation timestamp on the normaliser task list page, but rather the job-success timestamp which due to async reasons might not be the same.

### Issue link

Closes #2875 

### QA notes

Untested. unreviewed code.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
