### PR TITLE
Remove action buttons on example boefjes at onboarding

### DIFF
--- a/rocky/onboarding/templates/step_3d_clearance_level_introduction.html
+++ b/rocky/onboarding/templates/step_3d_clearance_level_introduction.html
@@ -33,7 +33,7 @@
                 </p>
                 <div id="id_boefjes" class="column-4 plugins tiles images-cover">
                     {% for boefje in boefjes %}
-                        {% include "partials/plugin_tile.html" with plugin=boefje show_meta=False %}
+                        {% include "partials/plugin_tile.html" with plugin=boefje remove_action_buttons=True %}
 
                     {% endfor %}
                 </div>

--- a/rocky/onboarding/views.py
+++ b/rocky/onboarding/views.py
@@ -183,7 +183,7 @@ class OnboardingClearanceLevelIntroductionView(
             {
                 "id": "dns_zone",
                 "type": "boefje",
-                "scan_level": "l1",
+                "scan_level": "1",
                 "name": "DNS-Zone",
                 "description": _("Fetch the parent DNS zone of a hostname"),
                 "enabled": False,
@@ -191,7 +191,7 @@ class OnboardingClearanceLevelIntroductionView(
             {
                 "id": "fierce",
                 "type": "boefje",
-                "scan_level": "l3",
+                "scan_level": "3",
                 "name": "Fierce",
                 "description": _("Finds subdomains by brute force"),
                 "enabled": False,

--- a/rocky/tests/onboarding/test_onboarding_organization_steps.py
+++ b/rocky/tests/onboarding/test_onboarding_organization_steps.py
@@ -15,7 +15,7 @@ from onboarding.views import (
     OnboardingSetupScanOOIInfoView,
     OnboardingSetupScanSelectPluginsView,
 )
-from pytest_django.asserts import assertContains
+from pytest_django.asserts import assertContains, assertNotContains
 
 from tests.conftest import setup_request
 
@@ -140,6 +140,8 @@ def test_onboarding_clearance_level_introduction(rf, redteam_member, mock_organi
     assertContains(response, "DNS-Zone")
     assertContains(response, "Skip onboarding")
     assertContains(response, "Continue")
+
+    assertNotContains(response, '<div class="action-buttons">', html=True)
 
 
 def test_onboarding_acknowledge_clearance_level(rf, redteam_member, mock_organization_view_octopoes, url):


### PR DESCRIPTION
### Changes
- This PR changes the onboarding part where we explain what scan levels are for boefjes and how you can choose based on the clearance level set for OOIs. These are example boefjes and they cannot be enabled/disabled
- The action buttons are not necessary, so I've removed them.
- I have added the scan levels for the example boefjes

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/3235


Closes https://github.com/minvws/nl-kat-coordination/issues/3235

### Demo
<img width="756" alt="Screenshot 2024-07-15 at 11 15 05" src="https://github.com/user-attachments/assets/cd11ac08-7f30-4609-9417-e3145192f5a5">

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
