### PR TITLE
Set timezone to UTC in SQLAlchemy when connecting to PostgreSQL

### DIFF
--- a/boefjes/boefjes/sql/db.py
+++ b/boefjes/boefjes/sql/db.py
@@ -22,7 +22,12 @@ def get_engine() -> Engine:
     db_uri_redacted = db_uri.render_as_string(hide_password=True)
     logger.info("Connecting to database %s with pool size %s...", db_uri_redacted, settings.db_connection_pool_size)
 
-    engine = create_engine(url=db_uri, pool_pre_ping=True, pool_size=settings.db_connection_pool_size)
+    engine = create_engine(
+        url=db_uri,
+        pool_pre_ping=True,
+        pool_size=settings.db_connection_pool_size,
+        connect_args={"options": "-c timezone=utc"},
+    )
 
     logger.info("Connected to database %s", db_uri_redacted)
 

--- a/bytes/bytes/database/db.py
+++ b/bytes/bytes/database/db.py
@@ -16,7 +16,7 @@ def get_engine(db_uri: str, pool_size: int) -> Engine:
     db_uri_redacted = make_url(name_or_url=str(db_uri)).render_as_string(hide_password=True)
     logger.info("Connecting to database %s with pool size %s...", db_uri_redacted, pool_size)
 
-    engine = create_engine(db_uri, pool_pre_ping=True, pool_size=pool_size)
+    engine = create_engine(db_uri, pool_pre_ping=True, pool_size=pool_size, connect_args={"options": "-c timezone=utc"})
 
     logger.info("Connected to database %s.", db_uri_redacted)
 

--- a/mula/scheduler/storage/storage.py
+++ b/mula/scheduler/storage/storage.py
@@ -39,6 +39,7 @@ class DBConn:
                 pool_size=pool_size,
                 pool_recycle=300,
                 json_serializer=serializer,
+                connect_args={"options": "-c timezone=utc"},
             )
         except sqlalchemy.exc.SQLAlchemyError as e:
             self.logger.error(


### PR DESCRIPTION
### Changes

Set timezone to UTC in SQLAlchemy when connecting to PostgreSQL

### Issue

The fixes the following exception:

```Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/core/handlers/base.py", line 197, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 104, in view
    return self.dispatch(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/base.py", line 143, in dispatch
    return handler(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/rocky/rocky/views/ooi_detail_related_object.py", line 78, in get
    return super().get(request, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/django/views/generic/list.py", line 174, in get
    context = self.get_context_data()
              ^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/rocky/rocky/views/ooi_detail.py", line 96, in get_context_data
    context.update(self.get_origins(self.ooi.reference, self.organization))
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/rocky/rocky/views/mixins.py", line 175, in get_origins
    boefje_meta["ended_at"] = datetime.strptime(boefje_meta["ended_at"], "%Y-%m-%dT%H:%M:%S.%fZ")
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/_strptime.py", line 567, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

Exception Type: ValueError at /en/test/objects/detail/
Exception Value: time data '2024-08-11T17:07:15.263467+02:00' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
```

The cause is that when connecting to PostgreSQL that is configured with a different timezone than UTC (which as far as I know is normal when you run Debian packages of PostgreSQL), PostgreSQL returns the datetime with the configured timezone and the datetime gets serialized with a timezone. Specifying UTC as the timezone when connecting to PostgreSQL means we always get UTC back and resolves this problem.

### QA notes

In docker the timezone is already UTC, so there shouldn't be any change when the standard docker development environment.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
