### PR TITLE
Fix rocky logging

### DIFF
--- a/rocky/katalogus/client.py
+++ b/rocky/katalogus/client.py
@@ -1,7 +1,7 @@
 from io import BytesIO
-from logging import getLogger
 
 import httpx
+import structlog
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 from jsonschema.exceptions import SchemaError
@@ -14,7 +14,7 @@ from octopoes.models.exception import TypeNotFound
 from octopoes.models.types import type_by_name
 from rocky.health import ServiceHealth
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Plugin(BaseModel):

--- a/rocky/katalogus/views/mixins.py
+++ b/rocky/katalogus/views/mixins.py
@@ -1,5 +1,4 @@
-from logging import getLogger
-
+import structlog
 from account.mixins import OrganizationView
 from django.contrib import messages
 from django.http import Http404
@@ -11,7 +10,7 @@ from rest_framework.status import HTTP_404_NOT_FOUND
 
 from katalogus.client import KATalogusClientV1, Plugin, get_katalogus
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class SinglePluginView(OrganizationView):

--- a/rocky/katalogus/views/plugin_detail.py
+++ b/rocky/katalogus/views/plugin_detail.py
@@ -1,5 +1,4 @@
 from datetime import datetime, timezone
-from logging import getLogger
 from typing import Any
 
 from account.mixins import OrganizationView
@@ -13,8 +12,6 @@ from tools.forms.ooi import SelectOOIFilterForm, SelectOOIForm
 from katalogus.client import Boefje, Normalizer, get_katalogus
 from katalogus.views.plugin_settings_list import PluginSettingsListView
 from rocky.views.tasks import TaskListView
-
-logger = getLogger(__name__)
 
 
 class PluginCoverImgView(OrganizationView):

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -1,5 +1,3 @@
-from logging import getLogger
-
 from django.contrib import messages
 from django.http import HttpResponseRedirect
 from django.shortcuts import redirect
@@ -8,8 +6,6 @@ from django.utils.translation import gettext_lazy as _
 from httpx import HTTPError
 
 from katalogus.views.mixins import SinglePluginView
-
-logger = getLogger(__name__)
 
 
 class PluginEnableDisableView(SinglePluginView):

--- a/rocky/reports/report_types/aggregate_organisation_report/report.py
+++ b/rocky/reports/report_types/aggregate_organisation_report/report.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
+import structlog
 from django.utils.translation import gettext_lazy as _
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
@@ -20,7 +20,7 @@ from reports.report_types.vulnerability_report.report import VulnerabilityReport
 from reports.report_types.web_system_report.report import WebSystemReport
 from rocky.views.health import flatten_health, get_rocky_health
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class AggregateOrganisationReport(AggregateReport):

--- a/rocky/reports/report_types/definitions.py
+++ b/rocky/reports/report_types/definitions.py
@@ -1,6 +1,5 @@
 from collections.abc import Callable, Iterable
 from datetime import datetime
-from logging import getLogger
 from pathlib import Path
 from typing import Any, TypedDict, TypeVar
 
@@ -11,7 +10,6 @@ from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from octopoes.models.types import OOIType
 
 REPORTS_DIR = Path(__file__).parent
-logger = getLogger(__name__)
 
 
 class ReportPlugins(TypedDict):

--- a/rocky/reports/report_types/dns_report/report.py
+++ b/rocky/reports/report_types/dns_report/report.py
@@ -1,7 +1,7 @@
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
+import structlog
 from django.utils.translation import gettext_lazy as _
 
 from octopoes.models import Reference
@@ -11,7 +11,7 @@ from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import Finding
 from reports.report_types.definitions import Report
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class DNSReport(Report):

--- a/rocky/reports/report_types/findings_report/report.py
+++ b/rocky/reports/report_types/findings_report/report.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -8,8 +7,6 @@ from octopoes.models import Reference
 from octopoes.models.ooi.findings import Finding, FindingType, RiskLevelSeverity
 from octopoes.models.types import ALL_TYPES
 from reports.report_types.definitions import Report, ReportPlugins
-
-logger = getLogger(__name__)
 
 TREE_DEPTH = 9
 SEVERITY_OPTIONS = [severity.value for severity in RiskLevelSeverity]

--- a/rocky/reports/report_types/ipv6_report/report.py
+++ b/rocky/reports/report_types/ipv6_report/report.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -9,8 +8,6 @@ from django.utils.translation import gettext_lazy as _
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 @dataclass

--- a/rocky/reports/report_types/mail_report/report.py
+++ b/rocky/reports/report_types/mail_report/report.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -8,8 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 MAIL_FINDING_TYPES = ["KAT-NO-SPF", "KAT-NO-DMARC", "KAT-NO-DKIM"]
 

--- a/rocky/reports/report_types/multi_organization_report/report.py
+++ b/rocky/reports/report_types/multi_organization_report/report.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from logging import getLogger
 from typing import Any, TypedDict
 
 from django.utils.translation import gettext_lazy as _
