### PR TITLE
RFC3161HashRepository accepts rfc3161_provider only as a string and Pydantic URLs are not strings anymore

### DIFF
--- a/bytes/bytes/timestamping/provider.py
+++ b/bytes/bytes/timestamping/provider.py
@@ -16,6 +16,6 @@ def create_hash_repository(settings: Settings) -> HashRepository:
     if settings.ext_hash_repository == HashingRepositoryReference.RFC3161:
         assert settings.rfc3161_cert_file and settings.rfc3161_provider, "RFC3161 service needs a url and a certificate"
 
-        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), settings.rfc3161_provider)
+        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), str(settings.rfc3161_provider))
 
     return InMemoryHashRepository()

--- a/bytes/tests/conftest.py
+++ b/bytes/tests/conftest.py
@@ -60,7 +60,7 @@ def pastebin_hash_repository(settings: Settings) -> HashRepository:
 @pytest.fixture
 def mock_hash_repository(settings: Settings) -> HashRepository:
     if settings.rfc3161_cert_file and settings.rfc3161_provider:
-        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), settings.rfc3161_provider)
+        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), str(settings.rfc3161_provider))
 
     return InMemoryHashRepository(signing_provider_url="https://test")
 


### PR DESCRIPTION
### Changes

Bugfix that is rather trivial.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/3277

### Demo


### QA notes

To enable an rfc provider add these test values to your env, restart kat and make sure you can add an OOI (also see the issue description):

```env
RFC3161_PROVIDER=https://freetsa.org/tsr
RFC3161_CERT_FILE=bytes/timestamping/certificates/freetsa.crt
```

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
