### PR TITLE
a bit more detailed erroring in the scheduler client.

### DIFF
--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -253,8 +253,9 @@ class SchedulerClient:
     def push_task(self, item: Task) -> None:
         try:
             queue_name = f"{item.data.type}-{self.organization_code}"
+            path = f"/queues/{queue_name}/push"
             res = self._client.post(
-                f"/queues/{queue_name}/push",
+                path,
                 content=item.json(exclude_none=True),
                 headers={"Content-Type": "application/json"},
             )
@@ -262,13 +263,13 @@ class SchedulerClient:
         except HTTPStatusError as http_error:
             code = http_error.response.status_code
             if code == codes.TOO_MANY_REQUESTS:
-                raise SchedulerTooManyRequestError()
+                raise SchedulerTooManyRequestError(path) from http_error
             elif code == codes.BAD_REQUEST:
-                raise SchedulerBadRequestError()
+                raise SchedulerBadRequestError(path) from http_error
             elif code == codes.CONFLICT:
-                raise SchedulerConflictError()
-        except RequestError:
-            raise SchedulerError()
+                raise SchedulerConflictError(path) from http_error
+        except RequestError as request_error:
+            raise SchedulerError(path) from request_error
 
     def health(self) -> ServiceHealth:
         return ServiceHealth.model_validate_json(self._get("/health", return_type="content"))


### PR DESCRIPTION
### Changes

We noticed some issues in Rocky's interaction with the scheduler, where we where unable to see what the organization or even the url was.

### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
