### PR TITLE
Skip empty queues in the Rocky worker

### DIFF
--- a/rocky/reports/runner/worker.py
+++ b/rocky/reports/runner/worker.py
@@ -85,7 +85,7 @@ class SchedulerWorkerManager(WorkerManager):
 
         # We do not target a specific queue since we start one runtime for all organisations
         # and queue ids contain the organisation_id
-        queues = [q for q in queues if q.id.startswith("report")]
+        queues = [q for q in queues if q.id.startswith("report") and q.size > 0]
 
         logger.debug("Found queues: %s", [queue.id for queue in queues])
 


### PR DESCRIPTION
### Changes

Trivial change: same as in the boefjes worker we now skip empty queues for less polling overhead.

### Issue link

-

### Demo

-

### QA notes

Please verify that the scheduled reports still work!

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
