### PR TITLE
Update dropdown.scss, add scrolling / max height

### DIFF
--- a/rocky/assets/css/components/dropdown.scss
+++ b/rocky/assets/css/components/dropdown.scss
@@ -30,7 +30,9 @@
     border-radius: var(--border-radius-s);
     border: 1px solid var(--colors-grey-200);
     background-color: var(--colors-white);
-
+    max-height: 90vh;
+    overflow-x: scroll;
+    
     > ul {
       margin: 0;
       width: 100%;


### PR DESCRIPTION
### Changes

Adds the max-height on the organisation dropdown list, and makes it scrollable.

### Issue link


related: https://github.com/minvws/nl-kat-coordination/issues/3448

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

See if the dropdown box starts scrolling (but stays in screen), when it contains too many organizations to fit in the current screen.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
