### PR TITLE
Fix: add related objects crash

### DIFF
--- a/rocky/rocky/templates/partials/ooi_detail_related_object.html
+++ b/rocky/rocky/templates/partials/ooi_detail_related_object.html
@@ -12,8 +12,8 @@
     {% if not ooi_past_due %}
         {% if not ooi|is_finding and not ooi|is_finding_type %}
             <div class="horizontal-view {% if related %}toolbar{% endif %}">
-                <a href="{% ooi_url "ooi_add_related" ooi.primary_key organization.code %}"
-                   class="button ghost">Add</a>
+                <a href="{% ooi_url "ooi_add_related" ooi.primary_key organization.code %}&add_ooi_type={{ ooi.get_ooi_type }}"
+                   class="button ghost">{% translate "Add" %}</a>
             </div>
         {% endif %}
     {% endif %}


### PR DESCRIPTION
### Changes

- URL was missing ooi_type parameter to populate form to add related objects to ooi detail view.
- Added missing translation for the button

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/3267

Closes https://github.com/minvws/nl-kat-coordination/issues/3267

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
