### PR TITLE
Fix/default finding type nibble not in cache

### DIFF
--- a/octopoes/nibbles/default_findingtype_risk/default_findingtype_risk.py
+++ b/octopoes/nibbles/default_findingtype_risk/default_findingtype_risk.py
@@ -4,7 +4,7 @@ from octopoes.models import OOI
 from octopoes.models.ooi.findings import FindingType, RiskLevelSeverity
 
 
-def nibble(input_ooi: FindingType) -> Iterator[OOI]:
+def nibble(input_ooi: FindingType, _dummy: int) -> Iterator[OOI]:
     value_set = False
     if not input_ooi.risk_severity:
         input_ooi.risk_severity = RiskLevelSeverity.PENDING

--- a/octopoes/nibbles/default_findingtype_risk/nibble.py
+++ b/octopoes/nibbles/default_findingtype_risk/nibble.py
@@ -5,7 +5,8 @@ from octopoes.models.ooi.findings import FindingType
 
 def query(targets: list[Reference | None]) -> str:
     ooi_type = targets[0].split("|")[0] if targets[0] else None
-    return f"""
+    if ooi_type:
+        return f"""
                 {{
                     :query {{
                         :find[(pull ?findingtype[*])]
@@ -16,6 +17,19 @@ def query(targets: list[Reference | None]) -> str:
                     }}
                 }}
     """
+    else:
+        return """
+                {
+                    :query {
+                        :find[(pull ?findingtype[*])]
+                        :where
+                        [
+                            [?findingtype :object_type ?object_type]
+                            [(clojure.string/includes? ?object_type "FindingType")]
+                        ]
+                    }
+                }
+            """
 
 
 NIBBLE = NibbleDefinition(

--- a/octopoes/nibbles/default_findingtype_risk/nibble.py
+++ b/octopoes/nibbles/default_findingtype_risk/nibble.py
@@ -1,4 +1,27 @@
 from nibbles.definitions import NibbleDefinition, NibbleParameter
+from octopoes.models import Reference
 from octopoes.models.ooi.findings import FindingType
 
-NIBBLE = NibbleDefinition(id="default-findingtype-risk", signature=[NibbleParameter(object_type=FindingType)])
+
+def query(targets: list[Reference | None]) -> str:
+    return f"""
+                {{
+                    :query {{
+                        :find[(pull ?findingtype[*])]
+                        :where
+                        [
+                            [?findingtype :KATFindingType/primary_key "{targets[0]}"]
+                        ]
+                    }}
+                }}
+    """
+
+
+NIBBLE = NibbleDefinition(
+    id="default-findingtype-risk",
+    signature=[
+        NibbleParameter(object_type=FindingType, parser="[*][?object_type == 'FindingType'][]"),
+        NibbleParameter(object_type=int, parser="[*][?object_type == 'KATFindingType'][] | [length(@)]"),
+    ],
+    query=query,
+)

--- a/octopoes/nibbles/default_findingtype_risk/nibble.py
+++ b/octopoes/nibbles/default_findingtype_risk/nibble.py
@@ -20,7 +20,7 @@ def query(targets: list[Reference | None]) -> str:
 NIBBLE = NibbleDefinition(
     id="default-findingtype-risk",
     signature=[
-        NibbleParameter(object_type=FindingType, parser="[*][?object_type == 'FindingType'][]"),
+        NibbleParameter(object_type=FindingType, parser="[*][?object_type == 'KATFindingType'][]"),
         NibbleParameter(object_type=int, parser="[*][?object_type == 'KATFindingType'][] | [length(@)]"),
     ],
     query=query,

--- a/octopoes/nibbles/default_findingtype_risk/nibble.py
+++ b/octopoes/nibbles/default_findingtype_risk/nibble.py
@@ -4,13 +4,14 @@ from octopoes.models.ooi.findings import FindingType
 
 
 def query(targets: list[Reference | None]) -> str:
+    ooi_type = targets[0].split("|")[0] if targets[0] else None
     return f"""
                 {{
                     :query {{
                         :find[(pull ?findingtype[*])]
                         :where
                         [
-                            [?findingtype :KATFindingType/primary_key "{targets[0]}"]
+                            [?findingtype :{ooi_type}/primary_key "{targets[0]}"]
                         ]
                     }}
                 }}
