### PR TITLE
Record the user who last changed the Scan Profile

### DIFF
--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -77,6 +77,7 @@ class ScanProfileBase(BaseModel):
     scan_profile_type: str
     reference: Reference
     level: ScanLevel
+    user: str | None = None
 
     def __eq__(self, other):
         if isinstance(other, ScanProfileBase) and self.__class__ == other.__class__:

--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -77,7 +77,7 @@ class ScanProfileBase(BaseModel):
     scan_profile_type: str
     reference: Reference
     level: ScanLevel
-    userid: int | None = None
+    user_id: int | None = None
 
     def __eq__(self, other):
         if isinstance(other, ScanProfileBase) and self.__class__ == other.__class__:

--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -77,7 +77,7 @@ class ScanProfileBase(BaseModel):
     scan_profile_type: str
     reference: Reference
     level: ScanLevel
-    user: str | None = None
+    user: int | None = None
 
     def __eq__(self, other):
         if isinstance(other, ScanProfileBase) and self.__class__ == other.__class__:

--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -77,7 +77,7 @@ class ScanProfileBase(BaseModel):
     scan_profile_type: str
     reference: Reference
     level: ScanLevel
-    user: int | None = None
+    userid: int | None = None
 
     def __eq__(self, other):
         if isinstance(other, ScanProfileBase) and self.__class__ == other.__class__:

--- a/octopoes/tests/test_api.py
+++ b/octopoes/tests/test_api.py
@@ -104,6 +104,7 @@ def test_get_scan_profiles(httpx_mock, patch_pika, valid_time):
             "level": 0,
             "reference": "Hostname|internet|mispo.es",
             "scan_profile_type": "empty",
+            "user": None,
         }
     ]
 

--- a/octopoes/tests/test_api.py
+++ b/octopoes/tests/test_api.py
@@ -104,7 +104,7 @@ def test_get_scan_profiles(httpx_mock, patch_pika, valid_time):
             "level": 0,
             "reference": "Hostname|internet|mispo.es",
             "scan_profile_type": "empty",
-            "user": None,
+            "userid": None,
         }
     ]
 

--- a/octopoes/tests/test_api.py
+++ b/octopoes/tests/test_api.py
@@ -104,7 +104,7 @@ def test_get_scan_profiles(httpx_mock, patch_pika, valid_time):
             "level": 0,
             "reference": "Hostname|internet|mispo.es",
             "scan_profile_type": "empty",
-            "userid": None,
+            "user_id": None,
         }
     ]
 

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -66,7 +66,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0},
+                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user": None},
                 "reference": "test_reference",
             },
         ),
@@ -79,7 +79,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
         "test__scan_profile_mutations",
         b'{"operation":"create","primary_key":"test_reference","value":{"primary_key":"test_reference",'
         b'"object_type":"test_reference","scan_profile":{"scan_profile_type":"empty","reference":"test_reference",'
-        b'"level":0}}}',
+        b'"level":0,"user":null}}}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )
 
@@ -108,7 +108,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "declared", "reference": "test_reference", "level": 2},
+                "new_data": {"scan_profile_type": "declared", "reference": "test_reference", "level": 2, "user": None},
                 "reference": "test_reference",
             },
         ),
@@ -122,7 +122,8 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             "",
             "test__scan_profile_increments",
             b'{"primary_key": "test_reference", "object_type": "test_reference",'
-            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference", "level": 2}}',
+            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
+            "level": 2, "user": None}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
         mocker.call(
@@ -131,7 +132,8 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             b'{"operation": "create", "primary_key": "test_reference", '
             b'"value": {"primary_key": "test_reference", '
             b'"object_type": "test_reference", '
-            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference", "level": 2}}}',
+            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
+            "level": 2, "user": None}}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
     )
@@ -160,7 +162,7 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
                 "operation_type": "delete",
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
-                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0},
+                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user": None},
                 "new_data": None,
                 "reference": "test_reference",
             },

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -66,7 +66,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "userid": None},
+                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user_id": None},
                 "reference": "test_reference",
             },
         ),
@@ -79,7 +79,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
         "test__scan_profile_mutations",
         b'{"operation":"create","primary_key":"test_reference","value":{"primary_key":"test_reference",'
         b'"object_type":"test_reference","scan_profile":{"scan_profile_type":"empty","reference":"test_reference",'
-        b'"level":0,"userid":null}}}',
+        b'"level":0,"user_id":null}}}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )
 
@@ -112,7 +112,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
                     "scan_profile_type": "declared",
                     "reference": "test_reference",
                     "level": 2,
-                    "userid": None,
+                    "user_id": None,
                 },
                 "reference": "test_reference",
             },
