### PR TITLE
Introduce a-sync recalculate bits with status polling

### DIFF
--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -527,6 +527,8 @@ async def recalculate_bits_launcher(octopoes: OctopoesService, session_id: uuid.
 
     octopoes.commit()
 
+    await asyncio.sleep(60)
+
     RECALCULATE_BITS_SESSIONS[session_id] = inference_count
 
 
@@ -547,15 +549,18 @@ async def recalculate_bits_status(request: Request) -> Any:
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error receiving objects") from e
     session_id = uuid.UUID(data.decode())
-    if session_id in RECALCULATE_BITS_SESSIONS:
-        retval = RECALCULATE_BITS_SESSIONS[session_id]
-        if retval > 0:
-            RECALCULATE_BITS_SESSIONS.pop(session_id)
-            return {"status": retval}
+    if session_id:
+        if session_id in RECALCULATE_BITS_SESSIONS:
+            retval = RECALCULATE_BITS_SESSIONS[session_id]
+            if retval > 0:
+                RECALCULATE_BITS_SESSIONS.pop(session_id)
+                return {"status": retval}
+            else:
+                return {"status": "awaiting"}
         else:
-            return {"status": "awaiting"}
+            return {"status": "unavailable"}
     else:
-        return {"status": "unavailable"}
+        return RECALCULATE_BITS_SESSIONS
 
 
 @router.get("/io/export", tags=["io"])

--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -527,8 +527,6 @@ async def recalculate_bits_launcher(octopoes: OctopoesService, session_id: uuid.
 
     octopoes.commit()
 
-    await asyncio.sleep(60)
-
     RECALCULATE_BITS_SESSIONS[session_id] = inference_count
 
 

--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -546,8 +546,8 @@ async def recalculate_bits_status(request: Request) -> Any:
         data = await request.body()
     except Exception as e:
         raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Error receiving objects") from e
-    session_id = uuid.UUID(data.decode())
-    if session_id:
+    if data:
+        session_id = uuid.UUID(data.decode())
         if session_id in RECALCULATE_BITS_SESSIONS:
             retval = RECALCULATE_BITS_SESSIONS[session_id]
             if retval > 0:
@@ -558,7 +558,7 @@ async def recalculate_bits_status(request: Request) -> Any:
         else:
             return {"status": "unavailable"}
     else:
-        return RECALCULATE_BITS_SESSIONS
+        return {"sessions": list(RECALCULATE_BITS_SESSIONS.keys())}
 
 
 @router.get("/io/export", tags=["io"])

--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from asgiref.sync import sync_to_async
 from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, status
+from fastapi.responses import JSONResponse
 from httpx import HTTPError
 from pydantic import AwareDatetime
 
@@ -556,7 +557,7 @@ async def recalculate_bits_status(request: Request) -> Any:
             else:
                 return {"status": "awaiting"}
         else:
-            return {"status": "unavailable"}
+            return JSONResponse(status_code=status.HTTP_404_NOT_FOUND, content={"status": "session not found"})
     else:
         return {"sessions": list(RECALCULATE_BITS_SESSIONS.keys())}
 

--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -531,13 +531,13 @@ async def recalculate_bits_launcher(octopoes: OctopoesService, session_id: uuid.
 
 
 @router.post("/bits/recalculate", tags=["Bits"])
-async def recalculate_bits(octopoes: OctopoesService = Depends(octopoes_service)) -> str:
+async def recalculate_bits(octopoes: OctopoesService = Depends(octopoes_service)) -> Any:
     session_id = uuid.uuid4()
     RECALCULATE_BITS_SESSIONS[session_id] = -1
 
     asyncio.create_task(recalculate_bits_launcher(octopoes, session_id))
 
-    return str(session_id)
+    return {"session_id": session_id}
 
 
 @router.post("/bits/recalculate/status", tags=["Bits"])


### PR DESCRIPTION
### Changes

When recalculate bits takes longer than a timeout in the the current setup, a timeout is achieved and the result is seen in the front-end.

This patch fixes that by launching recalculate_bits a-sync (with a session_id) and then providing a a-sync retrieve result function that indicates either if the jobs exists, is running or is done.

This way the front-end can await the recalculation without timing out and retrieving the results.

### Issue link

N/A

### Demo

Create a large system where calculations take sufficiently long (and special thanks to @Rieven).

Launch a recalculation:
```
curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate"

{"session_id":"e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"}
```
Check the sessions with:
```
curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate/status"

{"sessions":["e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"]}
```
Check session `"e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"` with:
```
curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate/status" -d "e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"

{"status":"awaiting"}
```

Some time later `"e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"` with:
```
curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate/status" -d "e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"

{"status":5240}
```

Sessions are empty:
```
 curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate/status"
 
{"sessions":[]}
```

And hence `"e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"`:
```
curl -s -X POST "http://localhost:8001/_rieven/bits/recalculate/status" -d "e197a7f2-c72e-4265-ae57-30dbdb1e4d8c"

{"status":"unavailable"}
```

### QA notes

Run the demo!
The current recalculate button in the front-end is broken (because that is not done in this patch).

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
