### PR TITLE
Fix CSRF error in API with token auth

### DIFF
--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -458,6 +458,7 @@ if BROWSABLE_API:
     DEFAULT_RENDERER_CLASSES = DEFAULT_RENDERER_CLASSES + ["rest_framework.renderers.BrowsableAPIRenderer"]
 
 REST_FRAMEWORK = {
+    "DEFAULT_AUTHENTICATION_CLASSES": ("knox.auth.TokenAuthentication",),
     "DEFAULT_PERMISSION_CLASSES": [
         # For now this will provide a safe default, but non-admin users will
         # need to be able to use the API in the future..

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -449,16 +449,24 @@ CSP_CONNECT_SRC = ["'self'"]
 
 CSP_BLOCK_ALL_MIXED_CONTENT = True
 
-DEFAULT_RENDERER_CLASSES = ["rest_framework.renderers.JSONRenderer"]
-
 # Turn on the browsable API by default if DEBUG is True, but disable by default in production
 BROWSABLE_API = env.bool("BROWSABLE_API", DEBUG)
 
 if BROWSABLE_API:
-    DEFAULT_RENDERER_CLASSES = DEFAULT_RENDERER_CLASSES + ["rest_framework.renderers.BrowsableAPIRenderer"]
+    DEFAULT_AUTHENTICATION_CLASSES = [
+        "knox.auth.TokenAuthentication",
+        "rest_framework.authentication.SessionAuthentication",
+    ]
+    DEFAULT_RENDERER_CLASSES = [
+        "rest_framework.renderers.JSONRenderer",
+        "rest_framework.renderers.BrowsableAPIRenderer",
+    ]
+else:
+    DEFAULT_AUTHENTICATION_CLASSES = ["knox.auth.TokenAuthentication"]
+    DEFAULT_RENDERER_CLASSES = ["rest_framework.renderers.JSONRenderer"]
 
 REST_FRAMEWORK = {
-    "DEFAULT_AUTHENTICATION_CLASSES": ("knox.auth.TokenAuthentication",),
+    "DEFAULT_AUTHENTICATION_CLASSES": DEFAULT_AUTHENTICATION_CLASSES,
     "DEFAULT_PERMISSION_CLASSES": [
         # For now this will provide a safe default, but non-admin users will
         # need to be able to use the API in the future..


### PR DESCRIPTION
### Changes

The API would wrongly return a CSRF when using token authentication. The reason is that we didn't set the Django REST framework authentencation class. Authentication still worked because we set request.user in middleware so the API token can also be used on non-DRF endpoints, but DRF assumes that the request.user comes from session authentication and will require CSRF .

### QA notes

Fix can be verified by creating an organization via the API using token authentication. Token can be created in the admin. Example request using [HTTPie](https://httpie.io/):

```bash
http http://127.0.0.1:8000/api/v1/organization/ "Authorization:Token abcdef123456" code=test1 name=Test1
```

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
