### PR TITLE
make reference parsing more strict in __init__.py

### DIFF
--- a/octopoes/octopoes/models/__init__.py
+++ b/octopoes/octopoes/models/__init__.py
@@ -11,8 +11,8 @@ from pydantic_core.core_schema import ValidationInfo
 class Reference(str):
     @classmethod
     def parse(cls, ref_str: str) -> tuple[str, str]:
-        object_type, *natural_key_parts = ref_str.split("|")
-        return object_type, "|".join(natural_key_parts)
+        object_type, natural_key_parts = ref_str.split("|", 1)
+        return object_type, natural_key_parts
 
     @property
     def class_(self) -> str:

--- a/octopoes/tests/conftest.py
+++ b/octopoes/tests/conftest.py
@@ -187,12 +187,12 @@ def http_resource_https(hostname, ipaddressv4, network):
 
 @pytest.fixture
 def empty_scan_profile():
-    return EmptyScanProfile(reference="test_reference")
+    return EmptyScanProfile(reference="test|reference")
 
 
 @pytest.fixture
 def declared_scan_profile():
-    return DeclaredScanProfile(reference="test_reference", level=2)
+    return DeclaredScanProfile(reference="test|reference", level=2)
 
 
 @pytest.fixture

--- a/octopoes/tests/test_bit_cipher.py
+++ b/octopoes/tests/test_bit_cipher.py
@@ -6,10 +6,10 @@ from octopoes.models.ooi.service import IPService, Service, TLSCipher
 
 
 def test_medium_bad_ciphers():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=22)
     ip_service = IPService(ip_port=port.reference, service=Service(name="https").reference)
