### PR TITLE
Stop yielding network in certain normalizers

### DIFF
--- a/boefjes/boefjes/plugins/kat_crt_sh/normalize.py
+++ b/boefjes/boefjes/plugins/kat_crt_sh/normalize.py
@@ -16,7 +16,6 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
     current = fqdn.lstrip(".")
 
     network = Network(name="internet")
-    yield network
     network_reference = network.reference
 
     unique_domains = set()

--- a/boefjes/boefjes/plugins/kat_nmap_tcp/normalize.py
+++ b/boefjes/boefjes/plugins/kat_nmap_tcp/normalize.py
@@ -53,7 +53,6 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
 
     # Relevant network object is received from the normalizer_meta.
     network = Network(name=input_ooi["network"]["name"])
-    yield network
 
     netblock_ref = None
     if "NetBlock" in input_ooi["object_type"]:

--- a/boefjes/tests/test_nmap.py
+++ b/boefjes/tests/test_nmap.py
@@ -9,7 +9,7 @@ class NmapTest(TestCase):
     def test_normalizer(self):
         input_ooi = IPAddressV4(network=Network(name="internet").reference, address="134.209.85.72")
         output = list(run(input_ooi.serialize(), get_dummy_data("raw/nmap_mispoes.xml")))
-        self.assertEqual(16, len(output))
+        self.assertEqual(15, len(output))
         for i, out in enumerate(output[:-1]):
             if out.object_type == "IPPort" and output[i + 1].object_type == "Service":
                 if out.port == 80:


### PR DESCRIPTION
### Changes
Stop yielding network in certain normalizers

### Issue link
N/A

### Demo
N/A

### QA notes
No specific changes in flow, good to check the affected normalizers (Nmap TCP). 

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
