### PR TITLE
Backport: update nmap udp image as well

### DIFF
--- a/boefjes/boefjes/plugins/kat_nmap_udp/boefje.json
+++ b/boefjes/boefjes/plugins/kat_nmap_udp/boefje.json
@@ -10,7 +10,7 @@
     "TOP_PORTS_UDP"
   ],
   "scan_level": 2,
-  "oci_image": "openkat/nmap",
+  "oci_image": "ghcr.io/minvws/openkat/nmap:latest",
   "oci_arguments": [
     "--open",
     "-T4",


### PR DESCRIPTION
### Changes

The `nmap-udp` image hasn't been updated yet. This is also an issue on main, resolved in this hotfix PR for main, among other hotfixes: https://github.com/minvws/nl-kat-coordination/pull/3227

### Issue link
-

### Demo

-
### QA notes

This should make nmap-udp not crash on the release branch.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