@@ -128,7 +128,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             "test__scan_profile_increments",
             b'{"primary_key": "test_reference", "object_type": "test_reference",'
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
-            "level": 2, "userid": None}}',
+            "level": 2, "user_id": None}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
         mocker.call(
@@ -138,7 +138,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             b'"value": {"primary_key": "test_reference", '
             b'"object_type": "test_reference", '
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
-            "level": 2, "userid": None}}}',
+            "level": 2, "user_id": None}}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
     )
@@ -167,7 +167,7 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
                 "operation_type": "delete",
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
-                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "userid": None},
+                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user_id": None},
                 "new_data": None,
                 "reference": "test_reference",
             },

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -66,7 +66,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user": None},
+                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "userid": None},
                 "reference": "test_reference",
             },
         ),
@@ -79,7 +79,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
         "test__scan_profile_mutations",
         b'{"operation":"create","primary_key":"test_reference","value":{"primary_key":"test_reference",'
         b'"object_type":"test_reference","scan_profile":{"scan_profile_type":"empty","reference":"test_reference",'
-        b'"level":0,"user":null}}}',
+        b'"level":0,"userid":null}}}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )
 
@@ -108,7 +108,12 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "declared", "reference": "test_reference", "level": 2, "user": None},
+                "new_data": {
+                    "scan_profile_type": "declared",
+                    "reference": "test_reference",
+                    "level": 2,
+                    "userid": None,
+                },
                 "reference": "test_reference",
             },
         ),
@@ -123,7 +128,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             "test__scan_profile_increments",
             b'{"primary_key": "test_reference", "object_type": "test_reference",'
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
-            "level": 2, "user": None}}',
+            "level": 2, "userid": None}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
         mocker.call(
@@ -133,7 +138,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             b'"value": {"primary_key": "test_reference", '
             b'"object_type": "test_reference", '
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
-            "level": 2, "user": None}}}',
+            "level": 2, "userid": None}}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
     )
@@ -162,7 +167,7 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
                 "operation_type": "delete",
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
-                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user": None},
+                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "userid": None},
                 "new_data": None,
                 "reference": "test_reference",
             },

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -136,7 +136,7 @@ class OrganizationView(View):
     def raise_clearance_level(self, ooi_reference: Reference, level: int) -> bool:
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_scan_profile(
-            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), user=str(self.request.user)),
+            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), user=self.request.user.id),
             datetime.now(timezone.utc),
         )
 

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -136,7 +136,7 @@ class OrganizationView(View):
     def raise_clearance_level(self, ooi_reference: Reference, level: int) -> bool:
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_scan_profile(
-            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), user=self.request.user.id),
+            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), userid=self.request.user.id),
             datetime.now(timezone.utc),
         )
 
@@ -146,7 +146,7 @@ class OrganizationView(View):
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_many_scan_profiles(
             [
-                DeclaredScanProfile(reference=reference, level=ScanLevel(level), user=self.request.user.id)
+                DeclaredScanProfile(reference=reference, level=ScanLevel(level), userid=self.request.user.id)
                 for reference in ooi_references
             ],
             datetime.now(timezone.utc),

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -146,7 +146,7 @@ class OrganizationView(View):
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_many_scan_profiles(
             [
-                DeclaredScanProfile(reference=reference, level=ScanLevel(level), user=str(self.request.user))
+                DeclaredScanProfile(reference=reference, level=ScanLevel(level), user=self.request.user.id)
                 for reference in ooi_references
             ],
             datetime.now(timezone.utc),

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -136,7 +136,7 @@ class OrganizationView(View):
     def raise_clearance_level(self, ooi_reference: Reference, level: int) -> bool:
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_scan_profile(
-            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level)),
+            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), user=str(self.request.user)),
             datetime.now(timezone.utc),
         )
 
@@ -145,7 +145,10 @@ class OrganizationView(View):
     def raise_clearance_levels(self, ooi_references: list[Reference], level: int) -> bool:
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_many_scan_profiles(
-            [DeclaredScanProfile(reference=reference, level=ScanLevel(level)) for reference in ooi_references],
+            [
+                DeclaredScanProfile(reference=reference, level=ScanLevel(level), user=str(self.request.user))
+                for reference in ooi_references
+            ],
             datetime.now(timezone.utc),
         )
 

--- a/rocky/account/mixins.py
+++ b/rocky/account/mixins.py
@@ -136,7 +136,7 @@ class OrganizationView(View):
     def raise_clearance_level(self, ooi_reference: Reference, level: int) -> bool:
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_scan_profile(
-            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), userid=self.request.user.id),
+            DeclaredScanProfile(reference=ooi_reference, level=ScanLevel(level), user_id=self.request.user.id),
             datetime.now(timezone.utc),
         )
 
