### PR TITLE
Update development tutorial documentation

### DIFF
--- a/docs/source/developer_documentation/development_tutorial/creating_a_normalizer.md
+++ b/docs/source/developer_documentation/development_tutorial/creating_a_normalizer.md
@@ -29,6 +29,7 @@ Here is an example of how our `normalizer.json` can look like:
 ```json
 {
   "id": "hello-katty-normalize",
+  "name": "hello katty normalizer",
   "consumes": ["boefje/hello-katty"],
   "produces": ["IPAddressV6", "IPAddressV4", "Network", "Greeting"]
 }
@@ -45,7 +46,6 @@ import json
 from collections.abc import Iterable
 from ipaddress import AddressValueError, IPv4Network, NetmaskValueError
 
-from boefjes.job_models import NormalizerMeta
 from octopoes.models import OOI
 from octopoes.models.ooi.network import IPAddressV4, IPAddressV6, Network
 from octopoes.models.ooi.greeting import Greeting
@@ -58,13 +58,13 @@ def is_ipv4(string: str) -> bool:
     except (AddressValueError, NetmaskValueError, ValueError) as e:
         return False
 
-def run(normalizer_meta: NormalizerMeta, raw: bytes | str) -> Iterable[OOI]:
+def run(input_ooi: dict, raw: bytes) -> Iterable[OOI]:
     """Function that gets run to produce OOIs from the boefje it consumes"""
 
     data_string = str(raw, "utf-8")
     data: dict = json.loads(data_string)
 
-    network = Network(name=normalizer_meta.raw_data.boefje_meta.arguments["input"]["network"]["name"])
+    network = Network(name=input_ooi["network"]["name"])
     yield network
 
     ip = None


### PR DESCRIPTION
### Changes

This pull request updates the documentation for the `Development tutorial - normalizer page`, as there is an issue with the normalizer definition and the normalizer code.

### Issue link

Following the [tutorial](https://docs.openkat.nl/developer_documentation/development_tutorial/index.html) results in a normalizer that fails.

#### How to reproduce

-  clone the repository
- start openkat with `make kat`
- create a test organization
- follow the guide to create the boefje here https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html
- follow the guide to create the model here https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_new_model.html
- follow the guide to create the normalizer here https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_normalizer.html
- navigate to the kat-alogus
- search for `Hello Katty`
- set the configuration for `MESSAGE` from the UI and enable the boefje (do not set `NUMBER` otherwise the boefje fails as explained in #2)
- go to the kat-alogus, it fails
![Screenshot from 2024-10-02 14-29-25](https://github.com/user-attachments/assets/18705d33-d054-4633-8b7a-5d6b93829af7)
- inspect the container logs for the kat-alogus, it complains about
```
  File "/app/boefjes/boefjes/local_repository.py", line 137, in resolve_normalizers
    normalizer_resources.append(NormalizerResource(path, package))
                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/boefjes/boefjes/plugins/models.py", line 84, in __init__
    self.normalizer = Normalizer.model_validate_json(path.joinpath(NORMALIZER_DEFINITION_FILE).read_text())
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/pydantic/main.py", line 625, in model_validate_json
    return cls.__pydantic_validator__.validate_json(json_data, strict=strict, context=context)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
pydantic_core._pydantic_core.ValidationError: 1 validation error for Normalizer
name
  Field required [type=missing, input_value={'id': 'hello-katty-norma... 'Network', 'Greeting']}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.9/v/missing

```

#### Expected behaviour

The boefje and normalizer should run successfully

#### Workaround

- add the property `name` to the `normalizer.json` file
```JSON
{
    "id": "hello-katty-normalize",
    "name": "hello-katty-normalizer",
    "consumes": ["boefje/hello-katty"],
    "produces": ["IPAddressV6", "IPAddressV4", "Network", "Greeting"]
}
```
- the boefje and normalizer are visible now in the kat-alogus, however, the normalizer stills fails when is is run
![Screenshot from 2024-10-02 14-34-04](https://github.com/user-attachments/assets/690b0bfb-db62-4fa4-a53a-40c9bd31160b)

- replace the following code
```
# replace line 18
def run(normalizer_meta: NormalizerMeta, raw: bytes | str) -> Iterable[OOI]: 
# with
def run(input_ooi: dict, raw: bytes) -> Iterable[OOI]:

# replace line 24
network = Network(name=normalizer_meta.raw_data.boefje_meta.arguments["input"]["network"]["name"])
# with
network = Network(name=input_ooi["network"]["name"])
```
- run `make down && make kat`
- run the boefje
- now the boefje and normalizer work
![Screenshot from 2024-10-02 14-43-12](https://github.com/user-attachments/assets/9d024c9f-1811-4480-be5d-af6f32d9b294)


### Demo

No new functionalities.

### QA notes

No new code was introduced, only changes in a MD file.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

- [ ] The code does not violate Model-View-Template and our other architectural principles.
- [ ] The code prioritizes readability over performance where appropriate.
- [ ] The code does not bypass authentication or security mechanisms.
- [ ] The code does not introduce any dependency on a library that has not been properly vetted.
- [ ] The code contains docstrings, comments, and documentation where needed.

---

## Checklist for QA:

- [ ] I have checked out this branch, and successfully ran a fresh `make reset`.
- [ ] I confirmed that there are no unintended functional regressions in this branch:
  - [ ] I have managed to pass the onboarding flow
  - [ ] Objects and Findings are created properly
  - [ ] Tasks are created and completed properly
- [ ] I confirmed that the PR's advertised `feature` or `hotfix` works as intended.
- [ ] I checked the logs for errors and/or warnings and made issues where necessary