### PR TITLE
Concatinated report only shows one report

### DIFF
--- a/rocky/reports/views/base.py
+++ b/rocky/reports/views/base.py
@@ -508,8 +508,7 @@ class ViewReportView(ObservedAtMixin, OrganizationView, TemplateView):
             context["data"] = self.get_report_data_from_bytes(self.report_ooi)
             for report in children_reports:
                 for ooi in report.input_oois:
-                    report_data[report.report_type] = {}
-                    report_data[report.report_type][ooi] = {
+                    report_data.setdefault(report.report_type, {})[ooi] = {
                         "data": self.get_report_data_from_bytes(report)["report_data"],
                         "template": report.template,
                         "report_name": get_report_by_id(report.report_type).name,


### PR DESCRIPTION
### Changes
Fix for saving report, which only showed one report, even though multiple OOIs were selected.

Problem: `report_data[report.report_type][ooi] = {}` resets report_data every time.

### Issue link
Closes #3147 

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
