### PR TITLE
Update mixins.py, make sure findingsTypes are present in tree for OOI  detail page

### DIFF
--- a/rocky/rocky/views/mixins.py
+++ b/rocky/rocky/views/mixins.py
@@ -480,7 +480,7 @@ class SingleOOIMixin(OctopoesView):
 class SingleOOITreeMixin(SingleOOIMixin):
     @cached_property
     def tree(self) -> ReferenceTree:
-        return self.get_ooi_tree(depth=1)
+        return self.get_ooi_tree(depth=2)
 
     def get_depth(self):
         try:

--- a/rocky/tests/objects/test_objects_graph.py
+++ b/rocky/tests/objects/test_objects_graph.py
@@ -37,7 +37,7 @@ def test_ooi_graph(rf, client_member, mock_organization_view_octopoes):
     assert response.status_code == 200
     mock_organization_view_octopoes().get_tree.assert_has_calls(
         [
-            call(Reference("Network|testnetwork"), valid_time=ANY, depth=1),
+            call(Reference("Network|testnetwork"), valid_time=ANY, depth=2),
             call(Reference("Network|testnetwork"), valid_time=ANY, depth=9),
         ]
     )

--- a/rocky/tests/objects/test_objects_tree.py
+++ b/rocky/tests/objects/test_objects_tree.py
@@ -35,7 +35,7 @@ def test_ooi_tree(rf, client_member, mock_organization_view_octopoes):
     assert response.status_code == 200
     mock_organization_view_octopoes().get_tree.assert_has_calls(
         [
-            call(Reference("Network|testnetwork"), valid_time=ANY, depth=1),
+            call(Reference("Network|testnetwork"), valid_time=ANY, depth=2),
             call(Reference("Network|testnetwork"), valid_time=ANY, depth=9),
         ]
     )


### PR DESCRIPTION
The findings list of the OOI detail page lists the findings, the tree view however did not include the findingtypes, as they are 2 steps removed.
The view however, expected the findingstypes are needed to show the findings if they are present.

### Changes

Change the default depth for the tree lookup from 1 (related), to 2, related (findings) + findingtypes.


### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4099

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
