### PR TITLE
:pushpin: add subfinder settings

### DIFF
--- a/boefjes/boefjes/plugins/pdio_subfinder/boefje.json
+++ b/boefjes/boefjes/plugins/pdio_subfinder/boefje.json
@@ -5,5 +5,9 @@
   "consumes": [
     "Hostname"
   ],
+  "environment_keys": [
+    "SUBFINDER_RATE_LIMIT",
+    "SUBFINDER_VERSION"
+  ],
   "scan_level": 2
 }

--- a/boefjes/boefjes/plugins/pdio_subfinder/main.py
+++ b/boefjes/boefjes/plugins/pdio_subfinder/main.py
@@ -1,15 +1,23 @@
+import logging
+import os
+
 import docker
 
 from boefjes.job_models import BoefjeMeta
 
-SUBFINDER_IMAGE = "projectdiscovery/subfinder:v2.6.6"
-
 
 def run(boefje_meta: BoefjeMeta) -> list[tuple[set, bytes | str]]:
+    """Create image from docker and run subfinder with only active domains output."""
+    subfinder_image = f"projectdiscovery/subfinder:{os.getenv('SUBFINDER_VERSION', 'v2.6.6')}"
+    rate_limit = int(os.getenv("SUBFINDER_RATE_LIMIT", "0"))
+
     client = docker.from_env()
     input_ = boefje_meta.arguments["input"]
     hostname = input_["name"]
 
-    output = client.containers.run(SUBFINDER_IMAGE, ["-silent", "-active", "-d", hostname], remove=True)
+    logging.info("Using %s with rate limit %s", subfinder_image, rate_limit)
+    output = client.containers.run(
+        subfinder_image, ["-silent", "-active", "-rate-limit", str(rate_limit), "-d", hostname], remove=True
+    )
 
     return [(set(), output)]

--- a/boefjes/boefjes/plugins/pdio_subfinder/schema.json
+++ b/boefjes/boefjes/plugins/pdio_subfinder/schema.json
@@ -1,0 +1,20 @@
+{
+  "title": "Arguments",
+  "type": "object",
+  "properties": {
+    "SUBFINDER_RATE_LIMIT": {
+      "title": "SUBFINDER_RATE_LIMIT",
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 65535,
+      "description": "Maximum number of http requests to send per second."
+    },
+    "SUBFINDER_VERSION": {
+      "title": "SUBFINDER_VERSION",
+      "type": "string",
+      "maxLength": 10,
+      "description": "Version string including 'v', e.g. 'v2.6.6'."
+    }
+  },
+  "required": []
+}


### PR DESCRIPTION
### Changes

This PR adds two settings to subfinder, one te manage the docker image version, and one to manage the rate limit.

### Issue link

Related: https://github.com/minvws/nl-kat-coordination/issues/2291

### Demo
![image](https://github.com/user-attachments/assets/aed98827-86d5-47c0-b572-dbe388e97148)

### QA notes

Try the settings.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