@@ -8,8 +7,6 @@ from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import Reference
 from octopoes.models.ooi.reports import ReportData
 from reports.report_types.definitions import MultiReport, ReportPlugins
-
-logger = getLogger(__name__)
 
 
 class OpenPortsDict(TypedDict):

--- a/rocky/reports/report_types/name_server_report/report.py
+++ b/rocky/reports/report_types/name_server_report/report.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
-from logging import getLogger
 from typing import Any, cast
 
 from django.utils.translation import gettext_lazy as _
@@ -10,8 +9,6 @@ from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 @dataclass

--- a/rocky/reports/report_types/open_ports_report/report.py
+++ b/rocky/reports/report_types/open_ports_report/report.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -8,8 +7,6 @@ from django.utils.translation import gettext_lazy as _
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 class OpenPortsReport(Report):

--- a/rocky/reports/report_types/rpki_report/report.py
+++ b/rocky/reports/report_types/rpki_report/report.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from datetime import datetime
-from logging import getLogger
 from typing import Any, TypedDict
 
 from django.utils.translation import gettext_lazy as _
@@ -9,8 +8,6 @@ from octopoes.models import Reference
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 class RPKIData(TypedDict):

--- a/rocky/reports/report_types/safe_connections_report/report.py
+++ b/rocky/reports/report_types/safe_connections_report/report.py
@@ -1,6 +1,5 @@
 from collections.abc import Iterable
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -14,8 +13,6 @@ CIPHER_FINDINGS = [
     "KAT-MEDIUM-BAD-CIPHER",
     "KAT-CRITICAL-BAD-CIPHER",
 ]
-
-logger = getLogger(__name__)
 
 
 class SafeConnectionsReport(Report):

--- a/rocky/reports/report_types/systems_report/report.py
+++ b/rocky/reports/report_types/systems_report/report.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -10,8 +9,6 @@ from strenum import StrEnum
 from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 class SystemType(StrEnum):

--- a/rocky/reports/report_types/tls_report/report.py
+++ b/rocky/reports/report_types/tls_report/report.py
@@ -1,5 +1,4 @@
 from datetime import datetime
-from logging import getLogger
 from typing import Any
 
 from django.utils.translation import gettext_lazy as _
