### PR TITLE
Silence KATFindingType not found error in JobHandler

### DIFF
--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -106,7 +106,7 @@ class BoefjeHandler(Handler):
                 )
             except ObjectNotFoundException as e:
                 if reference.class_type == KATFindingType:
-                    logger.exception("Object {%s} not found in Octopoes", e)
+                    logger.error("Object %s not found in Octopoes", reference)
                     return
                 else:
                     raise ObjectNotFoundException(f"Object {reference} not found in Octopoes") from e

--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -22,7 +22,6 @@ from octopoes.api.models import Affirmation, Declaration, Observation
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import Reference, ScanLevel
 from octopoes.models.exception import ObjectNotFoundException
-from octopoes.models.ooi.findings import KATFindingType
 
 MIMETYPE_MIN_LENGTH = 5  # two chars before, and 2 chars after the slash ought to be reasonable
 
@@ -104,12 +103,14 @@ class BoefjeHandler(Handler):
                 ooi = get_octopoes_api_connector(boefje_meta.organization).get(
                     reference, valid_time=datetime.now(timezone.utc)
                 )
-            except ObjectNotFoundException as e:
-                if reference.class_type == KATFindingType:
-                    logger.error("Object %s not found in Octopoes", reference)
-                    return
-                else:
-                    raise ObjectNotFoundException(f"Object {reference} not found in Octopoes") from e
+            except ObjectNotFoundException:
+                logger.info(
+                    "Can't run boefje because OOI does not exist anymore",
+                    boefje_id=boefje_meta.boefje.id,
+                    ooi=reference,
+                    task_id=boefje_meta.id,
+                )
+                return
 
             boefje_meta.arguments["input"] = ooi.serialize()
 

--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -22,6 +22,7 @@ from octopoes.api.models import Affirmation, Declaration, Observation
 from octopoes.connector.octopoes import OctopoesAPIConnector
 from octopoes.models import Reference, ScanLevel
 from octopoes.models.exception import ObjectNotFoundException
+from octopoes.models.ooi.findings import KATFindingType
 
 MIMETYPE_MIN_LENGTH = 5  # two chars before, and 2 chars after the slash ought to be reasonable
 
@@ -104,7 +105,11 @@ class BoefjeHandler(Handler):
                     reference, valid_time=datetime.now(timezone.utc)
                 )
             except ObjectNotFoundException as e:
-                raise ObjectNotFoundException(f"Object {reference} not found in Octopoes") from e
+                if reference.class_type == KATFindingType:
+                    logger.exception("Object {%s} not found in Octopoes", e)
+                    return
+                else:
+                    raise ObjectNotFoundException(f"Object {reference} not found in Octopoes") from e
 
             boefje_meta.arguments["input"] = ooi.serialize()
 


### PR DESCRIPTION
### Changes

Silence KATFindingType not found error in JobHandler in an attempt to propose a solution to #3598
(The issue is likely with KATFindingType because the get deleted and affirmed continuously) 

### Issue link

#3598

### Demo

### QA notes
Mimic #3598

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
