### PR TITLE
Dont show manual tasks in normalizer list

### DIFF
--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-09-24 12:03+0000\n"
+"POT-Creation-Date: 2024-09-25 14:37+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6304,6 +6304,10 @@ msgstr ""
 
 #: rocky/templates/tasks/normalizers.html
 msgid "Boefje input OOI"
+msgstr ""
+
+#: rocky/templates/tasks/normalizers.html
+msgid "Manually added"
 msgstr ""
 
 #: rocky/templates/tasks/ooi_detail_task_list.html

--- a/rocky/rocky/templates/tasks/normalizers.html
+++ b/rocky/rocky/templates/tasks/normalizers.html
@@ -57,13 +57,19 @@
                                         <td>{{ task.modified_at }}</td>
                                         <td>
                                             {% if task.data.raw_data.boefje_meta.boefje.name %}
-                                                <a href="{% url "boefje_detail" task.data.raw_data.boefje_meta.organization task.data.raw_data.boefje_meta.boefje.id %}">{{ task.data.raw_data.boefje_meta.boefje.name }}</a>
+                                                {% if task.data.raw_data.boefje_meta.boefje.id == "manual" %}
+                                                    <p>{% translate "Manually added" %}</p>
+                                                {% else %}
+                                                    <a href="{% url "boefje_detail" task.data.raw_data.boefje_meta.organization task.data.raw_data.boefje_meta.boefje.id %}">{{ task.data.raw_data.boefje_meta.boefje.name }}</a>
+                                                {% endif %}
                                             {% else %}
                                                 <a href="{% url "boefje_detail" task.data.raw_data.boefje_meta.organization task.data.raw_data.boefje_meta.boefje.id %}">{{ task.data.raw_data.boefje_meta.boefje.id }}</a>
                                             {% endif %}
                                         </td>
                                         <td>
-                                            <a href="{% ooi_url "ooi_detail" task.data.raw_data.boefje_meta.input_ooi task.data.raw_data.boefje_meta.organization observed_at=task.created_at|date:'c' %}">{{ task.data.raw_data.boefje_meta.input_ooi }}</a>
+                                            {% if task.data.raw_data.boefje_meta.input_ooi %}
+                                                <a href="{% ooi_url "ooi_detail" task.data.raw_data.boefje_meta.input_ooi task.data.raw_data.boefje_meta.organization observed_at=task.created_at|date:'c' %}">{{ task.data.raw_data.boefje_meta.input_ooi }}</a>
+                                            {% endif %}
                                         </td>
                                         <td>
                                             <button type="button"

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -81,10 +81,7 @@ class NormalizersTaskListView(TaskListView):
 
         for task in task_list:
             boefje_id = task.data.raw_data.boefje_meta.boefje.id
-            if boefje_id == "manual":
-                task_list.remove(task)
-            else:
-                task.data.raw_data.boefje_meta.boefje.name = plugin_dict[boefje_id]
+            task.data.raw_data.boefje_meta.boefje.name = plugin_dict[boefje_id] if boefje_id != "manual" else "Manual"
 
         return context
 

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -80,7 +80,10 @@ class NormalizersTaskListView(TaskListView):
         plugin_dict = {p.id: p.name for p in plugins}
 
         for task in task_list:
-            task.data.raw_data.boefje_meta.boefje.name = plugin_dict[task.data.raw_data.boefje_meta.boefje.id]
+            if task.data.raw_data.boefje_meta.boefje.id == "manual":
+                task_list.remove(task)
+            else:
+                task.data.raw_data.boefje_meta.boefje.name = plugin_dict[task.data.raw_data.boefje_meta.boefje.id]
 
         return context
 

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -80,10 +80,11 @@ class NormalizersTaskListView(TaskListView):
         plugin_dict = {p.id: p.name for p in plugins}
 
         for task in task_list:
-            if task.data.raw_data.boefje_meta.boefje.id == "manual":
+            boefje_id = task.data.raw_data.boefje_meta.boefje.id
+            if boefje_id == "manual":
                 task_list.remove(task)
             else:
-                task.data.raw_data.boefje_meta.boefje.name = plugin_dict[task.data.raw_data.boefje_meta.boefje.id]
+                task.data.raw_data.boefje_meta.boefje.name = plugin_dict[boefje_id]
 
         return context
 


### PR DESCRIPTION
### Changes

The normalizer task list was broken because tasks of manually added oois have no boefje (id), but manually added oois should in my opinion not show up in the task list.

### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes ...

### Demo

<img width="1453" alt="image" src="https://github.com/user-attachments/assets/af4dd5a2-f8db-4e1b-b8b4-6b58ebb46c62">

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
