### PR TITLE
Remove an erroneously generated request body from an object history GET call in Octopoes' router

### DIFF
--- a/octopoes/octopoes/api/router.py
+++ b/octopoes/octopoes/api/router.py
@@ -224,7 +224,7 @@ def get_object_history(
     has_doc: bool | None = None,
     offset: int = 0,
     limit: int | None = None,
-    indices: list[int] | None = None,
+    indices: list[int] | None = Query(None),
     octopoes: OctopoesService = Depends(octopoes_service),
 ) -> list[TransactionRecord]:
     return octopoes.get_ooi_history(

--- a/octopoes/tests/integration/test_api_connector.py
+++ b/octopoes/tests/integration/test_api_connector.py
@@ -104,7 +104,7 @@ def test_history(octopoes_api_connector: OctopoesAPIConnector):
     assert len(octopoes_api_connector.get_history(network.reference, offset=1)) == 2
     assert len(octopoes_api_connector.get_history(network.reference, limit=2)) == 2
 
-    first_and_last = octopoes_api_connector.get_history(network.reference, has_doc=True, indices=[1, -1])
+    first_and_last = octopoes_api_connector.get_history(network.reference, has_doc=True, indices=[0, -1])
     assert len(first_and_last) == 2
     assert first_and_last[0].valid_time == first_seen
     assert first_and_last[1].valid_time == last_seen


### PR DESCRIPTION
Remove an erroneously generated request body from an object history GET call in Octopoes' router

### Changes

Remove an erroneously generated request body from an object history GET call in Octopoes' router

Many thanks to @ammar92 for essentially fixing this.


### Issue link

Fixed as promised in #3495

### Demo

Before:
![image](https://github.com/user-attachments/assets/ab9a7f70-a1b2-48ca-947c-71c27ae256e0)

After:
![image](https://github.com/user-attachments/assets/359ef7bb-222a-4fa2-9ebb-512598cfc0be)


### QA notes

Do a regular onboarding with mispo.es, browse to http://localhost:8001/docs#/Objects/get_object_history__client__object_history_get and verify you can see the history of an OOI like `URL|internet|https://mispo.es/` for instance.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