@@ -8,8 +7,6 @@ from octopoes.models import Reference
 from octopoes.models.ooi.findings import Finding
 from octopoes.models.ooi.service import IPService, TLSCipher
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 CIPHER_FINDINGS = [
     "KAT-RECOMMENDATION-BAD-CIPHER",

--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -1,7 +1,6 @@
 from collections import Counter
 from collections.abc import Iterable
 from datetime import datetime
-from logging import getLogger
 from typing import Any, TypedDict
 
 from django.utils.translation import gettext_lazy as _
@@ -10,8 +9,6 @@ from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import Finding, FindingType, KATFindingType, RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 class FindingsData(TypedDict):

--- a/rocky/reports/report_types/web_system_report/report.py
+++ b/rocky/reports/report_types/web_system_report/report.py
@@ -1,7 +1,6 @@
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime
-from logging import getLogger
 from typing import Any, cast
 
 from django.utils.translation import gettext_lazy as _
@@ -10,8 +9,6 @@ from octopoes.models.ooi.dns.zone import Hostname
 from octopoes.models.ooi.findings import KATFindingType, RiskLevelSeverity
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6
 from reports.report_types.definitions import Report
-
-logger = getLogger(__name__)
 
 
 @dataclass

--- a/rocky/reports/views/base.py
+++ b/rocky/reports/views/base.py
@@ -2,11 +2,11 @@ import json
 from collections import defaultdict
 from collections.abc import Iterable, Sequence
 from datetime import datetime, timezone
-from logging import getLogger
 from operator import attrgetter
 from typing import Any, Literal, cast
 from uuid import uuid4
 
+import structlog
 from account.mixins import OrganizationView
 from django.conf import settings
 from django.contrib import messages
@@ -45,7 +45,7 @@ def get_selection(request: HttpRequest, pre_selection: dict[str, str | Sequence[
     return "?" + urlencode(request.GET, True)
 
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class ReportBreadcrumbs(OrganizationView, BreadcrumbsMixin):

--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -5,7 +5,6 @@ import json
 import uuid
 from enum import Enum
 from functools import cached_property
-from logging import getLogger
 from typing import Any
 
 import httpx
@@ -15,8 +14,6 @@ from httpx import ConnectError, HTTPError, HTTPStatusError, RequestError, codes
 from pydantic import BaseModel, ConfigDict, Field, SerializeAsAny, ValidationError
 
 from rocky.health import ServiceHealth
-
-logger = getLogger(__name__)
 
 
 class Boefje(BaseModel):

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -53,6 +53,9 @@ FEATURE_REPORTS = env.bool("FEATURE_REPORTS", False)
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = env.bool("DEBUG", False)
 
+# Logging format ("text" or "json")
+LOGGING_FORMAT = env("LOGGING_FORMAT", default="text")
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -63,13 +66,13 @@ LOGGING = {
         },
         "plain_console": {
             "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(),
+            "processor": structlog.dev.ConsoleRenderer(colors=True, pad_level=False),
         },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "formatter": "plain_console",
+            "formatter": "json_formatter" if LOGGING_FORMAT == "json" else "plain_console",
         },
     },
     "loggers": {
@@ -214,7 +217,10 @@ TEMPLATES = [
                 "tools.context_processors.organizations_including_blocked",
                 "tools.context_processors.rocky_version",
             ],
-            "builtins": ["django_components.templatetags.component_tags", "tools.templatetags.ooi_extra"],
+            "builtins": [
+                "django_components.templatetags.component_tags",
+                "tools.templatetags.ooi_extra",
+            ],
             "loaders": [
                 (
                     "django.template.loaders.cached.Loader",
@@ -501,9 +507,6 @@ WEASYPRINT_BASEURL = env("WEASYPRINT_BASEURL", default="http://127.0.0.1:8000/")
 KNOX_TOKEN_MODEL = "account.AuthToken"
 
 FORMS_URLFIELD_ASSUME_HTTPS = True
-
-# Logging format ("text" or "json")
-LOGGING_FORMAT = env("LOGGING_FORMAT", default="text")
 
 structlog.configure(
     processors=[

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -57,25 +57,25 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "formatters": {
-        "structlog": {
+        "json_formatter": {
             "()": structlog.stdlib.ProcessorFormatter,
             "processor": structlog.processors.JSONRenderer(),
+        },
+        "plain_console": {
+            "()": structlog.stdlib.ProcessorFormatter,
+            "processor": structlog.dev.ConsoleRenderer(),
         },
     },
     "handlers": {
         "console": {
-            "formatter": "structlog",
             "class": "logging.StreamHandler",
+            "formatter": "plain_console",
         },
     },
     "loggers": {
         "root": {
             "handlers": ["console"],
             "level": "INFO",
-        },
-        "django_structlog": {
-            "handlers": ["console"],
-            "level": "DEBUG",
         },
     },
 }
@@ -158,6 +158,7 @@ INSTALLED_APPS = [
     "account",
     "tools",
     "fmea",
+    "rocky",
     "crisis_room",
     "onboarding",
     "katalogus",

--- a/rocky/rocky/views/scans.py
+++ b/rocky/rocky/views/scans.py
@@ -1,11 +1,7 @@
-from logging import getLogger
-
 from account.mixins import OrganizationView
 from django.views.generic import TemplateView
 from katalogus.client import get_katalogus
 from tools.view_helpers import Breadcrumb, ObjectsBreadcrumbsMixin
-
-logger = getLogger(__name__)
 
 
 class ScanListView(ObjectsBreadcrumbsMixin, OrganizationView, TemplateView):

--- a/rocky/tools/management/commands/almost_flush.py
+++ b/rocky/tools/management/commands/almost_flush.py
@@ -1,5 +1,4 @@
-from logging import getLogger
-
+import structlog
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 from django.core.management import BaseCommand, call_command
@@ -8,7 +7,7 @@ from django_otp.plugins.otp_totp.models import TOTPDevice
 from tools.models import Indemnification, OrganizationMember
 
 User = get_user_model()
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):

--- a/rocky/tools/management/commands/export_migrations.py
+++ b/rocky/tools/management/commands/export_migrations.py
@@ -1,12 +1,12 @@
-from logging import getLogger
 from pathlib import Path
 
+import structlog
 from django.core.management import BaseCommand, CommandParser
 from django.db import DEFAULT_DB_ALIAS, connections
 from django.db.migrations.loader import MigrationLoader
 from django.db.migrations.recorder import MigrationRecorder
 
-logger = getLogger(__name__)
+logger = structlog.get_logger(__name__)
 
 
 class Command(BaseCommand):

--- a/rocky/tools/management/commands/generate_report.py
+++ b/rocky/tools/management/commands/generate_report.py
@@ -1,6 +1,5 @@
 import sys
 from datetime import datetime, timezone
-from logging import getLogger
 from pathlib import Path
 from typing import Any
 
@@ -16,7 +15,6 @@ from rocky.views.mixins import FindingList
 from tools.models import Organization
 
 User = get_user_model()
-logger = getLogger(__name__)
 
 
 class Command(BaseCommand):


### PR DESCRIPTION
### Changes

Fixes logging in rocky so the console output is readable again.

Not sure if this is exactly how we want it to be, but I've copied it from https://django-structlog.readthedocs.io/en/latest/getting_started.html#getting-started and it seems to do what we want. At least the rocky console log is readable again.

### Demo

![image](https://github.com/user-attachments/assets/a0ca10a6-56cd-4f65-90c5-3b4d7c5aa976)

### QA notes

Just start rocky and see that logging looks good again.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
