### PR TITLE
Increase max number of PostgreSQL connections

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,9 @@ services:
       test: ["CMD", "gosu", "postgres", "pg_isready"]
       interval: 10s
       retries: 10
+    # Django runserver does not limit the number of threads. We need to increase
+    # the maximum number of connection to make sure that we don't hit the limit.
+    command: -c max_connections=500
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./init-user-db.sh:/docker-entrypoint-initdb.d/init-user-db.sh


### PR DESCRIPTION
### Changes

This PR increases the max number of PostgreSQL connections in docker-compose.yml.

When trying to reproduce this I couldn't do this in a production setup with granian, but I could reproduce the problem with runserver. With granian we have a configured maximum number of workers/threads, so there is a maximum of concurrent requests and we don't hit the PostgreSQL connection limit. Runserver however doesn't have this and will just create as many threads as there are requests. So 50 requests for 50 katalogus images would result in 100 connections and hit the limit (one database connection in rocky and one database connection in the katalogus). 

With the lazy loading of katalogus images this should also be less of a problem, but I think it is still good to increase the maximum number of database connections.

### Issue link

Closes #2304
Closes #2404 

### QA notes

Only a database setting in the development setup changed, so not much to check other than if "make kat" still works.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
