### PR TITLE
Make it possible to use SSL with PostgreSQL without client certificate

### DIFF
--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -249,9 +249,14 @@ if env.bool("POSTGRES_SSL_ENABLED", False):
     DATABASES["default"]["OPTIONS"] = {
         "sslmode": env("POSTGRES_SSL_MODE"),
         "sslrootcert": env.path("POSTGRES_SSL_ROOTCERT"),
-        "sslcert": env.path("POSTGRES_SSL_CERT"),
-        "sslkey": env.path("POSTGRES_SSL_KEY"),
     }
+
+    POSTGRES_SSL_CERT = env.path("POSTGRES_SSL_CERT", default=None)
+    POSTGRES_SSL_KEY = env.path("POSTGRES_SSL_KEY", default=None)
+
+    if POSTGRES_SSL_CERT and POSTGRES_SSL_KEY:
+        DATABASES["default"]["OPTIONS"]["sslcert"] = POSTGRES_SSL_CERT
+        DATABASES["default"]["OPTIONS"]["sslkey"] = POSTGRES_SSL_KEY
 
 # Password validation
 # https://docs.djangoproject.com/en/4.2/ref/settings/#auth-password-validators


### PR DESCRIPTION
### Changes

The rocky settings required providing a client certificate when you use SSL to connect to PostgreSQL, but it is also possible to connect using SSL without a client certificate.

### QA notes

_Please add some information for QA on how to test the newly created code._

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
