### PR TITLE
Fix ooi detail scan warnings 

### DIFF
--- a/rocky/katalogus/client.py
+++ b/rocky/katalogus/client.py
@@ -391,7 +391,7 @@ class KATalogus:
         return self._katalogus_client.disable_plugin(self._member.organization.code, plugin)
 
     def get_enabled_boefjes(self) -> list[Plugin]:
-        return self._katalogus_client.get_plugins(self._member.organization.code, plugin_type="boefje", enabled=True)
+        return self._katalogus_client.get_plugins(self._member.organization.code, plugin_type="boefje", state=True)
 
     def get_cover(self, plugin_id: str) -> BytesIO:
         return self._katalogus_client.get_cover(self._member.organization.code, plugin_id)

--- a/rocky/rocky/templates/oois/ooi_detail.html
+++ b/rocky/rocky/templates/oois/ooi_detail.html
@@ -42,28 +42,56 @@
             {% endif %}
             <div>
                 <h2>{% translate "Scan" %} {% translate "using boefjes" %}</h2>
-                {% if enabled_boefjes_available %}
+                {% if not organization_indemnification %}
+                    <p class="warning"
+                       role="group"
+                       aria-label="{% translate "indemnification warning" %}">
+                        {% url "organization_settings" organization.code as organization_settings %}
+                        {% blocktranslate %}
+                            <strong>Warning:</strong>
+                            Indemnification is not set for this organization.
+                            Go to the <a href="{{ organization_settings }}">organization settings page</a> to add one.
+                        {% endblocktranslate %}
+                    </p>
+                {% elif not perms.tools.can_scan_organization %}
+                    <p class="warning"
+                       role="group"
+                       aria-label="{% translate "Permission warning" %}">
+                        {% blocktranslate %}
+                            <strong>Warning:</strong>
+                            You don't have the proper permission at the organizational level to scan objects.
+                            Contact your administrator.
+                        {% endblocktranslate %}
+                    </p>
+                {% elif ooi.scan_profile.level > member.max_clearance_level %}
+                    <p class="warning"
+                       role="group"
+                       aria-label="{% translate "Scan warning" %}">
+                        {% url "account_detail" organization.code as account_details %}
+                        {% blocktranslate %}
+                            <strong>Warning:</strong>
+                            You are unable to scan. Your permission to set clearance level for {{ooi}} is maximum {{member.max_clearance_level}}
+                            Go to your <a href="{{account_details}}">account details</a> to view your clearance level.
+                        {% endblocktranslate %}
+                    </p>
+                {% elif boefjes %}
                     <div class="horizontal-view">
                         <div>
-                            {% if member.max_clearance_level > 0 and organization_indemnification %}
-                                <form id="show_all_boefjes"
-                                      method="get"
-                                      action="#show_all_boefjes"
-                                      class="inline">
-                                    <input type="hidden" name="ooi_id" value="{{ ooi }}">
-                                    {% include "partials/form/form_errors.html" with form=possible_boefjes_filter_form %}
+                            <form id="show_all_boefjes"
+                                  method="get"
+                                  action="#show_all_boefjes"
+                                  class="inline">
+                                <input type="hidden" name="ooi_id" value="{{ ooi }}">
+                                {% include "partials/form/form_errors.html" with form=possible_boefjes_filter_form %}
 
-                                    {% for field in possible_boefjes_filter_form %}
-                                        <fieldset>
-                                            {{ field }}
-                                        </fieldset>
-                                    {% endfor %}
-                                </form>
-                            {% endif %}
+                                {% for field in possible_boefjes_filter_form %}
+                                    <fieldset>
+                                        {{ field }}
+                                    </fieldset>
+                                {% endfor %}
+                            </form>
                         </div>
                     </div>
-                {% endif %}
-                {% if boefjes %}
                     <div class="horizontal-scroll">
                         <table>
                             <caption class="visually-hidden">{% translate "Boefjes overview" %}</caption>
@@ -88,36 +116,19 @@
                                             {% include "partials/scan_level_indicator.html" with value=boefje.scan_level.value %}
 
                                         </td>
-                                        {% if perms.tools.can_scan_organization %}
-                                            <td>
-                                                {% include "partials/single_action_form.html" with btn_text="Start Scan" action="start_scan" key="boefje_id" value=boefje.id %}
+                                        <td>
+                                            {% include "partials/single_action_form.html" with btn_text="Start Scan" action="start_scan" key="boefje_id" value=boefje.id %}
 
-                                            </td>
-                                        {% endif %}
+                                        </td>
                                     </tr>
                                 {% endfor %}
                             </tbody>
                         </table>
                     </div>
                 {% else %}
-                    <div class="system">
-                        {% if not enabled_boefjes_available %}
-                            <p>
-                                {% translate "There are no boefjes enabled to scan an OOI of type" %} "{{ ooi.get_ooi_type }}". {% translate "See" %} <a href="{% url "katalogus" organization.code %}">KAT-alogus</a> {% translate "to find and enable boefjes that can scan within the current level." %}
-                            </p>
-                        {% else %}
-                            <div>
-                                <p>
-                                    {% translate "There are no boefjes available within the current clearance level of" %} "{{ ooi.scan_profile.human_readable }}".
-                                    <br>
-                                    {% translate "See" %} <a href="{% url "katalogus" organization.code %}">KAT-alogus</a> {% translate "to find and enable boefjes that can scan within the current level." %}
-                                </p>
-                                <p>
-                                    <a href="{% ooi_url 'scan_profile_detail' ooi.primary_key organization.code query=mandatory_fields %}">{% translate "Or if you have the authorization, upgrade the clearance level of" %} "{{ ooi.human_readable }}".</a>
-                                </p>
-                            </div>
-                        {% endif %}
-                    </div>
+                    <p>
+                        {% translate "There are no boefjes enabled to scan an OOI of type" %} "{{ ooi.get_ooi_type }}". {% translate "See" %} <a href="{% url "katalogus" organization.code %}">KAT-alogus</a> {% translate "to find and enable boefjes that can scan within the current level." %}
+                    </p>
                 {% endif %}
             </div>
         </section>


### PR DESCRIPTION
### Changes
There are different levels of scan warnings that were missing when a user wants to scan an object from the ooi detail page. It is now possible to show the user warnings for each warning levels based on:

1.  When an indemnification is not set for the organization. Informs user specifically that they need to set the indemnification at organization level. start scan is not showing
2. The user does not have the proper role or permission to scan any object. The permission is user is able to scan organization. Start scan is not showing.

### Issue link
https://github.com/minvws/nl-kat-coordination/issues/4106

Closes https://github.com/minvws/nl-kat-coordination/issues/4106

### Demo
The user can see Boefjes and scan level but cannot scan because of indemnification. Has a general indemnification warning + warning in scan field.
<img width="1562" alt="image" src="https://github.com/user-attachments/assets/580cea49-7938-498f-9f64-071d52aea101" />

Double warning when 2 permissions is missing.
<img width="1532" alt="image" src="https://github.com/user-attachments/assets/01fcd785-2868-4678-a2a3-7b5842bae80c" />



### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
