### PR TITLE
add more precise error when rabbitMQ cannot be reached when storing raw files

### DIFF
--- a/bytes/bytes/api/router.py
+++ b/bytes/bytes/api/router.py
@@ -1,6 +1,7 @@
 from base64 import b64decode
 from uuid import UUID
 
+import pika.exceptions
 import structlog
 from cachetools import TTLCache, cached
 from fastapi import APIRouter, Depends, HTTPException, Query
@@ -190,6 +191,11 @@ def create_raw(
                 raw_data=RawDataMeta(id=raw_id, boefje_meta=raw_data.boefje_meta, mime_types=raw_data.mime_types),
             )
             event_manager.publish(event)
+        except pika.exceptions.AMQPError:
+            logger.exception("Error sending 'new raw data' event to RabbitMQ")
+            raise HTTPException(
+                status_code=codes.INTERNAL_SERVER_ERROR, detail="Error sending 'new raw data' event to RabbitMQ"
+            ) from error
         except Exception as error:
             logger.exception("Error saving raw data")
             raise HTTPException(status_code=codes.INTERNAL_SERVER_ERROR, detail="Could not save raw data") from error


### PR DESCRIPTION

### Changes

Specifically catches the rabbitMQ errors which might occur if (even after the retries) it still cannot be reached.
The original 500 does not show the stacktrace in de logs, and as such there is no easy way for the user to know rabbitMQ might be at fault.

### Issue link

```
bytes-1                | $IP:$PORT - "POST /bytes/raw?boefje_meta_id=$SOME_UUID HTTP/1.1" 500
bytes-1                | fastapi.exceptions.HTTPException: 500: Could not save raw data
```

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
