### PR TITLE
Do not let enabling plugins affect the global plugin cache

### DIFF
--- a/boefjes/boefjes/dependencies/plugins.py
+++ b/boefjes/boefjes/dependencies/plugins.py
@@ -43,13 +43,13 @@ class PluginService:
 
     def get_all(self, organisation_id: str) -> list[PluginType]:
         all_plugins = self._get_all_without_enabled()
-        plugin_states = self.config_storage.get_state_by_id(organisation_id)
+        plugin_states = self.config_storage.get_states_for_organisation(organisation_id)
 
         for plugin in all_plugins.values():
             if plugin.id not in plugin_states:
                 continue
 
-            plugin.enabled = plugin_states[plugin.id]
+            all_plugins[plugin.id] = plugin.model_copy(update={"enabled": plugin_states[plugin.id]})
 
         return list(all_plugins.values())
 

--- a/boefjes/boefjes/sql/config_storage.py
+++ b/boefjes/boefjes/sql/config_storage.py
@@ -111,7 +111,7 @@ class SQLConfigStorage(SessionMixin, ConfigStorage):
 
         return [plugin[0] for plugin in enabled_normalizers.all()]
 
-    def get_state_by_id(self, organisation_id: str) -> dict[str, bool]:
+    def get_states_for_organisation(self, organisation_id: str) -> dict[str, bool]:
         enabled_boefjes = (
             self.session.query(BoefjeInDB.plugin_id, BoefjeConfigInDB.enabled)
             .join(BoefjeConfigInDB)

--- a/boefjes/boefjes/storage/interfaces.py
+++ b/boefjes/boefjes/storage/interfaces.py
@@ -157,5 +157,5 @@ class ConfigStorage(ABC):
     def get_enabled_normalizers(self, organisation_id: str) -> list[str]:
         raise NotImplementedError
 
-    def get_state_by_id(self, organisation_id: str) -> dict[str, bool]:
+    def get_states_for_organisation(self, organisation_id: str) -> dict[str, bool]:
         raise NotImplementedError

--- a/boefjes/boefjes/storage/memory.py
+++ b/boefjes/boefjes/storage/memory.py
@@ -131,5 +131,5 @@ class ConfigStorageMemory(ConfigStorage):
             if enabled and "norm" in plugin_id
         ]
 
-    def get_state_by_id(self, organisation_id: str) -> dict[str, bool]:
+    def get_states_for_organisation(self, organisation_id: str) -> dict[str, bool]:
         return self._enabled.get(organisation_id, {})

--- a/boefjes/tests/conftest.py
+++ b/boefjes/tests/conftest.py
@@ -239,6 +239,11 @@ def test_organisation():
 
 
 @pytest.fixture
+def second_test_organisation():
+    return Organisation(id="test2", name="Test org2")
+
+
+@pytest.fixture
 def mock_plugin_service(mock_local_repository, test_organisation) -> PluginService:
     storage = ConfigStorageMemory()
     storage.upsert(test_organisation.id, "test_plugin", {"DUMMY_VAR": "123"})
@@ -252,6 +257,14 @@ def organisation(organisation_storage, test_organisation) -> Organisation:
         repo.create(test_organisation)
 
     return test_organisation
+
+
+@pytest.fixture
+def second_organisation(organisation_storage, second_test_organisation) -> Organisation:
+    with organisation_storage as repo:
+        repo.create(second_test_organisation)
+
+    return second_test_organisation
 
 
 @pytest.fixture

--- a/boefjes/tests/integration/test_api.py
+++ b/boefjes/tests/integration/test_api.py
@@ -73,6 +73,16 @@ def test_add_boefje(test_client, organisation):
     assert response.json() == boefje_dict
 
 
+def test_enable_boefje(test_client, organisation, second_organisation):
+    test_client.patch(f"/v1/organisations/{organisation.id}/plugins/dns-records", json={"enabled": True})
+
+    response = test_client.get(f"/v1/organisations/{organisation.id}/plugins/dns-records")
+    assert response.json()["enabled"] is True
+
+    response = test_client.get(f"/v1/organisations/{second_organisation.id}/plugins/dns-records")
+    assert response.json()["enabled"] is False
+
+
 def test_cannot_add_static_plugin_with_duplicate_name(test_client, organisation):
     boefje = Boefje(id="test_plugin", name="DNS records", static=False)
     response = test_client.post(f"/v1/organisations/{organisation.id}/plugins", content=boefje.model_dump_json())
@@ -137,7 +147,7 @@ def test_delete_normalizer(test_client, organisation):
     assert response.status_code == 404
 
 
-def test_update_plugins(test_client, organisation):
+def test_update_plugins(test_client, organisation, second_organisation):
     normalizer = Normalizer(id="norm_id", name="My test normalizer")
     boefje = Boefje(id="test_plugin", name="My test boefje", description="123", interval=20)
 


### PR DESCRIPTION
### Changes

A nice example of why you should avoid caches as long as possible.

This PR makes sure we do not edit the `enabled` field in-place, since these objects are cached in-memory and hence take "remember" their previous state. If we perform no overrides by default, the state transcends organisations.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/3941

### Demo

See the new integration test that fails on main.

### QA notes

Please check if enabling `dns-records` in organization 1 does not enable it for organization 2!

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
