### PR TITLE
Show proper error message instead of stacktrace if boefje API is unreachable

### DIFF
--- a/boefjes/images/oci_adapter.py
+++ b/boefjes/images/oci_adapter.py
@@ -9,7 +9,11 @@ from main import run
 
 def main():
     input_url = sys.argv[-1]
-    boefje_input = httpx.get(input_url).json()
+    try:
+        boefje_input = httpx.get(input_url).json()
+    except httpx.HTTPError as e:
+        # sys.exit will print the message on stderr and return with exit code 1
+        sys.exit(f"Failed to get input from boefje API: {e}")
 
     try:
         os.environ.update(boefje_input["boefje_meta"]["environment"])
@@ -32,7 +36,10 @@ def main():
             ],
         }
 
-    httpx.post(boefje_input["output_url"], json=out)
+    try:
+        httpx.post(boefje_input["output_url"], json=out)
+    except httpx.HTTPError as e:
+        sys.exit(f"Failed to post output to boefje API: {e}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Changes

This catches exceptions from httpx and shows a proper error message.

### QA notes

Change the BOEFJE_API to something else so that it unreachable. Run a containerized boefje (nmap, dnssec) and download the task raw data to see the error message.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
