### PR TITLE
Workaround setuptools 72 removing test command

### DIFF
--- a/boefjes/Dockerfile
+++ b/boefjes/Dockerfile
@@ -20,10 +20,10 @@ RUN --mount=type=cache,target=/root/.cache \
     pip install --upgrade pip \
     && if [ "$ENVIRONMENT" = "dev" ]; \
     then \
-    grep -v git+https:// requirements-dev.txt | pip install -r /dev/stdin ; \
+    grep -v git+https:// requirements-dev.txt | pip install -r /dev/stdin && \
     grep git+https:// requirements-dev.txt | pip install -r /dev/stdin ; \
     else \
-    grep -v git+https:// requirements.txt | pip install -r /dev/stdin ;\
+    grep -v git+https:// requirements.txt | pip install -r /dev/stdin && \
     grep git+https:// requirements.txt | pip install -r /dev/stdin ; \
     fi
 

--- a/rocky/Dockerfile
+++ b/rocky/Dockerfile
@@ -39,15 +39,19 @@ ARG ENVIRONMENT
 # requirements separately
 COPY rocky/requirements*.txt .
 RUN --mount=type=cache,target=/root/.cache \
-    pip install --upgrade pip \
+    # Workaround for https://github.com/pypa/setuptools/issues/4519 \
+    echo "setuptools<72" > /tmp/constraints.txt \
+    && export PIP_CONSTRAINT=/tmp/constraints.txt \
+    && pip install --upgrade pip \
     && if [ "$ENVIRONMENT" = "dev" ]; \
     then \
-    grep -v git+https:// requirements-dev.txt | pip install -r /dev/stdin ; \
+    grep -v git+https:// requirements-dev.txt | pip install -r /dev/stdin && \
     grep git+https:// requirements-dev.txt | pip install -r /dev/stdin ; \
     else \
-    grep -v git+https:// requirements.txt | pip install -r /dev/stdin ;\
+    grep -v git+https:// requirements.txt | pip install -r /dev/stdin && \
     grep git+https:// requirements.txt | pip install -r /dev/stdin ; \
-    fi
+    fi \
+    && rm /tmp/constraints.txt
 
 FROM dev
 


### PR DESCRIPTION
### Changes

This implements one of the workarounds described in https://github.com/pypa/setuptools/issues/4519

It also fixes that the error was ignored because the shell code didn't use `&&`.

### QA notes

If the CI succeeds it can be merged.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