-    cipher = TLSCipher(
+    cipher = TLSCipher(e
         ip_service=ip_service.reference,
         suites={
             "TLSv1.3": [
@@ -104,7 +104,7 @@ def test_medium_bad_ciphers():
 
 
 def test_good_ciphers():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=22)
     ip_service = IPService(ip_port=port.reference, service=Service(name="https").reference)
     cipher = TLSCipher(

--- a/octopoes/tests/test_bit_cipher.py
+++ b/octopoes/tests/test_bit_cipher.py
@@ -9,7 +9,7 @@ def test_medium_bad_ciphers():
     address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=22)
     ip_service = IPService(ip_port=port.reference, service=Service(name="https").reference)
-    cipher = TLSCipher(e
+    cipher = TLSCipher(
         ip_service=ip_service.reference,
         suites={
             "TLSv1.3": [

--- a/octopoes/tests/test_bit_ports.py
+++ b/octopoes/tests/test_bit_ports.py
@@ -6,7 +6,7 @@ from octopoes.models.ooi.network import IPAddressV4, IPPort
 
 
 def test_port_classification_tcp_80():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=80)
     results = list(run_port_classification(address, [port], {}))
 
@@ -14,7 +14,7 @@ def test_port_classification_tcp_80():
 
 
 def test_port_classification_udp_53():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=53)
     results = list(run_port_classification(address, [port], {}))
 
@@ -22,7 +22,7 @@ def test_port_classification_udp_53():
 
 
 def test_port_classification_tcp_22():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=22)
     results = list(run_port_classification(address, [port], {}))
 
@@ -33,7 +33,7 @@ def test_port_classification_tcp_22():
 
 
 def test_port_classification_tcp_5432():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=5432)
     results = list(run_port_classification(address, [port], {}))
 
@@ -44,7 +44,7 @@ def test_port_classification_tcp_5432():
 
 
 def test_port_classification_tcp_12345():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=12345)
     results = list(run_port_classification(address, [port], {}))
 
@@ -55,7 +55,7 @@ def test_port_classification_tcp_12345():
 
 
 def test_port_classification_tcp_3306_with_config():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="tcp", port=3306)
     results = list(run_port_classification(address, [port], {"db_tcp_ports": "1234"}))
 
@@ -66,7 +66,7 @@ def test_port_classification_tcp_3306_with_config():
 
 
 def test_port_classification_udp_80():
-    address = IPAddressV4(address="8.8.8.8", network="fake")
+    address = IPAddressV4(address="8.8.8.8", network="network|fake")
     port = IPPort(address=address.reference, protocol="udp", port=80)
     results = list(run_port_classification(address, [port], {}))
 
@@ -77,7 +77,7 @@ def test_port_classification_udp_80():
 
 
 def test_port_common_tcp_80():
-    port = IPPort(address="fake", protocol="tcp", port=80)
+    port = IPPort(address="address|8.8.8.8", protocol="tcp", port=80)
     results = list(run_port_common(port, [], {}))
 
     assert len(results) == 2
@@ -87,21 +87,21 @@ def test_port_common_tcp_80():
 
 
 def test_port_common_tcp_22():
-    port = IPPort(address="fake", protocol="tcp", port=22)
+    port = IPPort(address="address|8.8.8.8", protocol="tcp", port=22)
     results = list(run_port_common(port, [], {}))
 
     assert not results
 
 
 def test_port_common_udp_80():
-    port = IPPort(address="fake", protocol="udp", port=80)
+    port = IPPort(address="address|8.8.8.8", protocol="udp", port=80)
     results = list(run_port_common(port, [], {}))
 
     assert not results
 
 
 def test_port_common_udp_53():
-    port = IPPort(address="fake", protocol="udp", port=53)
+    port = IPPort(address="address|8.8.8.8", protocol="udp", port=53)
     results = list(run_port_common(port, [], {}))
 
     assert len(results) == 2

--- a/octopoes/tests/test_bits.py
+++ b/octopoes/tests/test_bits.py
@@ -7,7 +7,7 @@ from octopoes.models.ooi.web import URL, HTTPHeader, HTTPHeaderURL, Website
 
 
 def test_url_extracted_by_oois_in_headers_url():
-    header = HTTPHeader(resource="resouce|url", key="Location", value="https://www.example.com/")
+    header = HTTPHeader(resource="resource|url", key="Location", value="https://www.example.com/")
 
     results = list(run_oois_in_headers(header, [], {}))
 

--- a/octopoes/tests/test_bits.py
+++ b/octopoes/tests/test_bits.py
@@ -7,7 +7,7 @@ from octopoes.models.ooi.web import URL, HTTPHeader, HTTPHeaderURL, Website
 
 
 def test_url_extracted_by_oois_in_headers_url():
-    header = HTTPHeader(resource="", key="Location", value="https://www.example.com/")
+    header = HTTPHeader(resource="resouce|url", key="Location", value="https://www.example.com/")
 
     results = list(run_oois_in_headers(header, [], {}))
 
@@ -39,7 +39,7 @@ def test_url_extracted_by_oois_in_headers_relative_path(http_resource_https):
 
 
 def test_finding_generated_when_443_not_open_and_80_is_open():
-    port_80 = IPPort(address="fake", protocol="tcp", port=80)
+    port_80 = IPPort(address="address|fake", protocol="tcp", port=80)
     website = Website(ip_service="fake", hostname="fake")
     results = list(run_https_availability(None, [port_80, website], {}))
     finding = results[0]

--- a/octopoes/tests/test_bits.py
+++ b/octopoes/tests/test_bits.py
@@ -1,4 +1,4 @@
-cefrom bits.https_availability.https_availability import run as run_https_availability
+from bits.https_availability.https_availability import run as run_https_availability
 from bits.oois_in_headers.oois_in_headers import run as run_oois_in_headers
 
 from octopoes.models.ooi.findings import Finding

--- a/octopoes/tests/test_bits.py
+++ b/octopoes/tests/test_bits.py
@@ -1,4 +1,4 @@
-from bits.https_availability.https_availability import run as run_https_availability
+cefrom bits.https_availability.https_availability import run as run_https_availability
 from bits.oois_in_headers.oois_in_headers import run as run_oois_in_headers
 
 from octopoes.models.ooi.findings import Finding
@@ -40,7 +40,7 @@ def test_url_extracted_by_oois_in_headers_relative_path(http_resource_https):
 
 def test_finding_generated_when_443_not_open_and_80_is_open():
     port_80 = IPPort(address="address|fake", protocol="tcp", port=80)
-    website = Website(ip_service="fake", hostname="fake")
+    website = Website(ip_service="service|fake", hostname="hostname|fake")
     results = list(run_https_availability(None, [port_80, website], {}))
     finding = results[0]
     assert isinstance(finding, Finding)

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -53,7 +53,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
         operation_type=OperationType.CREATE,
         valid_time=datetime(2023, 1, 1),
         new_data=empty_scan_profile,
-        reference="test_reference",
+        reference="test|reference",
         client="test",
     )
     manager.publish(event)
@@ -67,8 +67,8 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
                 "old_data": None,
-                "new_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user_id": None},
-                "reference": "test_reference",
+                "new_data": {"scan_profile_type": "empty", "reference": "test|reference", "level": 0, "user_id": None},
+                "reference": "test|reference",
             },
         ),
         queue="queue",
@@ -78,8 +78,8 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
     channel_mock.basic_publish.assert_called_once_with(
         "",
         "test__scan_profile_mutations",
-        b'{"operation":"create","primary_key":"test_reference","value":{"primary_key":"test_reference",'
-        b'"object_type":"test_reference","scan_profile":{"scan_profile_type":"empty","reference":"test_reference",'
+        b'{"operation":"create","primary_key":"test|reference","value":{"primary_key":"test|reference",'
+        b'"object_type":"test|reference","scan_profile":{"scan_profile_type":"empty","reference":"test|reference",'
         b'"level":0,"user_id":null}}}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )
@@ -95,7 +95,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
         operation_type=OperationType.CREATE,
         valid_time=datetime(2023, 1, 1),
         new_data=declared_scan_profile,
-        reference="test_reference",
+        reference="test|reference",
         client="test",
     )
     manager.publish(event)
