### PR TITLE
Make systemctl call for kat-rocky-worker conditional

### DIFF
--- a/scripts/installation/openkat-empty-job-queue.sh
+++ b/scripts/installation/openkat-empty-job-queue.sh
@@ -2,7 +2,12 @@
 
 # Stop openKAT
 echo "Stopping openKAT processes"
-sudo systemctl stop xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl stop xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl stop kat-rocky-worker
+fi
 
 # Start postgres, switch to the mula_db and empty the job queue
 echo "Emptying job queue"
@@ -13,6 +18,11 @@ EOF
 
 # Start openKAT
 echo "Starting openKAT processes"
-sudo systemctl start xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl start xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl stop kat-rocky-worker
+fi
 
 echo "End of script. It might take a few more seconds for OpenKAT to be fully started and available."

--- a/scripts/installation/openkat-install.sh
+++ b/scripts/installation/openkat-install.sh
@@ -285,9 +285,19 @@ echo "Step 6.11 - Set kat permissions in rabbitmq"
 sudo rabbitmqctl set_permissions -p "kat" "kat" ".*" ".*" ".*"
 
 echo "Step 7 - Configure start at system boot"
-sudo systemctl enable kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl enable kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl enable kat-rocky-worker
+fi
 
 echo "Step 8 - Restart OpenKAT"
-sudo systemctl restart kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl restart kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl restart kat-rocky-worker
+fi
 
 echo "Step 9 - End of OpenKAT install script"

--- a/scripts/installation/openkat-reset.sh
+++ b/scripts/installation/openkat-reset.sh
@@ -29,7 +29,12 @@ fi
 pushd /
 
 echo "Stop OpenKAT"
-sudo systemctl stop xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl stop xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl stop kat-rocky-worker
+fi
 
 echo "Delete XTDB databases"
 sudo rm -rf /var/lib/xtdb/*
@@ -89,6 +94,11 @@ if [[ ${1} != "no_super_user" ]]; then
 fi
 
 echo "Start OpenKAT"
-sudo systemctl start xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl start xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl start kat-rocky-worker
+fi
 
 popd

--- a/scripts/installation/openkat-restart.sh
+++ b/scripts/installation/openkat-restart.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 echo "Restarting openKAT..."
-sudo systemctl restart xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl restart xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl restart kat-rocky-worker
+fi

--- a/scripts/installation/openkat-start.sh
+++ b/scripts/installation/openkat-start.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 echo "Starting openKAT..."
-sudo systemctl start xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl start xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl start kat-rocky-worker
+fi

--- a/scripts/installation/openkat-stop.sh
+++ b/scripts/installation/openkat-stop.sh
@@ -1,4 +1,9 @@
 #!/bin/bash
 
 echo "Stopping openKAT..."
-sudo systemctl stop xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl stop xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl stop kat-rocky-worker
+fi

--- a/scripts/installation/openkat-update.sh
+++ b/scripts/installation/openkat-update.sh
@@ -82,6 +82,11 @@ sudo -u kat update-katalogus-db
 sudo -u kat update-mula-db
 
 echo "Step 7 - Restart OpenKAT"
-sudo systemctl restart xtdb-http-multinode kat-rocky kat-rocky-worker kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+sudo systemctl restart xtdb-http-multinode kat-rocky kat-mula kat-bytes kat-boefjes kat-normalizers kat-katalogus kat-keiko kat-octopoes kat-octopoes-worker
+
+# Kat-rocky-worker service was introduced in OpenKAT 1.18
+if [ -f /usr/lib/systemd/system/kat-rocky-worker.service ]; then
+    sudo systemctl restart kat-rocky-worker
+fi
 
 echo "End of OpenKAT update script"


### PR DESCRIPTION
### Changes

Make systemctl call for kat-rocky-worker conditional so it doesn't get executed for 1.17 that doesn't have a kat rocky worker service.

### QA notes

Run the scripts on 1.17 and main. I already tested this myself.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
