### PR TITLE
fix open redirects in plugin_enable_disable.py

### DIFF
--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -24,7 +24,8 @@ class PluginEnableDisableView(SinglePluginView):
                 messages.WARNING,
                 _("{} '{}' disabled.").format(self.plugin.type.title(), self.plugin.name),
             )
-            return HttpResponseRedirect(request.POST.get("current_url"))
+            url = request.build_absolute_uri(request.POST.get("current_url"))
+            return HttpResponseRedirect(url)
 
         try:
             plugin_settings = self.katalogus_client.get_plugin_settings(self.plugin.id)
@@ -91,5 +92,6 @@ class PluginEnableDisableView(SinglePluginView):
                     self.plugin.scan_level.value,
                 ),
             )
-
-        return HttpResponseRedirect(request.POST.get("current_url"))
+            
+            url = request.build_absolute_uri(request.POST.get("current_url"))
+            return HttpResponseRedirect(url)

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -92,6 +92,5 @@ class PluginEnableDisableView(SinglePluginView):
                     self.plugin.scan_level.value,
                 ),
             )
-            
             url = request.build_absolute_uri(request.POST.get("current_url"))
             return HttpResponseRedirect(url)

--- a/rocky/tests/katalogus/test_katalogus.py
+++ b/rocky/tests/katalogus/test_katalogus.py
@@ -348,6 +348,7 @@ def test_enable_disable_plugin_has_clearance(rf, redteam_member, mocker):
     request = setup_request(
         rf.post(
             "plugin_enable_disable",
+            {"current_url": "test"}
         ),
         redteam_member.user,
     )
@@ -376,6 +377,7 @@ def test_enable_disable_normalizer(rf, redteam_member, mocker):
     request = setup_request(
         rf.post(
             "plugin_enable_disable",
+            {"current_url": "test"}
         ),
         redteam_member.user,
     )


### PR DESCRIPTION
This fixes two open redirects by binding them onto our own domain.

### Changes

These changes add the requested url, after the current hostname making it an absolute redirect limited to our own webserver/hostname instead of anywhere.
Allowing redirects to anywhere is a potential security issue.

### Issue link

https://github.com/minvws/nl-kat-coordination/security/code-scanning/1
https://github.com/minvws/nl-kat-coordination/security/code-scanning/2


### QA notes

Enabling / Disabling plugins should still work.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
