### PR TITLE
[Backport 1.18] Hotfix for empty report in history table (#4087)

### DIFF
--- a/rocky/reports/templates/report_overview/report_history_table.html
+++ b/rocky/reports/templates/report_overview/report_history_table.html
@@ -87,24 +87,24 @@
                 </thead>
                 <tbody>
                     {% for report in reports %}
-                        {% if report.total_asset_reports >= 1 %}
-                            <tr>
-                                <td>
-                                    <input type="checkbox"
-                                           class="report-checkbox"
-                                           name="report"
-                                           value="{{ report.report.reference }}"
-                                           {% if report.id in selected_reports or "all" in selected_reports %}checked{% endif %}
-                                           {% if "all" in selected_reports %}disabled{% endif %}>
-                                </td>
-                                <td class="report_name">
-                                    <a id="report_name_{{ report.report.reference|slugify }}"
-                                       href="{% url "view_report" organization.code %}?report_id={{ report.report.reference }}&observed_at={{ report.report.observed_at|date:"Y-m-d H:i:s:u" }}"
-                                       title="{% translate "Shows parent report details" %}">{{ report.report.name }}</a>
-                                </td>
-                                <td class="report_types">
-                                    <ul class="tags horizontal-view">
-                                        {% if report.report.report_type == "concatenated-report" or report.report.report_type is None %}
+                        <tr>
+                            <td>
+                                <input type="checkbox"
+                                       class="report-checkbox"
+                                       name="report"
+                                       value="{{ report.report.reference }}"
+                                       {% if report.id in selected_reports or "all" in selected_reports %}checked{% endif %}
+                                       {% if "all" in selected_reports %}disabled{% endif %}>
+                            </td>
+                            <td class="report_name">
+                                <a id="report_name_{{ report.report.reference|slugify }}"
+                                   href="{% url "view_report" organization.code %}?report_id={{ report.report.reference }}&observed_at={{ report.report.observed_at|date:"Y-m-d H:i:s:u" }}"
+                                   title="{% translate "Shows parent report details" %}">{{ report.report.name }}</a>
+                            </td>
+                            <td class="report_types">
+                                <ul class="tags horizontal-view">
+                                    {% if report.report.report_type == "concatenated-report" %}
+                                        {% if report.report_type_summary %}
                                             {% for report_type, total_objects in report.report_type_summary.items %}
                                                 {% if forloop.counter0 < 2 %}
                                                     <li>
@@ -118,22 +118,26 @@
                                                 {% endif %}
                                             {% endfor %}
                                         {% else %}
-                                            <li>
-                                                <span class="label tags-color-{{ report.report.report_type|get_report_type_label_style }}">{{ report.report.report_type|get_report_type_name }}</span>
-                                            </li>
+                                            -
                                         {% endif %}
-                                    </ul>
-                                </td>
-                                <td class="report_oois">
-                                    {% if report.total_objects == 1 %}
-                                        <a href="{% ooi_url "ooi_detail" report.report.input_oois.0.input_ooi organization.code query=ooi.mandatory_fields %}">{{ report.report.input_oois.0.input_ooi|human_readable }}</a>
                                     {% else %}
-                                        {{ report.total_objects }}
+                                        <li>
+                                            <span class="label tags-color-{{ report.report.report_type|get_report_type_label_style }}">{{ report.report.report_type|get_report_type_name }}</span>
+                                        </li>
                                     {% endif %}
-                                </td>
-                                <td class="nowrap report_reference_date">{{ report.report.observed_at|date }}</td>
-                                <td class="nowrap report_creation_date">{{ report.report.date_generated }}</td>
-                                <td>
+                                </ul>
+                            </td>
+                            <td class="report_oois">
+                                {% if report.total_objects == 1 %}
+                                    <a href="{% ooi_url "ooi_detail" report.report.input_oois.0.input_ooi organization.code query=ooi.mandatory_fields %}">{{ report.report.input_oois.0.input_ooi|human_readable }}</a>
+                                {% else %}
+                                    {{ report.total_objects }}
+                                {% endif %}
+                            </td>
+                            <td class="nowrap report_reference_date">{{ report.report.observed_at|date }}</td>
+                            <td class="nowrap report_creation_date">{{ report.report.date_generated }}</td>
+                            <td>
+                                {% if report.total_asset_reports >= 1 %}
                                     <button type="button"
                                             class="expando-button icon ti-chevron-down"
                                             data-icon-open-class="icon ti-chevron-down"
@@ -142,83 +146,85 @@
                                             aria-expanded="false">
                                         {% translate "Open asset report object details" %}
                                     </button>
-                                </td>
-                            </tr>
-                        {% endif %}
-                        <tr class="expando-row">
-                            <td colspan="6">
-                                <table>
-                                    <caption class="visually-hidden">{% translate "Asset reports details:" %}</caption>
-                                    <h5>{% translate "Report types" %}</h5>
-                                    <p>
-                                        {% blocktranslate count counter=report.total_asset_reports %}
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% if report.total_asset_reports >= 1 %}
+                            <tr class="expando-row">
+                                <td colspan="6">
+                                    <table>
+                                        <caption class="visually-hidden">{% translate "Asset reports details:" %}</caption>
+                                        <h5>{% translate "Report types" %}</h5>
+                                        <p>
+                                            {% blocktranslate count counter=report.total_asset_reports %}
                                 This report consists of {{counter}} asset report with the following report type and object:
                             {% plural %}
                                 This report consists of {{counter}} asset reports with the following report types and objects:
                             {% endblocktranslate %}