@@ -146,7 +146,7 @@ class OrganizationView(View):
         self.verify_raise_clearance_level(level)
         self.octopoes_api_connector.save_many_scan_profiles(
             [
-                DeclaredScanProfile(reference=reference, level=ScanLevel(level), userid=self.request.user.id)
+                DeclaredScanProfile(reference=reference, level=ScanLevel(level), user_id=self.request.user.id)
                 for reference in ooi_references
             ],
             datetime.now(timezone.utc),

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-07-16 11:52+0000\n"
+"POT-Creation-Date: 2024-07-25 12:28+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -957,6 +957,7 @@ msgstr ""
 #: katalogus/templates/partials/plugin_settings_required.html
 #: katalogus/templates/plugin_settings_list.html
 #: rocky/templates/findings/finding_add.html
+#: rocky/templates/partials/ooi_detail_related_object.html
 #: rocky/templates/partials/ooi_list_toolbar.html
 msgid "Add"
 msgstr ""
@@ -5858,6 +5859,10 @@ msgstr ""
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid "Current clearance level"
+msgstr ""
+
+#: rocky/templates/scan_profiles/scan_profile_detail.html
+msgid "Inactive"
 msgstr ""
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -12,7 +12,7 @@
                 {% include "partials/ooi_head.html" with ooi=ooi view="scan_profile_detail" %}
 
                 <h2 rf-selector="clearance-header">{% translate "Current clearance level" %}</h2>
-                <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }}</p>
+                <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{{ username }}")</p>
                 {% if ooi.scan_profile.scan_profile_type == "declared" %}
                     <p class="explanation">
                         <span>{% translate "Declared:" %}</span>{% blocktranslate with scan_level=ooi.scan_profile.human_readable %}

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -12,7 +12,11 @@
                 {% include "partials/ooi_head.html" with ooi=ooi view="scan_profile_detail" %}
 
                 <h2 rf-selector="clearance-header">{% translate "Current clearance level" %}</h2>
-                <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{{ username }}")</p>
+                {% if username %}
+                    <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{{ username }}")</p>
+                {% else %}
+                    <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }}</p>
+                {% endif %}
                 {% if ooi.scan_profile.scan_profile_type == "declared" %}
                     <p class="explanation">
                         <span>{% translate "Declared:" %}</span>{% blocktranslate with scan_level=ooi.scan_profile.human_readable %}

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -13,7 +13,15 @@
 
                 <h2 rf-selector="clearance-header">{% translate "Current clearance level" %}</h2>
                 {% if username %}
-                    <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{% if not scan_profile_user.is_active %}<s title="{% translate "Inactive" %}">{{ scan_profile_user }}</s>{% else %} {{ scan_profile_user }}{% endif %}")</p>
+                    <p>
+                        {{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "
+                        {% if not scan_profile_user.is_active %}
+                            <s title="{% translate "Inactive" %}">{{ scan_profile_user }}</s>
+                        {% else %}
+                            {{ scan_profile_user }}
+                        {% endif %}
+                        ")
+                    </p>
                 {% else %}
                     <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }}</p>
                 {% endif %}

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -13,7 +13,7 @@
 
                 <h2 rf-selector="clearance-header">{% translate "Current clearance level" %}</h2>
                 {% if username %}
-                    <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{{ username }}")</p>
+                    <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "{% if not scan_profile_user.is_active %}<s title="{% translate "Inactive" %}">{{ scan_profile_user }}</s>{% else %} {{ scan_profile_user }}{% endif %}")</p>
                 {% else %}
                     <p>{{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }}</p>
                 {% endif %}

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -12,7 +12,7 @@
                 {% include "partials/ooi_head.html" with ooi=ooi view="scan_profile_detail" %}
 
                 <h2 rf-selector="clearance-header">{% translate "Current clearance level" %}</h2>
-                {% if username %}
+                {% if scan_profile_user %}
                     <p>
                         {{ ooi.scan_profile.human_readable }}, {{ ooi.scan_profile.scan_profile_type }} (by user "
                         {% if not scan_profile_user.is_active %}

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -28,7 +28,7 @@ class ScanProfileDetailView(FormView, OOIDetailView):
                 name = str(kat_user)
                 context["username"] = ''.join([c + '\u0336' if i < len(name) - 1 else c for i, c in enumerate(name)])
         except get_user_model().DoesNotExist:
-            context["username"] = "unknown"
+            context["username"] = ""
         return context
 
     def get_initial(self):

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,20 +20,12 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
+        context["scan_profile_user"] = False
         if self.ooi.scan_profile and self.ooi.scan_profile.user:
             try:
-                kat_user = get_user_model().objects.get(id=self.ooi.scan_profile.user)
-                if kat_user.is_active:
-                    context["username"] = str(kat_user)
-                else:
-                    name = str(kat_user)
-                    context["username"] = "".join(
-                        [c + "\u0336" if i < len(name) - 1 else c for i, c in enumerate(name)]
-                    )
+                context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.user)
             except get_user_model().DoesNotExist:
