### PR TITLE
Add additional check if task already run for report scheduler

### DIFF
--- a/mula/scheduler/schedulers/schedulers/report.py
+++ b/mula/scheduler/schedulers/schedulers/report.py
@@ -91,34 +91,35 @@ class ReportScheduler(Scheduler):
                 # When the schedule has no schedule (cron expression), but a
                 # task is already executed for this schedule we should not run
                 # the task again
-                try:
-                    _, count = self.ctx.datastores.task_store.get_tasks(
-                        scheduler_id=self.scheduler_id,
-                        task_type=report_task.type,
-                        filters=filters.FilterRequest(
-                            filters=[
-                                filters.Filter(column="hash", operator="eq", value=report_task.hash),
-                                filters.Filter(column="schedule_id", operator="eq", value=str(schedule.id)),
-                            ]
-                        ),
-                    )
-                    if count > 0 and schedule.schedule is None:
-                        self.logger.debug(
-                            "Schedule has no schedule, but task already executed",
-                            schedule_id=schedule.id,
+                if schedule.schedule is None:
+                    try:
+                        _, count = self.ctx.datastores.task_store.get_tasks(
+                            scheduler_id=self.scheduler_id,
+                            task_type=report_task.type,
+                            filters=filters.FilterRequest(
+                                filters=[
+                                    filters.Filter(column="hash", operator="eq", value=report_task.hash),
+                                    filters.Filter(column="schedule_id", operator="eq", value=str(schedule.id)),
+                                ]
+                            ),
+                        )
+                        if count > 0:
+                            self.logger.debug(
+                                "Schedule has no schedule, but task already executed",
+                                schedule_id=schedule.id,
+                                scheduler_id=self.scheduler_id,
+                                organisation_id=self.organisation.id,
+                            )
+                            continue
+                    except storage.errors.StorageError as exc_db:
+                        self.logger.error(
+                            "Could not get latest task by hash %s",
+                            report_task.hash,
                             scheduler_id=self.scheduler_id,
                             organisation_id=self.organisation.id,
+                            exc_info=exc_db,
                         )
                         continue
-                except storage.errors.StorageError as exc_db:
-                    self.logger.error(
-                        "Could not get latest task by hash %s",
-                        report_task.hash,
-                        scheduler_id=self.scheduler_id,
-                        organisation_id=self.organisation.id,
-                        exc_info=exc_db,
-                    )
-                    continue
 
                 executor.submit(self.push_report_task, report_task, self.push_tasks_for_rescheduling.__name__)
 

--- a/mula/scheduler/schedulers/schedulers/report.py
+++ b/mula/scheduler/schedulers/schedulers/report.py
@@ -98,7 +98,7 @@ class ReportScheduler(Scheduler):
                         filters=filters.FilterRequest(
                             filters=[
                                 filters.Filter(column="hash", operator="eq", value=report_task.hash),
-                                filters.Filter(column="schedule_id", operator="eq", value=schedule.id),
+                                filters.Filter(column="schedule_id", operator="eq", value=str(schedule.id)),
                             ]
                         ),
                     )


### PR DESCRIPTION
### Changes

Since we're allowing scheduled tasks that have a single recurrence. We need to check if the task is already on the queue and we need to check if the task has been executed before when there isn't a cron expression is specified.  This PR addsthis  additional check if task already run for the report scheduler.

### QA notes

With https://github.com/minvws/nl-kat-coordination/pull/3840 check if you can schedule different type of reporting jobs with different recurrence and make sure that it executes tasks as expected.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
