### PR TITLE
REST API to recalculate bits and clone katalogus settings

### DIFF
--- a/rocky/katalogus/views/katalogus_settings.py
+++ b/rocky/katalogus/views/katalogus_settings.py
@@ -9,9 +9,12 @@ from django.urls.base import reverse_lazy
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import FormView, TemplateView
 from httpx import HTTPError
+from structlog import get_logger
 from tools.models import Organization
 
 from katalogus.client import get_katalogus
+
+logger = get_logger(__name__)
 
 
 class ConfirmCloneSettingsView(
@@ -35,6 +38,7 @@ class ConfirmCloneSettingsView(
 
     def post(self, request, *args, **kwargs):
         to_organization = Organization.objects.get(code=kwargs["to_organization"])
+        logger.info("Cloning organization settings", event_code=910000, to_organization_code=to_organization.code)
         get_katalogus(self.organization.code).clone_all_configuration_to_organization(to_organization.code)
         messages.add_message(
             self.request,

--- a/rocky/rocky/views/organization_list.py
+++ b/rocky/rocky/views/organization_list.py
@@ -9,10 +9,13 @@ from django.db.models import Count
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import ListView
+from structlog import get_logger
 from tools.models import Organization
 from tools.view_helpers import OrganizationBreadcrumbsMixin
 
 from octopoes.connector.octopoes import OctopoesAPIConnector
+
+logger = get_logger(__name__)
 
 
 class OrganizationListView(
@@ -40,6 +43,7 @@ class OrganizationListView(
             start_time = datetime.now()
             for organization in organizations:
                 try:
+                    logger.info("Recalculating bits", event_code=920000, organization_code=organization.code)
                     number_of_bits += OctopoesAPIConnector(settings.OCTOPOES_API, organization.code).recalculate_bits()
                 except Exception as exc:
                     failed.append(f"{organization}, ({str(exc)})")

--- a/rocky/rocky/views/organization_settings.py
+++ b/rocky/rocky/views/organization_settings.py
@@ -7,7 +7,10 @@ from django.core.exceptions import PermissionDenied
 from django.http import HttpRequest, HttpResponse, HttpResponseBadRequest
 from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
+from structlog import get_logger
 from tools.view_helpers import OrganizationDetailBreadcrumbsMixin
+
+logger = get_logger(__name__)
 
 
 class PageActions(Enum):
@@ -26,6 +29,7 @@ class OrganizationSettingsView(
         if not self.request.user.has_perm("tools.can_recalculate_bits"):
             raise PermissionDenied()
         if action == PageActions.RECALCULATE.value:
+            logger.info("Recalculating bits", event_code=920000)
             connector = self.octopoes_api_connector
 
             start_time = datetime.now()

--- a/rocky/tests/test_api_organization.py
+++ b/rocky/tests/test_api_organization.py
@@ -12,6 +12,7 @@ from pytest_drf import (
     Returns200,
     Returns201,
     Returns204,
+    Returns400,
     Returns403,
     Returns409,
     Returns500,
@@ -363,3 +364,57 @@ class TestIndemnificationAlreadyExists(APIViewTest, UsesPostMethod, Returns409):
     def test_it_returns_indemnification(self, json, superuser_member):
         expected = {"indemnification": True, "user": superuser_member.user.id}
         assert json == expected
+
+
+class TestRecalculateBits(APIViewTest, UsesPostMethod, Returns200):
+    url = lambda_fixture(lambda organization: reverse("organization-recalculate-bits", args=[organization.pk]))
+
+    @pytest.fixture
+    def client(self, drf_redteam_client, redteamuser):
+        redteamuser.user_permissions.set([Permission.objects.get(codename="can_recalculate_bits")])
+        return drf_redteam_client
+
+    @pytest.fixture(autouse=True)
+    def mock_octopoes(self, mocker):
+        return mocker.patch("tools.viewsets.OctopoesAPIConnector.recalculate_bits", return_value=42)
+
+    def test_it_recalculates_bits(self, json):
+        expected = {"number_of_bits": 42}
+        assert json == expected
+
+
+class TestRecalculateBitsNoPermission(APIViewTest, UsesPostMethod, Returns403):
+    url = lambda_fixture(lambda organization: reverse("organization-recalculate-bits", args=[organization.pk]))
+    client = lambda_fixture("drf_redteam_client")
+
+
+class TestKatalogusCloneSettings(APIViewTest, UsesPostMethod, Returns200):
+    url = lambda_fixture(lambda organization: reverse("organization-clone-katalogus-settings", args=[organization.pk]))
+    data = lambda_fixture(lambda organization_b: {"to_organization": organization_b.id})
+
+    @pytest.fixture
+    def client(self, drf_redteam_client, redteamuser):
+        redteamuser.user_permissions.set([Permission.objects.get(codename="can_set_katalogus_settings")])
+        return drf_redteam_client
+
+    @pytest.fixture(autouse=True)
+    def mock_katalogus(self, mocker):
+        return mocker.patch("katalogus.client.KATalogusClientV1")
+
+    def test_it_clones_settings(self, mock_katalogus, organization_b):
+        mock_katalogus().clone_all_configuration_to_organization.assert_called_once_with(organization_b.code)
+
+
+class TestCloneKatalogusSettingsNoPermission(APIViewTest, UsesPostMethod, Returns403):
+    url = lambda_fixture(lambda organization: reverse("organization-clone-katalogus-settings", args=[organization.pk]))
+    client = lambda_fixture("drf_redteam_client")
+
+
+class TestCloneKatalogusSettingsInvalidData(APIViewTest, UsesPostMethod, Returns400):
+    url = lambda_fixture(lambda organization: reverse("organization-clone-katalogus-settings", args=[organization.pk]))
+    data = lambda_fixture(lambda organization_b: {"wrong_field": organization_b.id})
+
+    @pytest.fixture
+    def client(self, drf_redteam_client, redteamuser):
+        redteamuser.user_permissions.set([Permission.objects.get(codename="can_set_katalogus_settings")])
+        return drf_redteam_client

--- a/rocky/tools/permissions.py
+++ b/rocky/tools/permissions.py
@@ -1,0 +1,13 @@
+from rest_framework.permissions import BasePermission
+
+
+# This is a bit clunky, but DRF doesn't allow you to specify a permission
+# directly, only a Permission class
+class CanRecalculateBits(BasePermission):
+    def has_permission(self, request, view) -> bool:
+        return request.user.has_perm("tools.can_recalculate_bits")
+
+
+class CanSetKatalogusSettings(BasePermission):
+    def has_permission(self, request, view) -> bool:
+        return request.user.has_perm("tools.can_set_katalogus_settings")

--- a/rocky/tools/serializers.py
+++ b/rocky/tools/serializers.py
@@ -1,3 +1,4 @@
+from rest_framework.serializers import PrimaryKeyRelatedField, Serializer
 from tagulous.contrib.drf import TagSerializer
 
 from tools.models import Organization
@@ -14,3 +15,7 @@ class OrganizationSerializerReadOnlyCode(TagSerializer):
         model = Organization
         fields = ["id", "name", "code", "tags"]
         read_only_fields = ["code"]
+
+
+class ToOrganizationSerializer(Serializer):
+    to_organization = PrimaryKeyRelatedField(queryset=Organization.objects.all())

--- a/rocky/tools/viewsets.py
+++ b/rocky/tools/viewsets.py
@@ -61,7 +61,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
     @action(detail=True, methods=["post"], permission_classes=[CanRecalculateBits])
     def recalculate_bits(self, request, pk=None):
         organization = self.get_object()
-        logger.info("Recalculating bits", event_code=920000, organization_code=self.organization.code)
+        logger.info("Recalculating bits", event_code=920000, organization_code=organization.code)
         connector = OctopoesAPIConnector(settings.OCTOPOES_API, organization.code)
         number_of_bits = connector.recalculate_bits()
 

--- a/rocky/tools/viewsets.py
+++ b/rocky/tools/viewsets.py
@@ -77,7 +77,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
             logger.info(
                 "Cloning organization settings",
                 event_code=910000,
-                organization_code=self.organization.code,
+                organization_code=from_organization.code,
                 to_organization_code=to_organization.code,
             )
             get_katalogus(from_organization.code).clone_all_configuration_to_organization(to_organization.code)


### PR DESCRIPTION
### Changes

This adds the REST API for recalculating bits and cloning settings. The endpoints are under the organization endpoint. For example if organization has rocky  primary key 1, using httpie you can recalculate bits using:

```bash
$ http POST http://127.0.0.1:8000/api/v1/organization/1/recalculate_bits/ "Authorization:Token <token>"
```

To clone the katalogus settings to organization with rocky primary key 2:

```bash
$ http POST http://127.0.0.1:8000/api/v1/organization/1/clone_katalogus_settings/ to_organization=2 "Authorization:Token <token>"
```

This includes PR #3571 because else the tests with the right permissions don't work, so PR #3571 needs to be merged first.

### Issue link

Closes #3525 


### QA notes

See Changes how to test the API.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
