### PR TITLE
Fix mula migrations Debian package

### DIFF
--- a/mula/MANIFEST.in
+++ b/mula/MANIFEST.in
@@ -1,2 +1,1 @@
-include scheduler/alembic.ini
-include scheduler/alembic/script.py.mako
+include scheduler/storage/migrations/alembic.ini

--- a/mula/packaging/deb/data/usr/bin/update-mula-db
+++ b/mula/packaging/deb/data/usr/bin/update-mula-db
@@ -4,4 +4,4 @@ set -ae
 source /usr/lib/kat/mula.defaults
 source /etc/kat/mula.conf
 cd /opt/venvs/kat-mula/lib/python*/site-packages
-/opt/venvs/kat-mula/bin/python -m alembic --config scheduler/alembic.ini upgrade head
+/opt/venvs/kat-mula/bin/python -m alembic --config scheduler/storage/migrations/alembic.ini upgrade head


### PR DESCRIPTION
### Changes

The movement of files in mula broke the migrations in the Debian package:
https://github.com/minvws/nl-kat-coordination/actions/runs/12070765548/job/33661255621

This also updates the paths that are used in Debian packaging.

### QA notes

We can trigger the Debian package test workflow manually and to see if it works again:
https://github.com/minvws/nl-kat-coordination/actions/runs/12085353362

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