@@ -111,11 +111,11 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
                 "old_data": None,
                 "new_data": {
                     "scan_profile_type": "declared",
-                    "reference": "test_reference",
+                    "reference": "test|reference",
                     "level": 2,
                     "user_id": None,
                 },
-                "reference": "test_reference",
+                "reference": "test|reference",
             },
         ),
         queue="queue",
@@ -127,18 +127,18 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
         mocker.call(
             "",
             "test__scan_profile_increments",
-            b'{"primary_key": "test_reference", "object_type": "test_reference",'
-            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
+            b'{"primary_key": "test|reference", "object_type": "test|reference",'
+            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
             "level": 2, "user_id": None}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
         mocker.call(
             "",
             "test__scan_profile_mutations",
-            b'{"operation": "create", "primary_key": "test_reference", '
-            b'"value": {"primary_key": "test_reference", '
-            b'"object_type": "test_reference", '
-            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test_reference",\
+            b'{"operation": "create", "primary_key": "test|reference", '
+            b'"value": {"primary_key": "test|reference", '
+            b'"object_type": "test|reference", '
+            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
             "level": 2, "user_id": None}}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
         ),
@@ -155,7 +155,7 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
         operation_type=OperationType.DELETE,
         valid_time=datetime(2023, 1, 1),
         old_data=empty_scan_profile,
-        reference="test_reference",
+        reference="test|reference",
         client="test",
     )
     manager.publish(event)
@@ -168,9 +168,9 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
                 "operation_type": "delete",
                 "valid_time": "2023-01-01T00:00:00",
                 "client": "test",
-                "old_data": {"scan_profile_type": "empty", "reference": "test_reference", "level": 0, "user_id": None},
+                "old_data": {"scan_profile_type": "empty", "reference": "test|reference", "level": 0, "user_id": None},
                 "new_data": None,
-                "reference": "test_reference",
+                "reference": "test|reference",
             },
         ),
         queue="queue",
@@ -180,6 +180,6 @@ def test_event_manager_delete_empty_scan_profile(mocker, empty_scan_profile):
     channel_mock.basic_publish.assert_called_once_with(
         "",
         "test__scan_profile_mutations",
-        b'{"operation":"delete","primary_key":"test_reference","value":null}',
+        b'{"operation":"delete","primary_key":"test|reference","value":null}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -79,7 +79,7 @@ def test_event_manager_create_empty_scan_profile(mocker, empty_scan_profile):
         "",
         "test__scan_profile_mutations",
         b'{"operation":"create","primary_key":"test|reference","value":{"primary_key":"test|reference",'
-        b'"object_type":"test|reference","scan_profile":{"scan_profile_type":"empty","reference":"test|reference",'
+        b'"object_type":"test","scan_profile":{"scan_profile_type":"empty","reference":"test|reference",'
         b'"level":0,"user_id":null}}}',
         properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
     )
@@ -127,7 +127,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
         mocker.call(
             "",
             "test__scan_profile_increments",
-            b'{"primary_key": "test|reference", "object_type": "test|reference",'
+            b'{"primary_key": "test|reference", "object_type": "test",'
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
             "level": 2, "user_id": None}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
@@ -137,7 +137,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             "test__scan_profile_mutations",
             b'{"operation": "create", "primary_key": "test|reference", '
             b'"value": {"primary_key": "test|reference", '
-            b'"object_type": "test|reference", '
+            b'"object_type": "test", '
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
             "level": 2, "user_id": None}}}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),

--- a/octopoes/tests/test_octopoes_service.py
+++ b/octopoes/tests/test_octopoes_service.py
@@ -80,8 +80,8 @@ def test_on_update_origin(octopoes_service, valid_time):
     )
 
 
-@pytest.mark.parametrize("new_data", [EmptyScanProfile(reference="test_reference"), None])
-@pytest.mark.parametrize("old_data", [EmptyScanProfile(reference="test_reference"), None])
+@pytest.mark.parametrize("new_data", [EmptyScanProfile(reference="test|reference"), None])
+@pytest.mark.parametrize("old_data", [EmptyScanProfile(reference="test|reference"), None])
 def test_on_create_scan_profile(octopoes_service, new_data, old_data, bit_runner: MagicMock):
     octopoes_service.origin_repository.list_origins.return_value = [
         Origin(
@@ -104,7 +104,7 @@ def test_on_create_scan_profile(octopoes_service, new_data, old_data, bit_runner
         valid_time=valid_time,
         old_data=old_data,
         new_data=new_data,
-        reference="test_reference",
+        reference="test|reference",
         client="_dev",
     )
 


### PR DESCRIPTION
### Changes

Optimizes reference parsing to only split once, and as a side effect only accept references that are formatted in the correct way. Eg, that have two parts after splitting.

### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
