### PR TITLE
Update boefje interval texts to make functionality more clear

### DIFF
--- a/rocky/katalogus/templates/plugin_container_image.html
+++ b/rocky/katalogus/templates/plugin_container_image.html
@@ -46,7 +46,7 @@
                                     <th scope="col">{% translate "Scan level" %}</th>
                                     <th scope="col">{% translate "Status" %}</th>
                                     <th scope="col">{% translate "Age" %}</th>
-                                    <th scope="col">{% translate "Time-out interval" %}</th>
+                                    <th scope="col">{% translate "Scan frequency" %}</th>
                                     <th scope="col"></th>
                                 </tr>
                             </thead>
@@ -81,7 +81,7 @@
                                                 {% if variant.interval %}
                                                     {{ variant.interval }} {% translate "minutes" %}
                                                 {% else %}
-                                                    {% translate "Default system interval" %}
+                                                    {% translate "Default system scan frequency" %}
                                                 {% endif %}
                                             </span>
                                         </td>

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -1189,7 +1189,7 @@ msgid "Age"
 msgstr ""
 
 #: katalogus/templates/plugin_container_image.html tools/forms/boefje.py
-msgid "Time-out interval"
+msgid "Scan frequency"
 msgstr ""
 
 #: katalogus/templates/plugin_container_image.html
@@ -1202,7 +1202,7 @@ msgid "minutes"
 msgstr ""
 
 #: katalogus/templates/plugin_container_image.html
-msgid "Default system interval"
+msgid "Default system scan frequency"
 msgstr ""
 
 #: katalogus/templates/plugin_container_image.html
@@ -4283,8 +4283,8 @@ msgstr ""
 
 #: tools/forms/boefje.py
 msgid ""
-"Specify the time-out interval for tasks using this Boefje in minutes. The "
-"default is 24 hours."
+"Specify the scanning frequency for this Boefje in minutes. The default is 24 hours."
+"For example: 5 minutes will let the boefje scan every 5 minutes."
 msgstr ""
 
 #: tools/forms/finding_type.py

--- a/rocky/tools/forms/boefje.py
+++ b/rocky/tools/forms/boefje.py
@@ -63,11 +63,12 @@ class BoefjeAddForm(BaseRockyForm):
     )
     interval = forms.CharField(
         required=False,
-        label=_("Time-out interval"),
+        label=_("Scan frequency"),
         widget=forms.TextInput(
             attrs={
                 "description": _(
-                    "Specify the time-out interval for tasks using this Boefje in minutes. The default is 24 hours."
+                    "Specify the scanning frequency for this Boefje in minutes. The default is 24 hours. "
+                    "For example: 5 minutes will let the boefje scan every 5 minutes."
                 )
             }
         ),


### PR DESCRIPTION
### Changes

This PR updates the texts initially set in #3579, as the functionality wasn't working back then. After the QA from the functionality it become clear that the texts were too technical/unclear as to what the functionality does. This PR fixes this to make them better aligned.

### Issue link
Update on: #3579 

### Demo
On the boefje overview page for Nmap: 
![image](https://github.com/user-attachments/assets/8a33c545-dd56-401f-8717-f18a2bef3701)

Editing/creating a boefje variant now looks like this: 
![image](https://github.com/user-attachments/assets/9c82495e-5382-40b7-8ae2-b7ee8e702a2a)



### QA notes
No specific notes. 

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
