### PR TITLE
Remove workaround for setuptools bug

### DIFF
--- a/rocky/Dockerfile
+++ b/rocky/Dockerfile
@@ -39,10 +39,7 @@ ARG ENVIRONMENT
 # requirements separately
 COPY rocky/requirements*.txt .
 RUN --mount=type=cache,target=/root/.cache \
-    # Workaround for https://github.com/pypa/setuptools/issues/4519 \
-    echo "setuptools<72" > /tmp/constraints.txt \
-    && export PIP_CONSTRAINT=/tmp/constraints.txt \
-    && pip install --upgrade pip \
+    pip install --upgrade pip \
     && if [ "$ENVIRONMENT" = "dev" ]; \
     then \
     grep -v git+https:// requirements-dev.txt | pip install -r /dev/stdin && \
@@ -50,8 +47,7 @@ RUN --mount=type=cache,target=/root/.cache \
     else \
     grep -v git+https:// requirements.txt | pip install -r /dev/stdin && \
     grep git+https:// requirements.txt | pip install -r /dev/stdin ; \
-    fi \
-    && rm /tmp/constraints.txt
+    fi
 
 FROM dev
 


### PR DESCRIPTION
### Changes

Setuptools has been fixed, so we can remove the workaround for bug

### QA notes

CI will build the container image and will show if there is a problem, no manual QA needed.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
