### PR TITLE
Fix for Web System Report and Name Server Report

### DIFF
--- a/rocky/reports/templatetags/report_extra.py
+++ b/rocky/reports/templatetags/report_extra.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 @register.filter
 def sum_attribute(checks, attribute):
-    return sum(getattr(check, attribute) for check in checks if hasattr(check, attribute))
+    return sum(int(check[attribute]) for check in checks)
 
 
 @register.filter


### PR DESCRIPTION
### Changes
The function sum_attribute didn't work anymore, because "checks" are a dict now instead of an object.

### Issue link
Closes #3138 

### Demo
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/0128a3c7-6294-4cf1-a364-42c7b8a7be38)
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/1ece55bd-89b1-4c92-a235-5bb0ca5b587d)

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
