### PR TITLE
Fix ssl certificates boefje scan level

### DIFF
--- a/boefjes/boefjes/plugins/kat_ssl_certificates/boefje.json
+++ b/boefjes/boefjes/plugins/kat_ssl_certificates/boefje.json
@@ -5,5 +5,5 @@
   "consumes": [
     "Website"
   ],
-  "scan_level": 1
+  "scan_level": 2
 }


### PR DESCRIPTION
### Changes

The SSL Certificates boefje uses the openssl command to fetch the certificate, so should be level 2 not 1.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
