### PR TITLE
Fix broken token auth when 2FA is enabled

### DIFF
--- a/docs/source/manual/usermanual.rst
+++ b/docs/source/manual/usermanual.rst
@@ -246,8 +246,8 @@ After the CSV file has been uploaded the users receive a welcome email on their 
  The OpenKAT team
 
 
-Token authentication
---------------------
+API token authentication
+------------------------
 
 Authentication tokens can be created in the admin interface (/admin). The token is created for an user account and will have the same permissions as the user. After creating a token it will display the newly created token once. You need to copy the token immediately, because the token are stored hashed in the database and won't be visible anymore.
 

--- a/rocky/rocky/middleware/auth_required.py
+++ b/rocky/rocky/middleware/auth_required.py
@@ -57,7 +57,6 @@ def AuthRequiredMiddleware(get_response):
         # When 2fa is enabled, check if user is verified, otherwise redirect to 2fa setup page
         if (
             settings.TWOFACTOR_ENABLED
-            and not request.user.is_verified()
             and not (
                 # check if path is not in excluded list
                 request.path in excluded
@@ -65,6 +64,8 @@ def AuthRequiredMiddleware(get_response):
                 # check if path starts with anything in excluded_prefix
                 or any([request.path.startswith(prefix) for prefix in excluded_prefix])
             )
+            # This check should be after excluding /api because API users won't have `is_verified`
+            and not request.user.is_verified()
         ):
             return redirect(two_factor_setup_path)
 

--- a/rocky/tests/test_api.py
+++ b/rocky/tests/test_api.py
@@ -1,0 +1,13 @@
+from account.models import AuthToken
+
+
+# Regression test for https://github.com/minvws/nl-kat-coordination/issues/2872
+def test_api_2fa_enabled(client, settings, admin_user):
+    settings.TWOFACTOR_ENABLED = True
+
+    token_object = AuthToken(name="Test", user=admin_user)
+    token = token_object.generate_new_token()
+    token_object.save()
+
+    response = client.get("/api/v1/organization/", headers={"Authorization": f"Token {token}"})
+    assert response.status_code == 200


### PR DESCRIPTION
### Changes

Fix broken token auth when 2FA is enabled.

Also add "API" to the "Token authentication" section heading so that the section is return if you search for "API".

### Issue link

Closes #2872 

### QA notes

Enable 2FA and test that the REST API work again.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
