### PR TITLE
Use stdlib instead of dateutil to parse ISO datetime

### DIFF
--- a/rocky/katalogus/views/plugin_detail.py
+++ b/rocky/katalogus/views/plugin_detail.py
@@ -2,7 +2,6 @@ from datetime import datetime, timezone
 from typing import Any
 
 from account.mixins import OrganizationView
-from dateutil import parser
 from django.contrib import messages
 from django.http import FileResponse
 from django.shortcuts import redirect
@@ -134,7 +133,7 @@ class BoefjeDetailView(PluginDetailView):
 
         for variant in context["variants"]:
             if variant.created:
-                variant.created = parser.isoparse(variant.created)
+                variant.created = datetime.fromisoformat(variant.created)
 
         context["select_ooi_filter_form"] = SelectOOIFilterForm
         if "show_all" in self.request.GET:


### PR DESCRIPTION
### Changes

In #3521 dateutil is used to parse an ISO datetime but dateutil isn't added as a dependency. Dateutil is available in dev environment because it is an indirect dev dependency, but not available in non-dev environments. See also https://github.com/minvws/nl-kat-coordination/actions/runs/11051578484/job/30701994096

An ISO datetime can be parsed using `datetime.fromisotimestamp` from the standard library so there is also no need to introduce a dependency on dateutil, so I have changed the code to use `datetime.fromisotimestamp`.

### QA notes

Check if the changes of #3521 still work.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
