### PR TITLE
Always uppercase for CVE-api urls

### DIFF
--- a/boefjes/boefjes/plugins/kat_cve_finding_types/main.py
+++ b/boefjes/boefjes/plugins/kat_cve_finding_types/main.py
@@ -6,7 +6,7 @@ from boefjes.job_models import BoefjeMeta
 
 
 def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
-    cve_id = boefje_meta.arguments["input"]["id"]
+    cve_id = boefje_meta.arguments["input"]["id"].upper()
     cveapi_url = getenv("CVEAPI_URL", "https://cve.openkat.dev/v1")
     response = requests.get(f"{cveapi_url}/{cve_id}.json", timeout=30)
 


### PR DESCRIPTION
### Changes
A CVE ID with lowercase cve- would result in a 404.
This is now changed, and always transforms the CVE-id to uppercase for this api.

### Issue link

Found when QA-ing https://github.com/minvws/nl-kat-coordination/pull/3181

### QA notes

Reruning the error-ed / pending CVEFindingType jobs should work.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
