### PR TITLE
Fix/sonarcloud https redirect dockerfiles

### DIFF
--- a/packaging/debian12/Dockerfile
+++ b/packaging/debian12/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && mkdir -p /etc/apt/keyrings && \
-    curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /etc/apt/keyrings/nodesource.asc && \
+    curl --proto "=https" -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /etc/apt/keyrings/nodesource.asc && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_20.x bookworm main" > /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update && apt-get -y upgrade && \

--- a/packaging/ubuntu22.04/Dockerfile
+++ b/packaging/ubuntu22.04/Dockerfile
@@ -4,7 +4,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 SHELL ["/bin/bash", "-c"]
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && mkdir -p /etc/apt/keyrings && \
-    curl -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /etc/apt/keyrings/nodesource.asc && \
+    curl --proto "=https" -sL https://deb.nodesource.com/gpgkey/nodesource.gpg.key -o /etc/apt/keyrings/nodesource.asc && \
     echo "deb [signed-by=/etc/apt/keyrings/nodesource.asc] https://deb.nodesource.com/node_20.x jammy main" > /etc/apt/sources.list.d/nodesource.list
 
 RUN apt-get update && apt-get -y upgrade && \


### PR DESCRIPTION
### Changes

adds --proto "=https" to both curl calls to make sure we only accept https servers when  being redirected, this to avoid downgrades and subsequent mitm atacks.

### Issue link

https://sonarcloud.io/project/security_hotspots?id=minvws_nl-kat-coordination&hotspots=AY_dVhm5GgO8mB8X8BTU

### QA notes

Build should still work.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
