### PR TITLE
Add workflow that builds containerized images on ghcr.io

### DIFF
--- a/.github/workflows/containerized_boefjes.yml
+++ b/.github/workflows/containerized_boefjes.yml
@@ -1,0 +1,69 @@
+name: Boefjes Create container image
+
+on:
+  push:
+    branches:
+      - "main"
+      - "release-*"
+    tags:
+      - "*"
+    paths:
+      - boefjes/boefjes/plugins/**
+      - boefjes/images/**
+      - .github/workflows/containerized_boefjes.yml
+  pull_request:
+    paths:
+      - boefjes/boefjes/plugins/kat_nmap_tcp/**
+      - boefjes/boefjes/plugins/kat_nmap_udp/**
+      - boefjes/boefjes/plugins/kat_dnssec/**
+      - boefjes/images/**
+      - .github/workflows/containerized_boefjes.yml
+
+jobs:
+  build_containerized_boefjes:
+    strategy:
+      matrix:
+        include:
+          - dockerfile: boefjes/boefjes/plugins/kat_nmap_tcp/boefje.Dockerfile
+            image: openkat/nmap
+          - dockerfile: boefjes/boefjes/plugins/kat_dnssec/boefje.Dockerfile
+            image: openkat/dns-sec
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository_owner }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        id: buildx
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build container image for ${{ matrix.image }}
+        uses: docker/build-push-action@v5
+        with:
+          # We don't use git context because that doesn't process .dockerignore
+          # https://github.com/docker/cli/issues/2827
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/boefjes/Makefile
+++ b/boefjes/Makefile
@@ -37,9 +37,9 @@ build: images
 
 images:  # Build the images for the containerized boefjes
   # Dns-records is disabled for now, see the discussion in https://github.com/minvws/nl-kat-coordination/pull/2709
-	# docker build -f images/base.Dockerfile -t openkat/dns-records --build-arg BOEFJE_PATH=./boefjes/plugins/kat_dns .
-	docker build -f ./boefjes/plugins/kat_dnssec/boefje.Dockerfile -t openkat/dns-sec .
-	docker build -f ./boefjes/plugins/kat_nmap_tcp/boefje.Dockerfile -t openkat/nmap  .
+	# docker build -f images/base.Dockerfile -t ghcr.io/minvws/openkat/dns-records --build-arg BOEFJE_PATH=./boefjes/plugins/kat_dns .
+	docker build -f ./boefjes/plugins/kat_dnssec/boefje.Dockerfile -t ghcr.io/minvws/openkat/dns-sec:latest .
+	docker build -f ./boefjes/plugins/kat_nmap_tcp/boefje.Dockerfile -t ghcr.io/minvws/openkat/nmap:latest  .
 
 
 ##

--- a/boefjes/boefjes/plugins/kat_dnssec/boefje.json
+++ b/boefjes/boefjes/plugins/kat_dnssec/boefje.json
@@ -6,5 +6,5 @@
     "Hostname"
   ],
   "scan_level": 1,
-  "oci_image": "openkat/dns-sec"
+  "oci_image": "ghcr.io/minvws/openkat/dns-sec:latest"
 }

--- a/boefjes/boefjes/plugins/kat_nmap_tcp/boefje.json
+++ b/boefjes/boefjes/plugins/kat_nmap_tcp/boefje.json
@@ -10,7 +10,7 @@
     "TOP_PORTS"
   ],
   "scan_level": 2,
-  "oci_image": "openkat/nmap",
+  "oci_image": "ghcr.io/minvws/openkat/nmap:latest",
   "oci_arguments": [
     "--open",
     "-T4",


### PR DESCRIPTION
### Changes

In this PR:
- Add workflow that builds containerized images using a matrix and the naming convention "openkat/{boefje_id}"
- Change the `make images` build step tag to the remote hosted image repository
- Change boefje.json files accordingly to support hosted images and local builds at the same time


### Demo

See the workflow output.

### QA notes

These boefjes should still work:
- nmap
- nmap-udp
- dns-sec

And the new workflow should succeed and build these two images:
- `ghcr.io/minvws/openkat/nmap`
- `ghcr.io/minvws/openkat/dns-sec`


---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
