### PR TITLE
Silence staticfiles warning

### DIFF
--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -495,3 +495,10 @@ POOL_SIZE = env.int("POOL_SIZE", default=2)
 POLL_INTERVAL = env.int("POLL_INTERVAL", default=10)
 # Seconds to wait before checking the workers when queues are full
 WORKER_HEARTBEAT = env.int("WORKER_HEARTBEAT", default=5)
+
+# In production deployments the staticfiles are coming from the collected static
+# files in the static directory. We should not ship all those files also in
+# their original location, but Django will complain if a directory in
+# STATICFILES_DIRS does not exist. We silence the warning here to prevent the
+# warning from confusing users.
+SILENCED_SYSTEM_CHECKS = ["staticfiles.W004"]


### PR DESCRIPTION
### Changes

This silences the staticfiles warning. In prod environments we don't need the source of the static files, but Django will complain if the directory does not exist, so we should silence the warning.

### Issue link

Closes #3791 

### QA notes

There is not much to QA.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
