### PR TITLE
Remove block-all-mixed-content

### DIFF
--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -405,8 +405,6 @@ CSP_FORM_ACTION = ["'self'"]
 CSP_INCLUDE_NONCE_IN = ["script-src"]
 CSP_CONNECT_SRC = ["'self'"]
 
-CSP_BLOCK_ALL_MIXED_CONTENT = True
-
 # Turn on the browsable API by default if DEBUG is True, but disable by default in production
 BROWSABLE_API = env.bool("BROWSABLE_API", DEBUG)
 


### PR DESCRIPTION
This CSP directive is no longer needed, and deprecated. Its also throwing warnings in modern browsers because of its deprecated status.

### Changes

Removal of setting from rocky config.

### Issue link

![image](https://github.com/user-attachments/assets/7a4f9ba5-f99e-4fe1-a3de-39c34694e685)

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/block-all-mixed-content


### QA notes

No real changes expected.  
The warning from the screenshot above should not be present in the browsers console / error log.

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
