### PR TITLE
…

### DIFF
--- a/boefjes/tests/integration/test_settings_to_boefje_config_migration.py
+++ b/boefjes/tests/integration/test_settings_to_boefje_config_migration.py
@@ -37,6 +37,13 @@ class TestSettingsToBoefjeConfig(TestCase):
         ]
         query = f"INSERT INTO settings (id, values, plugin_id, organisation_pk) values {','.join(map(str, entries))}"  # noqa: S608
         self.engine.execute(text(query))
+
+        entries = [(1, "dns-records", True, 1)]
+        query = (
+            f"INSERT INTO plugin_state (id, plugin_id, enabled, organisation_pk) values {','.join(map(str, entries))}"
+        )
+        self.engine.execute(text(query))
+
         session.close()
 
     def test_fail_on_wrong_plugin_ids(self):


### PR DESCRIPTION
### Changes

Check for existence of plugins in the SQLAlchemy session, because a raw query bypasses any entities, hence creating duplicate objects

### Demo

See the integration test changes.

### QA notes

This is tricky to QA: you need to be on an older version of the main branch before https://github.com/minvws/nl-kat-coordination/pull/3118 was merged, build kat, enable dns-records and create settings for it, e.g. REMOTE_NS, and then switch to this PR and only restart :

```shell
git checkout 1ba89832a1b69157e29e4d6824b5c489749ffbc9  # last version before the PR merge
make kat
# Perform the steps described above in Rocky for dns-records: enable it and create settings
git checkout hotfix/migrating-with-duplicate-boefje-bug
docker compose restart boefje  # restarts should trigger migrations to run
```

And now check the boefje logs for exceptions and verify that the KATalogus works properly.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
