### PR TITLE
[Backport] RFC3161HashRepository accepts rfc3161_provider only as a string and Pydantic URLs are not strings anymore

### DIFF
--- a/bytes/bytes/timestamping/provider.py
+++ b/bytes/bytes/timestamping/provider.py
@@ -16,6 +16,6 @@ def create_hash_repository(settings: Settings) -> HashRepository:
     if settings.ext_hash_repository == HashingRepositoryReference.RFC3161:
         assert settings.rfc3161_cert_file and settings.rfc3161_provider, "RFC3161 service needs a url and a certificate"
 
-        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), settings.rfc3161_provider)
+        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), str(settings.rfc3161_provider))
 
     return InMemoryHashRepository()

--- a/bytes/tests/conftest.py
+++ b/bytes/tests/conftest.py
@@ -60,7 +60,7 @@ def pastebin_hash_repository(settings: Settings) -> HashRepository:
 @pytest.fixture
 def mock_hash_repository(settings: Settings) -> HashRepository:
     if settings.rfc3161_cert_file and settings.rfc3161_provider:
-        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), settings.rfc3161_provider)
+        return RFC3161HashRepository(settings.rfc3161_cert_file.read_bytes(), str(settings.rfc3161_provider))
 
     return InMemoryHashRepository(signing_provider_url="https://test")
 


### PR DESCRIPTION
See #3281 