-                                    </p>
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">{% translate "Report type" %}</th>
-                                            <th scope="col">{% translate "Objects" %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for report_type, total_objects in report.report_type_summary.items %}
+                                        </p>
+                                        <thead>
                                             <tr>
-                                                <td>
-                                                    <ul class="tags horizontal-view">
-                                                        <li>
-                                                            <span class="label tags-color-{{ report_type|get_report_type_label_style }}">{{ report_type|get_report_type_name }}</span>
-                                                        </li>
-                                                    </ul>
-                                                </td>
-                                                <td>{{ total_objects }}</td>
+                                                <th scope="col">{% translate "Report type" %}</th>
+                                                <th scope="col">{% translate "Objects" %}</th>
                                             </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                                <table>
-                                    <h5>
-                                        {% translate "Asset reports" %}
-                                        ({{ report.asset_reports|length }}/{{ report.total_asset_reports }})
-                                    </h5>
-                                    <thead>
-                                        <tr>
-                                            <th scope="col">{% translate "Report type" %}</th>
-                                            <th scope="col">{% translate "Object" %}</th>
-                                            <th scope="col">{% translate "Report name" %}</th>
-                                        </tr>
-                                    </thead>
-                                    <tbody>
-                                        {% for asset_report in report.asset_reports %}
+                                        </thead>
+                                        <tbody>
+                                            {% for report_type, total_objects in report.report_type_summary.items %}
+                                                <tr>
+                                                    <td>
+                                                        <ul class="tags horizontal-view">
+                                                            <li>
+                                                                <span class="label tags-color-{{ report_type|get_report_type_label_style }}">{{ report_type|get_report_type_name }}</span>
+                                                            </li>
+                                                        </ul>
+                                                    </td>
+                                                    <td>{{ total_objects }}</td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                    <table>
+                                        <h5>
+                                            {% translate "Asset reports" %}
+                                            ({{ report.asset_reports|length }}/{{ report.total_asset_reports }})
+                                        </h5>
+                                        <thead>
                                             <tr>
-                                                <td>
-                                                    <ul class="tags horizontal-view">
-                                                        <li>
-                                                            <span class="label tags-color-{{ asset_report.report_type|get_report_type_label_style }}">{{ asset_report.report_type|get_report_type_name }}</span>
-                                                        </li>
-                                                    </ul>
-                                                </td>
-                                                <td>
-                                                    <a href="{% ooi_url 'ooi_detail' asset_report.input_ooi organization.code %}">{{ asset_report.input_ooi|human_readable }}</a>
-                                                </td>
-                                                <td>
-                                                    <a href="{% url "view_report" organization.code %}?asset_report_id={{ asset_report }}&observed_at={{ asset_report.observed_at|date:"Y-m-d H:i:s:u" }}"
-                                                       title="{% translate "Shows asset report details" %}">{{ asset_report.name }}</a>
-                                                </td>
+                                                <th scope="col">{% translate "Report type" %}</th>
+                                                <th scope="col">{% translate "Object" %}</th>
+                                                <th scope="col">{% translate "Report name" %}</th>
                                             </tr>
-                                        {% endfor %}
-                                    </tbody>
-                                </table>
-                                <div class="button-container">
-                                    {% if report.total_asset_reports > 5 %}
-                                        <a href="{% url "subreports" organization.code %}?report_id={{ report.report.reference }}"
-                                           class="button">{% translate "View all asset reports" %}</a>
-                                    {% endif %}
-                                </div>
-                            </td>
-                        </tr>
+                                        </thead>
+                                        <tbody>
+                                            {% for asset_report in report.asset_reports %}
+                                                <tr>
+                                                    <td>
+                                                        <ul class="tags horizontal-view">
+                                                            <li>
+                                                                <span class="label tags-color-{{ asset_report.report_type|get_report_type_label_style }}">{{ asset_report.report_type|get_report_type_name }}</span>
+                                                            </li>
+                                                        </ul>
+                                                    </td>
+                                                    <td>
+                                                        <a href="{% ooi_url 'ooi_detail' asset_report.input_ooi organization.code %}">{{ asset_report.input_ooi|human_readable }}</a>
+                                                    </td>
+                                                    <td>
+                                                        <a href="{% url "view_report" organization.code %}?asset_report_id={{ asset_report }}&observed_at={{ asset_report.observed_at|date:"Y-m-d H:i:s:u" }}"
+                                                           title="{% translate "Shows asset report details" %}">{{ asset_report.name }}</a>
+                                                    </td>
+                                                </tr>
+                                            {% endfor %}
+                                        </tbody>
+                                    </table>
+                                    <div class="button-container">
+                                        {% if report.total_asset_reports > 5 %}
+                                            <a href="{% url "subreports" organization.code %}?report_id={{ report.report.reference }}"
+                                               class="button">{% translate "View all asset reports" %}</a>
+                                        {% endif %}
+                                    </div>
+                                </td>
+                            </tr>
+                        {% endif %}
                     {% endfor %}
                 </tbody>
             </table>


### PR DESCRIPTION
### Changes
Backport of https://github.com/minvws/nl-kat-coordination/pull/4087

The history table didn't show empty reports as expected. This PR fixes this

### Issue link
Closes ... (hotfix)

### Demo
#### Before:
![afbeelding](https://github.com/user-attachments/assets/abdf35d5-b12c-4478-977e-bf9d2df80962)
------------------
#### After:
![afbeelding](https://github.com/user-attachments/assets/cc487bd6-3663-427a-8cae-1b1401747aaa)

### QA notes
Create a report with a query/filter that results in 0 objects. Then check if the (empty) report is shown correctly in the history table.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
