### PR TITLE
Add indemnification to API

### DIFF
--- a/rocky/tests/conftest.py
+++ b/rocky/tests/conftest.py
@@ -1785,3 +1785,12 @@ def boefje_dns_records():
         runnable_hash=None,
         produces={"boefje/dns-records"},
     )
+
+
+@pytest.fixture
+def drf_admin_client(create_drf_client, admin_user):
+    client = create_drf_client(admin_user)
+    # We need to set this so that the test client doesn't throw an
+    # exception, but will return error in the API we can test
+    client.raise_request_exception = False
+    return client

--- a/rocky/tests/test_api_organization.py
+++ b/rocky/tests/test_api_organization.py
@@ -2,13 +2,16 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
+from django.urls import reverse
 from httpx import HTTPError
 from pytest_assert_utils import assert_model_attrs
 from pytest_common_subject import precondition_fixture
 from pytest_drf import (
+    APIViewTest,
     Returns200,
     Returns201,
     Returns204,
+    Returns409,
     Returns500,
     UsesDeleteMethod,
     UsesDetailEndpoint,
@@ -51,13 +54,7 @@ class TestOrganizationViewSet(ViewSetTest):
     list_url = lambda_fixture(lambda: url_for("organization-list"))
     detail_url = lambda_fixture(lambda organization: url_for("organization-detail", organization.pk))
 
-    @pytest.fixture
-    def client(self, create_drf_client, admin_user):
-        client = create_drf_client(admin_user)
-        # We need to set this so that the test client doesn't throw an
-        # exception, but will return error in the API we can test
-        client.raise_request_exception = False
-        return client
+    client = lambda_fixture("drf_admin_client")
 
     class TestList(
         UsesGetMethod,
@@ -280,3 +277,45 @@ class TestOrganizationViewSet(ViewSetTest):
                 ],
             }
             assert json == expected
+
+
+class TestGetIndemnification(APIViewTest, UsesGetMethod, Returns200):
+    # The superuser_member fixture creates the indemnification
+    url = lambda_fixture(
+        lambda organization, superuser_member: reverse("organization-indemnification", args=[organization.pk])
+    )
+    client = lambda_fixture("drf_admin_client")
+
+    def test_it_returns_indemnification(self, json, superuser_member):
+        expected = {"indemnification": True, "user": superuser_member.user.id}
+        assert json == expected
+
+
+class TestIndemnificationDoesNotExist(APIViewTest, UsesGetMethod, Returns200):
+    url = lambda_fixture(lambda organization: reverse("organization-indemnification", args=[organization.pk]))
+    client = lambda_fixture("drf_admin_client")
+
+    def test_it_returns_no_indemnification(self, json):
+        expected = {"indemnification": False, "user": None}
+        assert json == expected
+
+
+class TestSetIndemnification(APIViewTest, UsesPostMethod, Returns201):
+    url = lambda_fixture(lambda organization: reverse("organization-indemnification", args=[organization.pk]))
+    client = lambda_fixture("drf_admin_client")
+
+    def test_it_sets_indemnification(self, json, admin_user):
+        expected = {"indemnification": True, "user": admin_user.id}
+        assert json == expected
+
+
+class TestIndemnificationAlreadyExists(APIViewTest, UsesPostMethod, Returns409):
+    # The superuser_member fixture creates the indemnification
+    url = lambda_fixture(
+        lambda organization, superuser_member: reverse("organization-indemnification", args=[organization.pk])
+    )
+    client = lambda_fixture("drf_admin_client")
+
+    def test_it_returns_indemnification(self, json, superuser_member):
+        expected = {"indemnification": True, "user": superuser_member.user.id}
+        assert json == expected

--- a/rocky/tools/viewsets.py
+++ b/rocky/tools/viewsets.py
@@ -1,6 +1,8 @@
-from rest_framework import viewsets
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 
-from tools.models import Organization
+from tools.models import Indemnification, Organization
 from tools.serializers import OrganizationSerializer, OrganizationSerializerReadOnlyCode
 
 
@@ -16,3 +18,25 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         if self.request.method != "POST":
             serializer_class = OrganizationSerializerReadOnlyCode
         return serializer_class
+
+    @action(detail=True)
+    def indemnification(self, request, pk=None):
+        organization = self.get_object()
+        indemnification = Indemnification.objects.filter(organization=organization).first()
+
+        if indemnification:
+            return Response({"indemnification": True, "user": indemnification.user.pk})
+        else:
+            return Response({"indemnification": False, "user": None})
+
+    @indemnification.mapping.post
+    def set_indemnification(self, request, pk=None):
+        organization = self.get_object()
+
+        indemnification = Indemnification.objects.filter(organization=organization).first()
+        if indemnification:
+            return Response({"indemnification": True, "user": indemnification.user.pk}, status=status.HTTP_409_CONFLICT)
+
+        indemnification = Indemnification.objects.create(organization=organization, user=self.request.user)
+
+        return Response({"indemnification": True, "user": indemnification.user.pk}, status=status.HTTP_201_CREATED)


### PR DESCRIPTION
### Changes

This adds `/api/v1/organization/<id>/indemnification/` as endpoint for getting and setting the indemnification. A GET request will return whether the an indemnification is set and the user. A POST will set the indemnification, the user that does the API call is set as user of the indemnification. The POST request doesn't need contents.

### Issue link

Closes #3362 

### QA notes

After creating a token you can test the API with httpie using:

```shell
$ http GET http://127.0.0.1:8000/api/v1/organization/3/indemnification/ "Authorization:Token ..."
$ http POST http://127.0.0.1:8000/api/v1/organization/1/indemnification/ "Authorization:Token ..."
```

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
