### PR TITLE
Fix pagination in the history API

### DIFF
--- a/octopoes/octopoes/xtdb/client.py
+++ b/octopoes/octopoes/xtdb/client.py
@@ -120,7 +120,7 @@ class XTDBHTTPClient:
         if indices:
             return [tx for i, tx in enumerate(transactions) if i in indices or i - len(transactions) in indices]
 
-        return transactions[offset:None if limit is None else limit + offset]
+        return transactions[offset : None if limit is None else limit + offset]
 
     def query(self, query: str | Query, valid_time: datetime | None = None) -> list[list[Any]]:
         if valid_time is None:

--- a/octopoes/octopoes/xtdb/client.py
+++ b/octopoes/octopoes/xtdb/client.py
@@ -120,7 +120,7 @@ class XTDBHTTPClient:
         if indices:
             return [tx for i, tx in enumerate(transactions) if i in indices or i - len(transactions) in indices]
 
-        return transactions[offset:limit]
+        return transactions[offset:None if limit is None else limit + offset]
 
     def query(self, query: str | Query, valid_time: datetime | None = None) -> list[list[Any]]:
         if valid_time is None:

--- a/octopoes/tests/integration/test_api_connector.py
+++ b/octopoes/tests/integration/test_api_connector.py
@@ -103,8 +103,10 @@ def test_history(octopoes_api_connector: OctopoesAPIConnector):
     assert len(octopoes_api_connector.get_history(network.reference, limit=2)) == 2
 
     # Test that moving the offset with 1 shifts the result set
-    assert (octopoes_api_connector.get_history(network.reference, offset=0, limit=2)[1] ==
-            octopoes_api_connector.get_history(network.reference, offset=1, limit=2)[0])
+    assert (
+        octopoes_api_connector.get_history(network.reference, offset=0, limit=2)[1]
+        == octopoes_api_connector.get_history(network.reference, offset=1, limit=2)[0]
+    )
     assert len(octopoes_api_connector.get_history(network.reference, offset=2, limit=10)) == 1
     assert len(octopoes_api_connector.get_history(network.reference, offset=2, limit=1)) == 1
 

--- a/octopoes/tests/integration/test_api_connector.py
+++ b/octopoes/tests/integration/test_api_connector.py
@@ -102,6 +102,12 @@ def test_history(octopoes_api_connector: OctopoesAPIConnector):
     assert len(octopoes_api_connector.get_history(network.reference, offset=1)) == 2
     assert len(octopoes_api_connector.get_history(network.reference, limit=2)) == 2
 
+    # Test that moving the offset with 1 shifts the result set
+    assert (octopoes_api_connector.get_history(network.reference, offset=0, limit=2)[1] ==
+            octopoes_api_connector.get_history(network.reference, offset=1, limit=2)[0])
+    assert len(octopoes_api_connector.get_history(network.reference, offset=2, limit=10)) == 1
+    assert len(octopoes_api_connector.get_history(network.reference, offset=2, limit=1)) == 1
+
     first_and_last = octopoes_api_connector.get_history(network.reference, has_doc=True, indices=[0, -1])
     assert len(first_and_last) == 2
     assert first_and_last[0].valid_time == first_seen


### PR DESCRIPTION
### Changes

There was a small bug in the history API `offset` parameter.

### Issue link

-

### QA notes

The only way to perhaps verify that the history still works is by creating a Findings report, looking at the usages. But I'm not sure how the history is reflected in it..

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
