### PR TITLE
Let local plugins (files) take precedence over database entries

### DIFF
--- a/boefjes/boefjes/dependencies/plugins.py
+++ b/boefjes/boefjes/dependencies/plugins.py
@@ -49,9 +49,9 @@ class PluginService:
         return [self._set_plugin_enabled(plugin, organisation_id) for plugin in all_plugins.values()]
 
     def _get_all_without_enabled(self) -> dict[str, PluginType]:
-        all_plugins = {plugin.id: plugin for plugin in self.local_repo.get_all()}
+        all_plugins = {plugin.id: plugin for plugin in self.plugin_storage.get_all()}
 
-        for plugin in self.plugin_storage.get_all():
+        for plugin in self.local_repo.get_all():  # Local plugins take precedence
             all_plugins[plugin.id] = plugin
 
         return all_plugins
@@ -175,7 +175,7 @@ class PluginService:
     def schema(self, plugin_id: str) -> dict | None:
         plugin = self._get_all_without_enabled().get(plugin_id)
 
-        if not plugin or not isinstance(plugin, Boefje):
+        if plugin is None or not isinstance(plugin, Boefje):
             return None
 
         return plugin.boefje_schema

--- a/boefjes/boefjes/storage/interfaces.py
+++ b/boefjes/boefjes/storage/interfaces.py
@@ -56,8 +56,17 @@ class CannotUpdateStaticPlugin(NotAllowed):
 
 
 class DuplicatePlugin(NotAllowed):
-    def __init__(self, key: str):
-        super().__init__(f"Duplicate plugin {key}")
+    FIELD_NAMES = {"boefje_plugin_id": "id", "boefje_name": "name"}
+
+    def __init__(self, *, field: str | None = None, error_message: str = ""):
+        if not field:
+            for name, field_name in self.FIELD_NAMES.items():
+                if name not in error_message:
+                    continue
+
+                field = field_name
+
+        super().__init__(f'Duplicate plugin "{field}"')
 
 
 class OrganisationStorage(ABC):

--- a/boefjes/tests/integration/test_api.py
+++ b/boefjes/tests/integration/test_api.py
@@ -169,6 +169,16 @@ def test_cannot_create_boefje_with_invalid_schema(test_client, organisation):
     assert r.status_code == 422
 
 
+def test_schema_is_taken_from_disk(test_client, organisation, session):
+    # creates a database record of dns-records
+    test_client.patch(f"/v1/organisations/{organisation.id}/plugins/dns-records", json={"enabled": True})
+    session.execute("UPDATE boefje set schema = null where plugin_id = 'dns-records'")
+    session.commit()
+
+    response = test_client.get(f"/v1/organisations/{organisation.id}/plugins/dns-records").json()
+    assert response["boefje_schema"] is not None
+
+
 def test_cannot_set_invalid_cron(test_client, organisation):
     boefje = Boefje(id="test_plugin", name="My test boefje", description="123").model_dump(mode="json")
     boefje["cron"] = "bad format"

--- a/boefjes/tests/integration/test_api.py
+++ b/boefjes/tests/integration/test_api.py
@@ -45,12 +45,12 @@ def test_cannot_add_plugin_reserved_id(test_client, organisation):
     boefje = Boefje(id="dns-records", name="My test boefje", static=False)
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=boefje.model_dump_json())
     assert response.status_code == 400
-    assert response.json() == {"detail": "Duplicate plugin id"}
+    assert response.json() == {"detail": 'Duplicate plugin "id"'}
 
     normalizer = Normalizer(id="kat_nmap_normalize", name="My test normalizer")
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=normalizer.model_dump_json())
     assert response.status_code == 400
-    assert response.json() == {"detail": "Duplicate plugin id"}
+    assert response.json() == {"detail": 'Duplicate plugin "id"'}
 
 
 def test_add_boefje(test_client, organisation):
@@ -80,7 +80,7 @@ def test_cannot_add_static_plugin_with_duplicate_name(test_client, organisation)
     boefje = Boefje(id="test_plugin", name="DNS records", static=False)
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=boefje.model_dump_json())
     assert response.status_code == 400
-    assert response.json() == {"detail": "Duplicate plugin name"}
+    assert response.json() == {"detail": 'Duplicate plugin "name"'}
 
 
 def test_cannot_add_plugin_with_duplicate_name(test_client, organisation):
@@ -91,7 +91,7 @@ def test_cannot_add_plugin_with_duplicate_name(test_client, organisation):
     boefje = Boefje(id="test_plugin_2", name="My test boefje", static=False)
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=boefje.model_dump_json())
     assert response.status_code == 400
-    assert response.json() == {"detail": "Duplicate plugin name"}
+    assert response.json() == {"detail": 'Duplicate plugin "name"'}
 
     normalizer = Normalizer(id="test_normalizer", name="My test normalizer", static=False)
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=normalizer.model_dump_json())


### PR DESCRIPTION
### Changes

This makes sure we return info from the `boefjes.json` and `schema.json` instead of returning data in the database. This solves issues where we updated these files locally but did not see the changes reflected due to a stale database.


### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/3850

### Demo

-

### QA notes

Please enable `dns-records` and then delete the `schema.json` file in the `kat_dns` directory in the boefjes module. In the KATalogus, we should see no more settings for `dns-records` (perhaps after a restart of the boefjes container: `docker compose restart boefje katalogus`).

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
