### PR TITLE
fix: notification width

### DIFF
--- a/rocky/assets/css/main.scss
+++ b/rocky/assets/css/main.scss
@@ -18,6 +18,7 @@
 @import "vendor_overrides/manon/layout-fifty-fifty";
 @import "vendor_overrides/manon/layout-form";
 @import "vendor_overrides/manon/nested-section";
+@import "vendor_overrides/manon/notification";
 @import "vendor_overrides/manon/table";
 @import "vendor_overrides/manon/tile";
 @import "vendor_overrides/two-factor";

--- a/rocky/assets/css/vendor_overrides/manon/notification.scss
+++ b/rocky/assets/css/vendor_overrides/manon/notification.scss
@@ -1,0 +1,18 @@
+p,
+a,
+span,
+li,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  &.error,
+  &.warning,
+  &.explanation,
+  &.confirmation,
+  &.system {
+    max-width: var(--max-line-length-max-width);
+  }
+}


### PR DESCRIPTION
### Changes

-Fixes max width on notifications that aren't block notifications

### Issue link

Fix for:  https://github.com/minvws/nl-kat-coordination/issues/3424 (Doesn't close it yet as we still need to add the icons and close button)

### Demo

Before: 
<img width="1166" alt="Screenshot 2024-09-03 at 19 40 31" src="https://github.com/user-attachments/assets/5deec793-5a41-4448-8ac6-0978d9cb67eb">

After:
<img width="1136" alt="Screenshot 2024-09-03 at 19 40 47" src="https://github.com/user-attachments/assets/4ed63b50-a20c-49c8-9d04-ba2a5a51894e">

### QA notes

- Please check if it works as expected. A notification can be found on "user icon" > profile
- Please check if page notifications are block notifications and still work as expected.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
