### PR TITLE
fix: Button height

### DIFF
--- a/rocky/assets/css/themes/soft/manon/button.scss
+++ b/rocky/assets/css/themes/soft/manon/button.scss
@@ -6,8 +6,10 @@
   --button-base-text-color: var(--branding-color-2-text-color);
   --button-base-border-radius: 1rem;
   --button-base-font-family: var(--application-base-font-family);
-  --button-base-padding-top: 0.25rem;
-  --button-base-padding-bottom: 0.25rem;
+  --button-base-padding-top: var(--spacing-grid-150);
+  --button-base-padding-right: var(--spacing-grid-200);
+  --button-base-padding-bottom: var(--spacing-grid-150);
+  --button-base-padding-left: var(--spacing-grid-200);
   --button-base-min-width: 2.75rem;
   --button-base-border-color: var(--branding-color-2-background-color);
   --button-base-border-style: solid;
@@ -19,7 +21,7 @@
   /* Text */
   --button-base-font-size: 1rem;
   --button-base-font-weight: bold;
-  --button-base-line-height: 1.5;
+  --button-base-line-height: 1.25;
 
   /* States */
 
@@ -52,6 +54,13 @@ input[type="reset"] {
 
   font-family: var(--button-base-font-family);
   max-width: 18rem;
+
+  .icon {
+    max-height: 1.25rem; /* Set to same height as button line-height to prevent icons from increasing line-height */
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
 
   @media (width >= 24rem) {
     text-align: left;

--- a/rocky/assets/css/themes/soft/manon/form-button.scss
+++ b/rocky/assets/css/themes/soft/manon/form-button.scss
@@ -3,4 +3,5 @@
 :root {
   --form-button-font-weight: var(--button-base-font-weight);
   --form-button-min-width: var(--button-base-min-width);
+  --form-button-line-height: var(--button-base-line-height);
 }

--- a/rocky/assets/css/themes/soft/manon/language-selector-list.scss
+++ b/rocky/assets/css/themes/soft/manon/language-selector-list.scss
@@ -8,6 +8,15 @@
   --language-selector-list-label-gap: 0;
 
   /* Button */
+  --language-selector-list-button-line-height: var(--button-base-line-height);
+  --language-selector-list-button-padding-top: var(--button-base-padding-top);
+  --language-selector-list-button-padding-right: var(
+    --button-base-padding-right
+  );
+  --language-selector-list-button-padding-bottom: var(
+    --button-base-padding-bottom
+  );
+  --language-selector-list-button-padding-left: var(--button-base-padding-left);
 
   /* --language-selector-list-button-font-size: var(--header-navigation-button-font-size); */
   --language-selector-list-button-border-color: var(
@@ -61,6 +70,10 @@ body > header nav {
 
       &::after {
         color: var(--language-selector-list-button-text-color);
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        max-height: 1.25rem; /* Set to same height as button line-height to prevent icons from increasing line-height */
       }
     }
 


### PR DESCRIPTION
### Changes

Makes sure buttons are consistent in height and padding. Across different button types we use.

- Buttons with or without an icon now have the same height. They had a slight variance before due tot the icon increasing the line-height. 
- Button padding now follows the design. Before the top and bottom padding were less to compensate for the increased line-height. 

### Issue link

Closes: https://github.com/minvws/nl-kat-coordination/issues/3285

### Demo
<img width="1326" alt="Screenshot 2024-08-03 at 11 50 31" src="https://github.com/user-attachments/assets/66b9410e-58d5-4a61-9a26-0153eb342fda">

<img width="876" alt="Screenshot 2024-08-03 at 11 50 38" src="https://github.com/user-attachments/assets/40724ee6-da57-49e7-85c1-e8f4154416ee">

<img width="257" alt="Screenshot 2024-08-03 at 11 52 19" src="https://github.com/user-attachments/assets/fcf6ec44-faf2-4857-b63e-1a9275b6b559">

### QA notes
- Please check if there are buttons that are inconsistent with this styling.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
