### PR TITLE
Bump django-rest-framework jquery version

### DIFF
--- a/rocky/rocky/templates/rest_framework/api.html
+++ b/rocky/rocky/templates/rest_framework/api.html
@@ -12,7 +12,7 @@ these here too. -->
       "csrfToken": "{% if request %}{{ csrf_token }}{% endif %}"
   }
     </script>
-    <script src="{% static "rest_framework/js/jquery-3.5.1.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "rest_framework/js/jquery-3.7.1.min.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "rest_framework/js/ajax-form.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "rest_framework/js/csrf.js" %}" nonce="{{ request.csp_nonce }}"></script>
     <script src="{% static "rest_framework/js/bootstrap.min.js" %}" nonce="{{ request.csp_nonce }}"></script>


### PR DESCRIPTION
### Changes

Django-rest-framework 3.15 updates jquery to 3.7.1 so our template that adds the nonces to the script tags also needs to bump the version.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