-                context["username"] = ""
-        else:
-            context["username"] = ""
+                pass
         return context
 
     def get_initial(self):

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,7 +20,15 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        context["username"] = get_user_model().objects.get(id=self.ooi.scan_profile.user)
+        try:
+            kat_user = get_user_model().objects.get(id=self.ooi.scan_profile.user)
+            if kat_user.is_active:
+                context["username"] = str(kat_user)
+            else:
+                name = str(kat_user)
+                context["username"] = ''.join([c + '\u0336' if i < len(name) - 1 else c for i, c in enumerate(name)])
+        except get_user_model().DoesNotExist:
+            context["username"] = "unknown"
         return context
 
     def get_initial(self):

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -26,7 +26,7 @@ class ScanProfileDetailView(FormView, OOIDetailView):
                 context["username"] = str(kat_user)
             else:
                 name = str(kat_user)
-                context["username"] = ''.join([c + '\u0336' if i < len(name) - 1 else c for i, c in enumerate(name)])
+                context["username"] = "".join([c + "\u0336" if i < len(name) - 1 else c for i, c in enumerate(name)])
         except get_user_model().DoesNotExist:
             context["username"] = ""
         return context

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,14 +20,19 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        try:
-            kat_user = get_user_model().objects.get(id=self.ooi.scan_profile.user)
-            if kat_user.is_active:
-                context["username"] = str(kat_user)
-            else:
-                name = str(kat_user)
-                context["username"] = "".join([c + "\u0336" if i < len(name) - 1 else c for i, c in enumerate(name)])
-        except get_user_model().DoesNotExist:
+        if self.ooi.scan_profile and self.ooi.scan_profile.user:
+            try:
+                kat_user = get_user_model().objects.get(id=self.ooi.scan_profile.user)
+                if kat_user.is_active:
+                    context["username"] = str(kat_user)
+                else:
+                    name = str(kat_user)
+                    context["username"] = "".join(
+                        [c + "\u0336" if i < len(name) - 1 else c for i, c in enumerate(name)]
+                    )
+            except get_user_model().DoesNotExist:
+                context["username"] = ""
+        else:
             context["username"] = ""
         return context
 

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from django.contrib import messages
+from django.contrib.auth import get_user_model
 from django.shortcuts import redirect
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView
@@ -19,6 +20,7 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
+        context["username"] = get_user_model().objects.get(id=self.ooi.scan_profile.user)
         return context
 
     def get_initial(self):

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,9 +20,9 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        if self.ooi.scan_profile and self.ooi.scan_profile.userid:
+        if self.ooi.scan_profile and self.ooi.scan_profile.user_id:
             try:
-                context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.userid)
+                context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.user_id)
             except get_user_model().DoesNotExist:
                 pass
         return context

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,9 +20,9 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        if self.ooi.scan_profile and self.ooi.scan_profile.user:
+        if self.ooi.scan_profile and self.ooi.scan_profile.userid:
             try:
-                context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.user)
+                context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.userid)
             except get_user_model().DoesNotExist:
                 pass
         return context

--- a/rocky/rocky/views/scan_profile.py
+++ b/rocky/rocky/views/scan_profile.py
@@ -20,7 +20,6 @@ class ScanProfileDetailView(FormView, OOIDetailView):
     def get_context_data(self, **kwargs) -> dict[str, Any]:
         context = super().get_context_data(**kwargs)
         context["mandatory_fields"] = get_mandatory_fields(self.request)
-        context["scan_profile_user"] = False
         if self.ooi.scan_profile and self.ooi.scan_profile.user:
             try:
                 context["scan_profile_user"] = get_user_model().objects.get(id=self.ooi.scan_profile.user)


### PR DESCRIPTION
### Changes

Record the user who last changed the Scan Profile

### Issue link

None

### Demo
```
{
  "type": "ScanProfile",
  "level": 2,
  "reference": "URL|internet|https://mispo.es/",
  "scan_profile_type": "declared",
  "user_id": "superuser@localhost",
  "xt/id": "ScanProfile|URL|internet|https://mispo.es/"
}
```

### QA notes

Create a bunch of objects and raise their clearance level and run:
```
octopoes/tools/xtdb-cli.py query '{:query {:find [(pull ?var [*])] :where [[?var :type "ScanProfile"][?var :user_id ?user_id][(not= ?user_id nil)]]}}' | jq -C | less -R
```

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
