### PR TITLE
Fix grace period is being used instead of interval for boefjes that have interval specified in scheduler

### DIFF
--- a/mula/tests/integration/test_boefje_scheduler.py
+++ b/mula/tests/integration/test_boefje_scheduler.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import mock
 
+from scheduler import config, connectors, models, schedulers, storage
 from structlog.testing import capture_logs
 
-from scheduler import config, connectors, models, schedulers, storage
 from tests.factories import (
     BoefjeFactory,
     BoefjeMetaFactory,

--- a/mula/tests/integration/test_boefje_scheduler.py
+++ b/mula/tests/integration/test_boefje_scheduler.py
@@ -3,9 +3,9 @@ from datetime import datetime, timedelta, timezone
 from types import SimpleNamespace
 from unittest import mock
 
-from scheduler import config, connectors, models, schedulers, storage
 from structlog.testing import capture_logs
 
+from scheduler import config, connectors, models, schedulers, storage
 from tests.factories import (
     BoefjeFactory,
     BoefjeMetaFactory,
@@ -375,6 +375,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         self.assertFalse(self.scheduler.has_boefje_task_stalled(boefje_task))
@@ -403,6 +404,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         self.assertTrue(self.scheduler.has_boefje_task_stalled(boefje_task))
@@ -434,6 +436,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         with self.assertRaises(RuntimeError):
@@ -468,6 +471,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         self.assertFalse(self.scheduler.has_boefje_task_started_running(boefje_task))
@@ -497,6 +501,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         has_passed = self.scheduler.has_boefje_task_grace_period_passed(boefje_task)
@@ -529,6 +534,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = None
+        self.mock_get_plugin.return_value = None
 
         # Act
         has_passed = self.scheduler.has_boefje_task_grace_period_passed(boefje_task)
@@ -567,6 +573,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = last_run_boefje
+        self.mock_get_plugin.return_value = None
 
         # Act
         has_passed = self.scheduler.has_boefje_task_grace_period_passed(boefje_task)
@@ -605,6 +612,7 @@ class BoefjeSchedulerTestCase(BoefjeSchedulerBaseTestCase):
         # Mock
         self.mock_get_latest_task_by_hash.return_value = task_db
         self.mock_get_last_run_boefje.return_value = last_run_boefje
+        self.mock_get_plugin.return_value = None
 
         # Act
         has_passed = self.scheduler.has_boefje_task_grace_period_passed(boefje_task)


### PR DESCRIPTION
### Changes

- In `has_boefje_task_grace_period_passed()` added a check to verify if a BoefjeTask has a Boefje associated with it that has an interval specified. Otherwise it will adhere to the default grace period specified, meaning:
  - if an interval of more than a day is specified it will still check it daily, and
  - if an interval of less than a day is specified it will check it daily

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/3601

### QA notes

- Go through the onboarding, scan mispoes
- Verify tasks have started
- Go to the katalogus
- Add boefje variant to the dnssec boefje, name it 5min and enable it
- Wait +/- 5 minutes
- New tasks should've been started with the 5min boefje

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