@@ -20,7 +21,7 @@ def query(targets: list[Reference | None]) -> str:
 NIBBLE = NibbleDefinition(
     id="default-findingtype-risk",
     signature=[
-        NibbleParameter(object_type=FindingType, parser="[*][?object_type == 'KATFindingType'][]"),
+        NibbleParameter(object_type=FindingType, parser="[*][?contains(object_type, 'FindingType')][]"),
         NibbleParameter(object_type=int, parser="[*][?object_type == 'KATFindingType'][] | [length(@)]"),
     ],
     query=query,

--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -946,7 +946,13 @@ class XTDBOOIRepository(OOIRepository):
                     first = True
                     arguments = [
                         ooi.reference
-                        if type_by_name(ooi.get_ooi_type()) in sgn.triggers and (first and not (first := False))
+                        if (
+                            any(
+                                issubclass(type_by_name(ooi.get_ooi_type()), trigger_class)
+                                for trigger_class in sgn.triggers
+                            )
+                            and (first and not (first := False))
+                        )
                         else None
                         for sgn in nibble.signature
                     ]

--- a/octopoes/tests/integration/test_default_finding_type_nibble.py
+++ b/octopoes/tests/integration/test_default_finding_type_nibble.py
@@ -46,11 +46,11 @@ def test_default_findingtype_risk_simple(
 
     assert xtdb_finding_type.risk_score is None
 
-    result = nibbler.infer([xtdb_finding_type], valid_time)
+    nibbler.infer([xtdb_finding_type], valid_time)
     event_manager.complete_process_events(xtdb_octopoes_service)
 
-    assert len(result) == 1
-    assert list(result.keys())[0].risk_score == 0.0
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-DUMMY-FINDING", valid_time)
+    assert xtdb_finding_type.risk_score == 0.0
 
 
 def test_default_findingtype_risk_should_not_go_back_to_pending(
@@ -76,17 +76,18 @@ def test_default_findingtype_risk_should_not_go_back_to_pending(
     event_manager.complete_process_events(xtdb_octopoes_service)
     xtdb_hostname = xtdb_octopoes_service.ooi_repository.get(hostname.reference, valid_time)
 
-    result = nibbler.infer([xtdb_hostname], valid_time)
+    nibbler.infer([xtdb_hostname], valid_time)
     event_manager.complete_process_events(xtdb_octopoes_service)
-
-    assert len(result) == 2
-    assert list(result.keys())[1].risk_score is None
 
     xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
-    result = nibbler.infer([xtdb_finding_type], valid_time)
+    assert xtdb_finding_type.risk_score is None
+
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
+    nibbler.infer([xtdb_finding_type], valid_time)
     event_manager.complete_process_events(xtdb_octopoes_service)
 
-    assert list(result.keys())[1].risk_score == 0.0
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
+    assert xtdb_finding_type.risk_score == 0.0
 
     # default risk score should be given by default_findingtype_risk_nibble
 
@@ -107,7 +108,11 @@ def test_default_findingtype_risk_should_not_go_back_to_pending(
     event_manager.complete_process_events(xtdb_octopoes_service)
     xtdb_hostname2 = xtdb_octopoes_service.ooi_repository.get(hostname2.reference, valid_time)
 
-    result = nibbler.infer([xtdb_hostname2], valid_time)
+    nibbler.infer([xtdb_hostname2], valid_time)
+    event_manager.complete_process_events(xtdb_octopoes_service)
+
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
+    nibbler.infer([xtdb_finding_type], valid_time)
     event_manager.complete_process_events(xtdb_octopoes_service)
 
     # make sure that the risk score is not reset to 0

--- a/octopoes/tests/integration/test_default_finding_type_nibble.py
+++ b/octopoes/tests/integration/test_default_finding_type_nibble.py
@@ -80,9 +80,15 @@ def test_default_findingtype_risk_should_not_go_back_to_pending(
     event_manager.complete_process_events(xtdb_octopoes_service)
 
     assert len(result) == 2
+    assert list(result.keys())[1].risk_score is None
+
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
+    result = nibbler.infer([xtdb_finding_type], valid_time)
+    event_manager.complete_process_events(xtdb_octopoes_service)
+
+    assert list(result.keys())[1].risk_score == 0.0
 
     # default risk score should be given by default_findingtype_risk_nibble
-    assert list(result.keys())[1].risk_score == 0
 
     # simulate a change in the risk score by a boefje
     xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
@@ -105,4 +111,5 @@ def test_default_findingtype_risk_should_not_go_back_to_pending(
     event_manager.complete_process_events(xtdb_octopoes_service)
 
     # make sure that the risk score is not reset to 0
-    assert list(result.keys())[1].risk_score == 5.0
+    xtdb_finding_type = xtdb_octopoes_service.ooi_repository.get("KATFindingType|KAT-NO-SPF", valid_time)
+    assert xtdb_finding_type.risk_score == 5.0

--- a/octopoes/tests/test_bit_default_findingtype_risk.py
+++ b/octopoes/tests/test_bit_default_findingtype_risk.py
@@ -9,7 +9,7 @@ def test_default_findingtype_risk_pending():
     assert test_finding_type.risk_severity is None
     assert test_finding_type.risk_score is None
 
-    results = list(run_default_findingtype_risk(test_finding_type))
+    results = list(run_default_findingtype_risk(test_finding_type, 0))
 
     expected_result = results[0]
     assert isinstance(expected_result, KATFindingType)
@@ -20,6 +20,6 @@ def test_default_findingtype_risk_pending():
 def test_default_findingtype_risk_unkown():
     test_finding_type = KATFindingType(id="KAT-TEST", risk_severity=RiskLevelSeverity.UNKNOWN, risk_score=5)
 
-    results = list(run_default_findingtype_risk(test_finding_type))
+    results = list(run_default_findingtype_risk(test_finding_type, 0))
 
     assert results == [], "Bit should not output anything when risk_severity or risk_score are set"


### PR DESCRIPTION
Dont run this nibble in cache as to avoid https://github.com/minvws/nl-kat-coordination/pull/3808#issuecomment-2656269568