### PR TITLE
Sort subreports

### DIFF
--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -339,6 +339,8 @@ class ReportList:
             [report_id],
         )
 
+        subreports = sorted(subreports, key=lambda x: (x[1].report_type, x[1].input_oois))
+
         return subreports
 
     def hydrate_report_list(self, reports: list[Report]) -> list[HydratedReport]:


### PR DESCRIPTION
### Changes
Subreports were sorted on report ID, which made it hard to search in the table.

Subreports are now sorted first by report types and then by input_oois.

### Issue link
Closes #3141

### Demo
![afbeelding](https://github.com/minvws/nl-kat-coordination/assets/99282220/1ebd1a87-5d59-44dd-8da2-1e39772d8725)

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
