### PR TITLE
Trim blocktranslates

### DIFF
--- a/rocky/account/templates/account_detail.html
+++ b/rocky/account/templates/account_detail.html
@@ -63,10 +63,11 @@
                         <div>
                             {% if tcl < 0 %}
                                 <p>
-                                    {% blocktranslate %}
-                            You don't have any clearance to scan objects.<br>
-                            Get in contact with the admin to give you the necessary clearance level.
-                        {% endblocktranslate %}
+                                    {% blocktranslate trimmed %}
+                                        You don't have any clearance to scan objects.
+                                        <br>
+                                        Get in contact with the admin to give you the necessary clearance level.
+                                    {% endblocktranslate %}
                                 </p>
                             {% elif tcl >= 0 and tcl == acl %}
                                 <p>
@@ -77,9 +78,9 @@
                                    aria-label="{% translate "Explanation OOI Clearance" %}">
                                     {% translate "You can withdraw this at anytime you like, but know that you won't be able to change clearance levels anymore when you do." %}
                                 </p>
-                                {% blocktranslate asvar btn_text_withdraw_tcl %}
-                            Withdraw L{{acl}} clearance and responsibility
-                    {% endblocktranslate %}
+                                {% blocktranslate asvar btn_text_withdraw_tcl trimmed %}
+                                    Withdraw L{{ acl }} clearance and responsibility
+                                {% endblocktranslate %}
                                 {% include "partials/single_action_form.html" with btn_text=btn_text_withdraw_tcl action="withdraw_acceptance" key="member_id" value=organization_member.id btn_class="ghost" %}
 
                             {% else %}
@@ -93,9 +94,9 @@
                                         Remember: <strong>with great power comes great responsibility.</strong>
                                     {% endblocktranslate %}
                                 </p>
-                                {% blocktranslate asvar btn_text_accept_tcl %}
-                        Accept level L{{tcl}} clearance and responsibility
-                    {% endblocktranslate %}
+                                {% blocktranslate asvar btn_text_accept_tcl trimmed %}
+                                    Accept level L{{ tcl }} clearance and responsibility
+                                {% endblocktranslate %}
                                 {% include "partials/single_action_form.html" with btn_text=btn_text_accept_tcl action="accept_clearance" key="member_id" value=organization_member.id btn_class="ghost" %}
 
                             {% endif %}

--- a/rocky/katalogus/templates/boefje_setup.html
+++ b/rocky/katalogus/templates/boefje_setup.html
@@ -18,10 +18,10 @@
                     <h1>{% translate "Boefje setup" %}</h1>
                 {% endif %}
                 <p>
-                    {% blocktranslate %}
+                    {% blocktranslate trimmed %}
                         You can create a new Boefje. If you want more information on this,
                         you can check out the <a href="https://docs.openkat.nl/developer_documentation/development_tutorial/creating_a_boefje.html">documentation</a>.
-                    {% endblocktranslate%}
+                    {% endblocktranslate %}
                 </p>
                 <form action="" method="post" class="help">
                     {% csrf_token %}

--- a/rocky/katalogus/templates/clone_settings.html
+++ b/rocky/katalogus/templates/clone_settings.html
@@ -4,10 +4,10 @@
     <div>
         <h2>{% translate "Clone settings" %}</h2>
         <p>
-            {% blocktranslate with current_organization=organization.name%}
-        Use the form below to clone the settings from <i>{{current_organization}}</i> to the selected organization.
-        This includes both the KAT-alogus settings as well as enabled and disabled plugins.
-      {% endblocktranslate %}
+            {% blocktranslate with current_organization=organization.name trimmed %}
+                Use the form below to clone the settings from <i>{{ current_organization }}</i> to the selected organization.
+                This includes both the KAT-alogus settings as well as enabled and disabled plugins.
+            {% endblocktranslate %}
         </p>
         <form action="{% url "katalogus_settings" organization.code %}"
               method="post"

--- a/rocky/katalogus/templates/katalogus.html
+++ b/rocky/katalogus/templates/katalogus.html
@@ -22,7 +22,7 @@
                     </p>
                     <p class="emphasized">
                         <strong>{{ object_list|length }}</strong>
-                        {% blocktranslate count counter=object_list|length %}
+                        {% blocktranslate count counter=object_list|length trimmed %}
                             Plugin available
                         {% plural %}
                             Plugins available

--- a/rocky/katalogus/templates/plugin_container_image.html
+++ b/rocky/katalogus/templates/plugin_container_image.html
@@ -11,7 +11,7 @@
         <div>
             <h3>{% translate "Variants" %}</h3>
             <p>
-                {% blocktranslate %}
+                {% blocktranslate trimmed %}
                     Boefje variants that use the same container image. For more
                     information about Boefje variants you can read the documentation.
                 {% endblocktranslate %}

--- a/rocky/katalogus/templates/plugin_settings_add.html
+++ b/rocky/katalogus/templates/plugin_settings_add.html
@@ -10,18 +10,18 @@
         <section>
             <div>
                 <h1>
-                    {% blocktrans count form.fields|length as count %}
-            Add setting
-          {% plural %}
-            Add settings
-          {% endblocktrans %}
+                    {% blocktranslate count form.fields|length as count trimmed %}
+                        Add setting
+                    {% plural %}
+                        Add settings
+                    {% endblocktranslate %}
                 </h1>
                 <p class="emphasized">
-                    {% blocktrans count form.fields|length as count %}
-            Setting
-          {% plural %}
-            Settings
-          {% endblocktrans %}
+                    {% blocktranslate count form.fields|length as count trimmed %}
+                        Setting
+                    {% plural %}
+                        Settings
+                    {% endblocktranslate %}
                 </p>
                 <div class="layout-form">
                     <form novalidate method="post" class="help">
@@ -31,18 +31,18 @@
 
                         <div class="button-container">
                             <button type="submit" name="add-enable">
-                                {% blocktrans count form.fields|length as count %}
-                  Add setting and enable boefje
-                {% plural %}
-                  Add settings and enable boefje
-                {% endblocktrans %}
+                                {% blocktranslate count form.fields|length as count trimmed %}
+                                    Add setting and enable boefje
+                                {% plural %}
+                                    Add settings and enable boefje
+                                {% endblocktranslate %}
                             </button>
                             <button type="submit" class="ghost" name="add">
-                                {% blocktrans count form.fields|length as count %}
-                Add setting
-              {% plural %}
-                Add settings
-              {% endblocktrans %}
+                                {% blocktranslate count form.fields|length as count trimmed %}
+                                    Add setting
+                                {% plural %}
+                                    Add settings
+                                {% endblocktranslate %}
                             </button>
                         </div>
                     </form>

--- a/rocky/katalogus/templates/plugin_settings_delete.html
+++ b/rocky/katalogus/templates/plugin_settings_delete.html
@@ -11,7 +11,9 @@
             <div>
                 <h1>{% translate "Delete settings" %}</h1>
                 <p>
-                    {% blocktranslate %}Are you sure you want to delete all settings for the plugin {{ plugin_name }}?{% endblocktranslate %}
+                    {% blocktranslate trimmed %}
+                        Are you sure you want to delete all settings for the plugin {{ plugin_name }}?
+                    {% endblocktranslate %}
                 </p>
                 <form class="inline" method="post">
                     {% csrf_token %}

--- a/rocky/katalogus/templates/plugin_settings_list.html
+++ b/rocky/katalogus/templates/plugin_settings_list.html
@@ -7,7 +7,7 @@
             <div>
                 <h2>{% translate "Settings" %}</h2>
                 <p>
-                    {% blocktranslate %}
+                    {% blocktranslate trimmed %}
                         In the table below the settings for this specific Boefje can be seen.
                         Set or change the value of the variables by editing the settings.
                     {% endblocktranslate %}

--- a/rocky/onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
+++ b/rocky/onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
@@ -14,13 +14,13 @@
 
                 <h2>{% translate "Setup scan - OOI clearance for" %} {{ ooi|human_readable }}</h2>
                 <h3>{% translate "Trusted clearance level" %}</h3>
-                {% blocktranslate %}
+                {% blocktranslate trimmed %}
                     OpenKAT has a permission system that allows administrators to
                     configure which users can set a certain clearance level. The will make sure
                     that only users that are trusted can start the more aggressive scans.
                 {% endblocktranslate %}
                 <h3>{% translate "Acknowledge clearance level" %}</h3>
-                {% blocktranslate %}
+                {% blocktranslate trimmed %}
                     Before a member is granted the ability to set clearance levels on an object,
                     they must first acknowledge and accept the clearance level set by the administrators.
                     The maximum scanning level permitted for a member is aligned with the trusted clearance level.
@@ -32,45 +32,50 @@
                 {% with tcl=organization_member.trusted_clearance_level acl=organization_member.acknowledged_clearance_level %}
                     {% if tcl < dns_report_least_clearance_level or tcl < 0 %}
                         <p>
-                            {% blocktranslate %}
-                                Unfortunately you cannot continue the onboarding. </br>
-                                Your administrator has trusted you with a clearance level of <strong>L{{tcl}}</strong>.</br>
-                                You need at least a clearance level of <strong>L{{dns_report_least_clearance_level}}</strong> to scan <strong>{{ ooi }}</strong></br>
-                                Contact your administrator to receive a higher clearance.
-                            {% endblocktranslate %}
-                        </p>
-                        <a href="{% url "complete_onboarding" organization.code %}"
-                           class="button ghost">{% translate "Skip onboarding" %}</a>
-                    {% elif tcl != acl %}
-                        <p>
-                            {% blocktranslate %}
-                            Your administrator has trusted you with a clearance level of <strong>L{{ tcl }}</strong>.</br>
-                            You must first accept this clearance level to continue.
-                            {% endblocktranslate %}
-                        </p>
-                        {% blocktranslate asvar btn_text_accept_tcl %}
-                            Accept level L{{tcl}} clearance and responsibility
-                        {% endblocktranslate %}
-                        {% include "partials/single_action_form.html" with btn_text=btn_text_accept_tcl action="accept_clearance" key="member_id" value=member.id btn_class="button" %}
+                            {% blocktranslate trimmed %}
+                                Unfortunately you cannot continue the onboarding.
+                            </br>
+                            Your administrator has trusted you with a clearance level of <strong>L{{ tcl }}</strong>.
+                        </br>
+                        You need at least a clearance level of <strong>L{{ dns_report_least_clearance_level }}</strong> to scan <strong>{{ ooi }}</strong>
+                    </br>
+                    Contact your administrator to receive a higher clearance.
+                {% endblocktranslate %}
+            </p>
+            <a href="{% url "complete_onboarding" organization.code %}"
+               class="button ghost">{% translate "Skip onboarding" %}</a>
+        {% elif tcl != acl %}
+            <p>
+                {% blocktranslate trimmed %}
+                    Your administrator has trusted you with a clearance level of <strong>L{{ tcl }}</strong>.
+                </br>
+                You must first accept this clearance level to continue.
+            {% endblocktranslate %}
+        </p>
+        {% blocktranslate asvar btn_text_accept_tcl trimmed %}
+            Accept level L{{ tcl }} clearance and responsibility
+        {% endblocktranslate %}
+        {% include "partials/single_action_form.html" with btn_text=btn_text_accept_tcl action="accept_clearance" key="member_id" value=member.id btn_class="button" %}
 
-                        <a href="{% url "complete_onboarding" organization.code %}"
-                           class="button ghost">{% translate "Skip onboarding" %}</a>
-                    {% else %}
-                        <p>
-                            {% blocktranslate %}
-                            Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L{{ tcl }}</strong>.</br>
-                            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L{{acl}}</strong>.
-                            {% endblocktranslate %}
-                        </p>
-                        <div class="button-container">
-                            <a href="{% url "step_set_clearance_level" organization.code %}?{{ request.GET.urlencode }}"
-                               class="button">{% translate "Set clearance level" %}</a>
-                            <a href="{% url "complete_onboarding" organization.code %}"
-                               class="button ghost">{% translate "Skip onboarding" %}</a>
-                        </div>
-                    {% endif %}
-                {% endwith %}
-            </div>
-        </section>
-    </main>
+        <a href="{% url "complete_onboarding" organization.code %}"
+           class="button ghost">{% translate "Skip onboarding" %}</a>
+    {% else %}
+        <p>
+            {% blocktranslate trimmed %}
+                Your administrator has <strong>trusted</strong> you with a clearance level of <strong>L{{ tcl }}</strong>.
+            </br>
+            You have also <strong>acknowledged</strong> to use this clearance level of <strong>L{{ acl }}</strong>.
+        {% endblocktranslate %}
+    </p>
+    <div class="button-container">
+        <a href="{% url "step_set_clearance_level" organization.code %}?{{ request.GET.urlencode }}"
+           class="button">{% translate "Set clearance level" %}</a>
+        <a href="{% url "complete_onboarding" organization.code %}"
+           class="button ghost">{% translate "Skip onboarding" %}</a>
+    </div>
+{% endif %}
+{% endwith %}
+</div>
+</section>
+</main>
 {% endblock content %}

--- a/rocky/reports/report_types/dns_report/report.html
+++ b/rocky/reports/report_types/dns_report/report.html
@@ -13,7 +13,7 @@
         <table>
             <caption class="visually-hidden">{% translate "Records found" %}</caption>
             <p>
-                {% blocktranslate %}
+                {% blocktranslate trimmed %}
                     <strong>Disclaimer:</strong>
                     Not all DNSRecords are parsed in OpenKAT.
                     DNS record types that are parsed and could be displayed in the table are:

--- a/rocky/reports/templates/partials/report_header.html
+++ b/rocky/reports/templates/partials/report_header.html
@@ -49,7 +49,9 @@
         </div>
         {% if report_ooi.report_type == "multi-organization-report" %}
             <p>
-                {% blocktranslate with length=report_data.organizations|length %}This sector contains {{ length }} scanned organizations.{% endblocktranslate %}
+                {% blocktranslate with length=report_data.organizations|length trimmed %}
+                    This sector contains {{ length }} scanned organizations.
+                {% endblocktranslate %}
                 {% if report_data.tags %}
                     {% translate "Of these organizations" %}
                     {% for tag, organizations in report_data.tags.items %}
@@ -65,7 +67,9 @@
                     {% endfor %}
                 {% endif %}
                 {% translate "The basic security scores are around " %}{{ report_data.basic_security_score }}%.
-                {% blocktranslate with total=report_data.total_critical_vulnerabilities %}A total of {{ total }} critical vulnerabilities have been identified.{% endblocktranslate %}
+                {% blocktranslate with total=report_data.total_critical_vulnerabilities trimmed %}
+                    A total of {{ total }} critical vulnerabilities have been identified.
+                {% endblocktranslate %}
             </p>
         {% endif %}
     </div>

--- a/rocky/reports/templates/partials/report_ooi_list.html
+++ b/rocky/reports/templates/partials/report_ooi_list.html
@@ -11,13 +11,13 @@
             {% endblocktranslate %}
         </h2>
         <p>
-            {% blocktranslate %}
+            {% blocktranslate trimmed %}
                 Select which objects you want to include in your report. You can either continue
                 with a live set or you can select the objects manually from the table below.
             {% endblocktranslate %}
         </p>
         <p>
-            {% blocktranslate %}
+            {% blocktranslate trimmed %}
                 A live set is a set of objects based on the applied filters.
                 Any object that matches this applied filter (now or in the future) will be used as
                 input for the scheduled report. If your live set filter (e.g. 'hostnames' with
@@ -58,7 +58,9 @@
                     <p class="de-emphasized">{{ total_oois }} {% translate "objects selected" %}</p>
                     <a class="select_all_objects_element">{% translate "Deselect all objects" %}</a>
                     <p class="de-emphasized end">
-                        {% blocktranslate with length=ooi_list|length total=total_oois %}Showing {{ length }} of {{ total }} objects{% endblocktranslate %}
+                        {% blocktranslate with length=ooi_list|length total=total_oois trimmed %}
+                            Showing {{ length }} of {{ total }} objects
+                        {% endblocktranslate %}
                     </p>
                 </div>
             {% else %}
@@ -74,7 +76,9 @@
                     </div>
                     <div class="end">
                         <p class="de-emphasized">
-                            {% blocktranslate with length=ooi_list|length total=total_oois %}Showing {{ length }} of {{ total }} objects{% endblocktranslate %}
+                            {% blocktranslate with length=ooi_list|length total=total_oois trimmed %}
+                                Showing {{ length }} of {{ total }} objects
+                            {% endblocktranslate %}
                         </p>
                     </div>
                 </div>

--- a/rocky/reports/templates/report_overview/modal_partials/delete_modal.html
+++ b/rocky/reports/templates/report_overview/modal_partials/delete_modal.html
@@ -4,14 +4,17 @@
 {% fill 'header' %}{% translate "Delete the following report(s):" %}{% endfill %}
 {% fill 'content' %}
 <p>
-    {% blocktranslate %}
-      Deleted reports are removed in the view from the moment of deletion. The report can still be accessed on timestamps before the deletion. Only the report is removed from the view, not the data it is based on.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+        Deleted reports are removed in the view from the moment of deletion.
+        The report can still be accessed on timestamps before the deletion.
+        Only the report is removed from the view, not the data it is based on.
+    {% endblocktranslate %}
 </p>
 <p>
-    {% blocktranslate %}
-      It is still possible to generate a new report for same date. If the report is part of a combined report, it will remain available in the combined report.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+        It is still possible to generate a new report for same date.
+        If the report is part of a combined report, it will remain available in the combined report.
+    {% endblocktranslate %}
 </p>
 <form id="delete-form" class="inline layout-wide" method="post">
     {% csrf_token %}

--- a/rocky/reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
+++ b/rocky/reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
@@ -8,7 +8,7 @@
 <form id="content-form"  class="horizontal-view"  action=""  method="post">
     {% csrf_token %}
     <p>
-        {% blocktranslate with report_name=schedule.recipe.report_name_format %}
+        {% blocktranslate with report_name=schedule.recipe.report_name_format trimmed %}
             Are you sure you want to disable the schedule for {{ report_name }}?
             The recipe will still exist and the schedule can be enabled later on.
         {% endblocktranslate %}

--- a/rocky/reports/templates/report_overview/modal_partials/rerun_modal.html
+++ b/rocky/reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4,9 +4,9 @@
 {% fill 'header' %}{% translate "Rerun the following report(s):" %}{% endfill %}
 {% fill 'content' %}
 <p>
-    {% blocktranslate %}
-      By submitting you're generating the selected reports again, using the current data.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+        By submitting you're generating the selected reports again, using the current data.
+    {% endblocktranslate %}
 </p>
 <form id="rerun-form" class="inline layout-wide" method="post">
     {% csrf_token %}

--- a/rocky/reports/templates/report_overview/modal_partials/share_modal.html
+++ b/rocky/reports/templates/report_overview/modal_partials/share_modal.html
@@ -4,14 +4,17 @@
 {% fill 'header' %}{% translate "Delete the following report(s):" %}{% endfill %}
 {% fill 'content' %}
 <p>
-    {% blocktranslate %}
-      Deleted reports are removed in the view from the moment of deletion. The report can still be accessed on timestamps before the deletion. Only the report is removed from the view, not the data it is based on.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+        Deleted reports are removed in the view from the moment of deletion.
+        The report can still be accessed on timestamps before the deletion.
+        Only the report is removed from the view, not the data it is based on.
+    {% endblocktranslate %}
 </p>
 <p>
-    {% blocktranslate %}
-      It is still possible to generate a new report for same date. If the report is part of a combined report, it will remain available in the combined report.
-  {% endblocktranslate %}
+    {% blocktranslate trimmed %}
+        It is still possible to generate a new report for same date.
+        If the report is part of a combined report, it will remain available in the combined report.
+    {% endblocktranslate %}
 </p>
 <form id="delete-form" class="inline layout-wide" method="post">
     {% csrf_token %}

--- a/rocky/reports/templates/report_overview/report_history_table.html
+++ b/rocky/reports/templates/report_overview/report_history_table.html
@@ -66,7 +66,9 @@
 
     </div>
     <p class="de-emphasized">
-        {% blocktranslate with length=reports|length total=total_reports %}Showing {{ length }} of {{ total }} reports{% endblocktranslate %}
+        {% blocktranslate with length=reports|length total=total_reports trimmed %}
+            Showing {{ length }} of {{ total }} reports
+        {% endblocktranslate %}
     </p>
     <div class="horizontal-scroll sticky-column">
         <form class="inline layout-wide">
@@ -156,11 +158,11 @@
                                         <caption class="visually-hidden">{% translate "Asset reports details:" %}</caption>
                                         <h5>{% translate "Report types" %}</h5>
                                         <p>
-                                            {% blocktranslate count counter=report.total_asset_reports %}
-                                This report consists of {{counter}} asset report with the following report type and object:
-                            {% plural %}
-                                This report consists of {{counter}} asset reports with the following report types and objects:
-                            {% endblocktranslate %}
+                                            {% blocktranslate count counter=report.total_asset_reports trimmed %}
+                                                This report consists of {{ counter }} asset report with the following report type and object:
+                                            {% plural %}
+                                                This report consists of {{ counter }} asset reports with the following report types and objects:
+                                            {% endblocktranslate %}
                                         </p>
                                         <thead>
                                             <tr>

--- a/rocky/reports/templates/report_overview/scheduled_reports_table.html
+++ b/rocky/reports/templates/report_overview/scheduled_reports_table.html
@@ -7,7 +7,9 @@
 
 {% if scheduled_reports %}
     <p class="de-emphasized">
-        {% blocktranslate with length=scheduled_reports|length total=total_report_schedules %}Showing {{ length }} of {{ total }} schedules{% endblocktranslate %}
+        {% blocktranslate with length=scheduled_reports|length total=total_report_schedules trimmed %}
+            Showing {{ length }} of {{ total }} schedules
+        {% endblocktranslate %}
     </p>
     <div class="horizontal-scroll sticky-column">
         <table>

--- a/rocky/reports/templates/report_overview/subreports.html
+++ b/rocky/reports/templates/report_overview/subreports.html
@@ -11,7 +11,9 @@
             {% include "report_overview/subreports_header.html" %}
 
             <p class="de-emphasized">
-                {% blocktranslate with length=asset_reports|length total=total_oois %}Showing {{ length }} of {{ total }} reports{% endblocktranslate %}
+                {% blocktranslate with length=asset_reports|length total=total_oois trimmed %}
+                    Showing {{ length }} of {{ total }} reports
+                {% endblocktranslate %}
             </p>
             {% include "report_overview/subreports_table.html" %}
             {% include "partials/list_paginator.html" %}

--- a/rocky/reports/templates/report_schedules/delete_recipe_modal.html
+++ b/rocky/reports/templates/report_schedules/delete_recipe_modal.html
@@ -4,11 +4,11 @@
 {% fill 'header' %}{% translate "Delete report recipe" %}{% endfill %}
 {% fill 'content' %}
 <p>
-    {% blocktranslate %}
+    {% blocktranslate trimmed %}
         Deleting this report recipe means it will be permanently deleted.
         It will not be possible anymore to see or enable the schedule.
         You will find previously generated reports in the report history tab.
-  {% endblocktranslate %}
+    {% endblocktranslate %}
 </p>
 <form id="delete-form" class="inline" method="post">
     {% csrf_token %}

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-02-27 10:26+0000\n"
+"POT-Creation-Date: 2025-03-05 15:04+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,12 +368,8 @@ msgstr ""
 
 #: account/templates/account_detail.html
 msgid ""
-"\n"
-"                            You don't have any clearance to scan objects."
-"<br>\n"
-"                            Get in contact with the admin to give you the "
-"necessary clearance level.\n"
-"                        "
+"You don't have any clearance to scan objects.<br> Get in contact with the "
+"admin to give you the necessary clearance level."
 msgstr ""
 
 #: account/templates/account_detail.html
@@ -392,10 +388,7 @@ msgstr ""
 
 #: account/templates/account_detail.html
 #, python-format
-msgid ""
-"\n"
-"                            Withdraw L%(acl)s clearance and responsibility\n"
-"                    "
+msgid "Withdraw L%(acl)s clearance and responsibility"
 msgstr ""
 
 #: account/templates/account_detail.html
@@ -412,11 +405,9 @@ msgid ""
 msgstr ""
 
 #: account/templates/account_detail.html
+#: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 #, python-format
-msgid ""
-"\n"
-"                        Accept level L%(tcl)s clearance and responsibility\n"
-"                    "
+msgid "Accept level L%(tcl)s clearance and responsibility"
 msgstr ""
 
 #: account/templates/password_reset.html
@@ -752,13 +743,9 @@ msgstr ""
 
 #: katalogus/templates/boefje_setup.html
 msgid ""
-"\n"
-"                        You can create a new Boefje. If you want more "
-"information on this,\n"
-"                        you can check out the <a href=\"https://docs.openkat."
-"nl/developer_documentation/development_tutorial/creating_a_boefje."
-"html\">documentation</a>.\n"
-"                    "
+"You can create a new Boefje. If you want more information on this, you can "
+"check out the <a href=\"https://docs.openkat.nl/developer_documentation/"
+"development_tutorial/creating_a_boefje.html\">documentation</a>."
 msgstr ""
 
 #: katalogus/templates/boefje_setup.html
@@ -858,12 +845,9 @@ msgstr ""
 #: katalogus/templates/clone_settings.html
 #, python-format
 msgid ""
-"\n"
-"        Use the form below to clone the settings from "
-"<i>%(current_organization)s</i> to the selected organization.\n"
-"        This includes both the KAT-alogus settings as well as enabled and "
-"disabled plugins.\n"
-"      "
+"Use the form below to clone the settings from <i>%(current_organization)s</"
+"i> to the selected organization. This includes both the KAT-alogus settings "
+"as well as enabled and disabled plugins."
 msgstr ""
 
 #: katalogus/templates/confirmation_clone_settings.html
@@ -875,14 +859,8 @@ msgid "All plugins"
 msgstr ""
 
 #: katalogus/templates/katalogus.html
-msgid ""
-"\n"
-"                            Plugin available\n"
-"                        "
-msgid_plural ""
-"\n"
-"                            Plugins available\n"
-"                        "
+msgid "Plugin available"
+msgid_plural "Plugins available"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1186,12 +1164,8 @@ msgstr ""
 
 #: katalogus/templates/plugin_container_image.html
 msgid ""
-"\n"
-"                    Boefje variants that use the same container image. For "
-"more\n"
-"                    information about Boefje variants you can read the "
-"documentation.\n"
-"                "
+"Boefje variants that use the same container image. For more information "
+"about Boefje variants you can read the documentation."
 msgstr ""
 
 #: katalogus/templates/plugin_container_image.html
@@ -1329,50 +1303,20 @@ msgid ""
 msgstr ""
 
 #: katalogus/templates/plugin_settings_add.html
-msgid ""
-"\n"
-"            Add setting\n"
-"          "
-msgid_plural ""
-"\n"
-"            Add settings\n"
-"          "
+msgid "Add setting"
+msgid_plural "Add settings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: katalogus/templates/plugin_settings_add.html
-msgid ""
-"\n"
-"            Setting\n"
-"          "
-msgid_plural ""
-"\n"
-"            Settings\n"
-"          "
+msgid "Setting"
+msgid_plural "Settings"
 msgstr[0] ""
 msgstr[1] ""
 
 #: katalogus/templates/plugin_settings_add.html
-msgid ""
-"\n"
-"                  Add setting and enable boefje\n"
-"                "
-msgid_plural ""
-"\n"
-"                  Add settings and enable boefje\n"
-"                "
-msgstr[0] ""
-msgstr[1] ""
-
-#: katalogus/templates/plugin_settings_add.html
-msgid ""
-"\n"
-"                Add setting\n"
-"              "
-msgid_plural ""
-"\n"
-"                Add settings\n"
-"              "
+msgid "Add setting and enable boefje"
+msgid_plural "Add settings and enable boefje"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -1397,12 +1341,8 @@ msgstr ""
 
 #: katalogus/templates/plugin_settings_list.html
 msgid ""
-"\n"
-"                        In the table below the settings for this specific "
-"Boefje can be seen.\n"
-"                        Set or change the value of the variables by editing "
-"the settings.\n"
-"                    "
+"In the table below the settings for this specific Boefje can be seen. Set or "
+"change the value of the variables by editing the settings."
 msgstr ""
 
 #: katalogus/templates/plugin_settings_list.html
@@ -2145,14 +2085,9 @@ msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 msgid ""
-"\n"
-"                    OpenKAT has a permission system that allows "
-"administrators to\n"
-"                    configure which users can set a certain clearance level. "
-"The will make sure\n"
-"                    that only users that are trusted can start the more "
-"aggressive scans.\n"
-"                "
+"OpenKAT has a permission system that allows administrators to configure "
+"which users can set a certain clearance level. The will make sure that only "
+"users that are trusted can start the more aggressive scans."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
@@ -2161,20 +2096,14 @@ msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 msgid ""
-"\n"
-"                    Before a member is granted the ability to set clearance "
-"levels on an object,\n"
-"                    they must first acknowledge and accept the clearance "
-"level set by the administrators.\n"
-"                    The maximum scanning level permitted for a member is "
-"aligned with the trusted clearance level.\n"
-"                    By acknowledging the trusted clearance level, this "
-"member formally agrees to abide by\n"
-"                    this permission and gains the capability to perform "
-"scans only up to this trusted clearance level.\n"
-"                    This two-step process ensures that the member operates "
-"within authorized boundaries.\n"
-"                "
+"Before a member is granted the ability to set clearance levels on an object, "
+"they must first acknowledge and accept the clearance level set by the "
+"administrators. The maximum scanning level permitted for a member is aligned "
+"with the trusted clearance level. By acknowledging the trusted clearance "
+"level, this member formally agrees to abide by this permission and gains the "
+"capability to perform scans only up to this trusted clearance level. This "
+"two-step process ensures that the member operates within authorized "
+"boundaries."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
@@ -2184,48 +2113,28 @@ msgstr ""
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid ""
-"\n"
-"                                Unfortunately you cannot continue the "
-"onboarding. </br>\n"
-"                                Your administrator has trusted you with a "
-"clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-"                                You need at least a clearance level of "
+"Unfortunately you cannot continue the onboarding. </br> Your administrator "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br> "
+"You need at least a clearance level of "
 "<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
-"<strong>%(ooi)s</strong></br>\n"
-"                                Contact your administrator to receive a "
-"higher clearance.\n"
-"                            "
+"<strong>%(ooi)s</strong></br> Contact your administrator to receive a higher "
+"clearance."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid ""
-"\n"
-"                            Your administrator has trusted you with a "
-"clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-"                            You must first accept this clearance level to "
-"continue.\n"
-"                            "
+"Your administrator has trusted you with a clearance level of "
+"<strong>L%(tcl)s</strong>.</br> You must first accept this clearance level "
+"to continue."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid ""
-"\n"
-"                            Accept level L%(tcl)s clearance and "
-"responsibility\n"
-"                        "
-msgstr ""
-
-#: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
-#, python-format
-msgid ""
-"\n"
-"                            Your administrator has <strong>trusted</strong> "
-"you with a clearance level of <strong>L%(tcl)s</strong>.</br>\n"
-"                            You have also <strong>acknowledged</strong> to "
-"use this clearance level of <strong>L%(acl)s</strong>.\n"
-"                            "
+"Your administrator has <strong>trusted</strong> you with a clearance level "
+"of <strong>L%(tcl)s</strong>.</br> You have also <strong>acknowledged</"
+"strong> to use this clearance level of <strong>L%(acl)s</strong>."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
@@ -2967,12 +2876,8 @@ msgstr ""
 
 #: reports/report_types/dns_report/report.html
 msgid ""
-"\n"
-"                    <strong>Disclaimer:</strong>\n"
-"                    Not all DNSRecords are parsed in OpenKAT.\n"
-"                    DNS record types that are parsed and could be displayed "
-"in the table are:\n"
-"                "
+"<strong>Disclaimer:</strong> Not all DNSRecords are parsed in OpenKAT. DNS "
+"record types that are parsed and could be displayed in the table are:"
 msgstr ""
 
 #: reports/report_types/dns_report/report.html
@@ -3848,31 +3753,20 @@ msgstr[1] ""
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"\n"
-"                Select which objects you want to include in your report. You "
-"can either continue\n"
-"                with a live set or you can select the objects manually from "
-"the table below.\n"
-"            "
+"Select which objects you want to include in your report. You can either "
+"continue with a live set or you can select the objects manually from the "
+"table below."
 msgstr ""
 
 #: reports/templates/partials/report_ooi_list.html
 msgid ""
-"\n"
-"                A live set is a set of objects based on the applied "
-"filters.\n"
-"                Any object that matches this applied filter (now or in the "
-"future) will be used as\n"
-"                input for the scheduled report. If your live set filter (e."
-"g. 'hostnames' with\n"
-"                'L2 clearance' that are 'declared') shows 2 hostnames that "
-"match the filter today,\n"
-"                the scheduled report will run for those 2 hostnames. If you "
-"add 3 more hostnames\n"
-"                tomorrow (with the same filter criteria), your next "
-"scheduled report will contain\n"
-"                5 hostnames. Your live set will update as you go.\n"
-"            "
+"A live set is a set of objects based on the applied filters. Any object that "
+"matches this applied filter (now or in the future) will be used as input for "
+"the scheduled report. If your live set filter (e.g. 'hostnames' with 'L2 "
+"clearance' that are 'declared') shows 2 hostnames that match the filter "
+"today, the scheduled report will run for those 2 hostnames. If you add 3 "
+"more hostnames tomorrow (with the same filter criteria), your next scheduled "
+"report will contain 5 hostnames. Your live set will update as you go."
 msgstr ""
 
 #: reports/templates/partials/report_ooi_list.html
@@ -4106,21 +4000,17 @@ msgstr ""
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid ""
-"\n"
-"      Deleted reports are removed in the view from the moment of deletion. "
-"The report can still be accessed on timestamps before the deletion. Only the "
-"report is removed from the view, not the data it is based on.\n"
-"  "
+"Deleted reports are removed in the view from the moment of deletion. The "
+"report can still be accessed on timestamps before the deletion. Only the "
+"report is removed from the view, not the data it is based on."
 msgstr ""
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
 #: reports/templates/report_overview/modal_partials/share_modal.html
 msgid ""
-"\n"
-"      It is still possible to generate a new report for same date. If the "
-"report is part of a combined report, it will remain available in the "
-"combined report.\n"
-"  "
+"It is still possible to generate a new report for same date. If the report "
+"is part of a combined report, it will remain available in the combined "
+"report."
 msgstr ""
 
 #: reports/templates/report_overview/modal_partials/delete_modal.html
@@ -4146,12 +4036,8 @@ msgstr ""
 #: reports/templates/report_overview/modal_partials/enable_disable_schedule_modal.html
 #, python-format
 msgid ""
-"\n"
-"            Are you sure you want to disable the schedule for "
-"%(report_name)s?\n"
-"            The recipe will still exist and the schedule can be enabled "
-"later on.\n"
-"        "
+"Are you sure you want to disable the schedule for %(report_name)s? The "
+"recipe will still exist and the schedule can be enabled later on."
 msgstr ""
 
 #: reports/templates/report_overview/modal_partials/rename_modal.html
@@ -4169,10 +4055,8 @@ msgstr ""
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
 msgid ""
-"\n"
-"      By submitting you're generating the selected reports again, using the "
-"current data.\n"
-"  "
+"By submitting you're generating the selected reports again, using the "
+"current data."
 msgstr ""
 
 #: reports/templates/report_overview/modal_partials/rerun_modal.html
@@ -4220,15 +4104,11 @@ msgstr ""
 #: reports/templates/report_overview/report_history_table.html
 #, python-format
 msgid ""
-"\n"
-"                                This report consists of %(counter)s asset "
-"report with the following report type and object:\n"
-"                            "
+"This report consists of %(counter)s asset report with the following report "
+"type and object:"
 msgid_plural ""
-"\n"
-"                                This report consists of %(counter)s asset "
-"reports with the following report types and objects:\n"
-"                            "
+"This report consists of %(counter)s asset reports with the following report "
+"types and objects:"
 msgstr[0] ""
 msgstr[1] ""
 
@@ -4351,12 +4231,9 @@ msgstr ""
 
 #: reports/templates/report_schedules/delete_recipe_modal.html
 msgid ""
-"\n"
-"        Deleting this report recipe means it will be permanently deleted.\n"
-"        It will not be possible anymore to see or enable the schedule.\n"
-"        You will find previously generated reports in the report history "
-"tab.\n"
-"  "
+"Deleting this report recipe means it will be permanently deleted. It will "
+"not be possible anymore to see or enable the schedule. You will find "
+"previously generated reports in the report history tab."
 msgstr ""
 
 #: reports/templates/summary/report_asset_overview.html
@@ -6119,14 +5996,9 @@ msgstr ""
 #: rocky/templates/organizations/organization_crisis_room.html
 #, python-format
 msgid ""
-"\n"
-"                            <strong>Warning:</strong>\n"
-"                            Indemnification is not set for this "
-"organization.\n"
-"                            Go to the <a "
-"href=\"%(organization_settings)s\">organization settings page</a> to add "
-"one.\n"
-"                        "
+"<strong>Warning:</strong> Indemnification is not set for this organization. "
+"Go to the <a href=\"%(organization_settings)s\">organization settings page</"
+"a> to add one."
 msgstr ""
 
 #: rocky/templates/organizations/organization_crisis_room.html
@@ -6221,10 +6093,7 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
 #, python-format
-msgid ""
-"\n"
-"                    An overview of \"%(organization_name)s\" its members.\n"
-"                "
+msgid "An overview of \"%(organization_name)s\" its members."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
@@ -6291,18 +6160,13 @@ msgstr ""
 #: rocky/templates/organizations/organization_settings.html
 #, python-format
 msgid ""
-"\n"
-"            An overview of \"%(organization_name)s\". This shows general "
-"information and its settings.\n"
-"          "
+"An overview of \"%(organization_name)s\". This shows general information and "
+"its settings."
 msgstr ""
 
 #: rocky/templates/organizations/organization_settings.html
 msgid ""
-"\n"
-"              <strong>Warning:</strong>\n"
-"              Indemnification is not set for this organization.\n"
-"            "
+"<strong>Warning:</strong> Indemnification is not set for this organization."
 msgstr ""
 
 #: rocky/templates/organizations/organization_settings.html
@@ -6685,20 +6549,12 @@ msgstr ""
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 #, python-format
 msgid ""
-"\n"
-"              This means that this object will be scanned by Boefjes with "
-"scan level\n"
-"              %(scan_level)s and lower. Setting the clearance level from "
-"“declared”\n"
-"              to “inherit” means that this object will inherit its level "
-"from neighbouring\n"
-"              objects. This means that the clearance level might stay the "
-"same, increase,\n"
-"              or decrease depending on other declared clearance levels. "
-"Clearance levels\n"
-"              of objects that inherit from this clearance level will also be "
-"recalculated.\n"
-"            "
+"This means that this object will be scanned by Boefjes with scan level "
+"%(scan_level)s and lower. Setting the clearance level from “declared” to "
+"“inherit” means that this object will inherit its level from neighbouring "
+"objects. This means that the clearance level might stay the same, increase, "
+"or decrease depending on other declared clearance levels. Clearance levels "
+"of objects that inherit from this clearance level will also be recalculated."
 msgstr ""
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
@@ -6711,14 +6567,10 @@ msgstr ""
 
 #: rocky/templates/scan_profiles/scan_profile_detail.html
 msgid ""
-"\n"
-"                This object has a clearance level of \"L0\". This means that "
-"this object will not be scanned by any Boefje until that\n"
-"                Boefje is run manually for this object again. Objects with a "
-"clearance level higher than \"L0\" will be scanned automatically by Boefjes "
-"with\n"
-"                corresponding scan levels.\n"
-"            "
+"This object has a clearance level of \"L0\". This means that this object "
+"will not be scanned by any Boefje until that Boefje is run manually for this "
+"object again. Objects with a clearance level higher than \"L0\" will be "
+"scanned automatically by Boefjes with corresponding scan levels."
 msgstr ""
 
 #: rocky/templates/scan_profiles/scan_profile_reset.html
@@ -6828,14 +6680,10 @@ msgstr ""
 #: rocky/templates/tasks/partials/tasks_overview_header.html
 #, python-format
 msgid ""
-"\n"
-"            An overview of the tasks for %(organization)s. Tasks are divided "
-"in Boefjes, Normalizers and Reports.\n"
-"            Boefjes scan objects and Normalizers dispatch on the output mime-"
-"type. Additionally, there is a Report\n"
-"            tasks. This task aggregates and presents findings from both "
-"Boefjes and Normalizers.\n"
-"        "
+"An overview of the tasks for %(organization)s. Tasks are divided in Boefjes, "
+"Normalizers and Reports. Boefjes scan objects and Normalizers dispatch on "
+"the output mime-type. Additionally, there is a Report tasks. This task "
+"aggregates and presents findings from both Boefjes and Normalizers."
 msgstr ""
 
 #: rocky/templates/tasks/plugin_detail_task_list.html

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-05 15:04+0000\n"
+"POT-Creation-Date: 2025-03-05 15:06+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -368,7 +368,7 @@ msgstr ""
 
 #: account/templates/account_detail.html
 msgid ""
-"You don't have any clearance to scan objects.<br> Get in contact with the "
+"You don't have any clearance to scan objects. <br> Get in contact with the "
 "admin to give you the necessary clearance level."
 msgstr ""
 
@@ -2114,18 +2114,18 @@ msgstr ""
 #, python-format
 msgid ""
 "Unfortunately you cannot continue the onboarding. </br> Your administrator "
-"has trusted you with a clearance level of <strong>L%(tcl)s</strong>.</br> "
+"has trusted you with a clearance level of <strong>L%(tcl)s</strong>. </br> "
 "You need at least a clearance level of "
 "<strong>L%(dns_report_least_clearance_level)s</strong> to scan "
-"<strong>%(ooi)s</strong></br> Contact your administrator to receive a higher "
-"clearance."
+"<strong>%(ooi)s</strong> </br> Contact your administrator to receive a "
+"higher clearance."
 msgstr ""
 
 #: onboarding/templates/step_3e_trusted_acknowledge_clearance_level.html
 #, python-format
 msgid ""
 "Your administrator has trusted you with a clearance level of "
-"<strong>L%(tcl)s</strong>.</br> You must first accept this clearance level "
+"<strong>L%(tcl)s</strong>. </br> You must first accept this clearance level "
 "to continue."
 msgstr ""
 
@@ -2133,7 +2133,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Your administrator has <strong>trusted</strong> you with a clearance level "
-"of <strong>L%(tcl)s</strong>.</br> You have also <strong>acknowledged</"
+"of <strong>L%(tcl)s</strong>. </br> You have also <strong>acknowledged</"
 "strong> to use this clearance level of <strong>L%(acl)s</strong>."
 msgstr ""
 

--- a/rocky/rocky/templates/admin/change_form.html
+++ b/rocky/rocky/templates/admin/change_form.html
@@ -40,7 +40,11 @@
 {% if save_on_top %}{% block submit_buttons_top %}{% submit_row %}{% endblock %}{% endif %}
 {% if errors %}
     <p class="errornote">
-    {% blocktranslate count counter=errors|length %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+      {% blocktranslate count counter=errors|length trimmed %}
+        Please correct the error below.
+      {% plural %}
+        Please correct the errors below.
+      {% endblocktranslate %}
     </p>
     {{ adminform.form.non_field_errors }}
 {% endif %}

--- a/rocky/rocky/templates/admin/change_list.html
+++ b/rocky/rocky/templates/admin/change_list.html
@@ -49,7 +49,11 @@
     {% endblock %}
     {% if cl.formset and cl.formset.errors %}
         <p class="errornote">
-        {% blocktranslate count counter=cl.formset.total_error_count %}Please correct the error below.{% plural %}Please correct the errors below.{% endblocktranslate %}
+          {% blocktranslate count counter=cl.formset.total_error_count trimmed %}
+            Please correct the error below.
+          {% plural %}
+            Please correct the errors below.
+          {% endblocktranslate %}
         </p>
         {{ cl.formset.non_form_errors }}
     {% endif %}

--- a/rocky/rocky/templates/admin/delete_confirmation.html
+++ b/rocky/rocky/templates/admin/delete_confirmation.html
@@ -22,17 +22,33 @@
 {% block content %}
 {% if perms_lacking %}
   {% block delete_forbidden %}
-    <p>{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would result in deleting related objects, but your account doesn't have permission to delete the following types of objects{% endblocktranslate %}:</p>
+    <p>
+      {% blocktranslate with escaped_object=object trimmed %}
+        Deleting the {{ object_name }} '{{ escaped_object }}' would result in
+        deleting related objects, but your account doesn't have permission to
+        delete the following types of objects
+      {% endblocktranslate %}:
+    </p>
     <ul id="deleted-objects">{{ perms_lacking|unordered_list }}</ul>
   {% endblock %}
 {% elif protected %}
   {% block delete_protected %}
-    <p>{% blocktranslate with escaped_object=object %}Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting the following protected related objects{% endblocktranslate %}:</p>
+    <p>
+      {% blocktranslate with escaped_object=object trimmed %}
+        Deleting the {{ object_name }} '{{ escaped_object }}' would require deleting
+        the following protected related objects
+      {% endblocktranslate %}:
+    </p>
     <ul id="deleted-objects">{{ protected|unordered_list }}</ul>
   {% endblock %}
 {% else %}
   {% block delete_confirm %}
-    <p>{% blocktranslate with escaped_object=object %}Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"? All of the following related items will be deleted{% endblocktranslate %}:</p>
+    <p>
+      {% blocktranslate with escaped_object=object trimmed %}
+        Are you sure you want to delete the {{ object_name }} "{{ escaped_object }}"?
+        All of the following related items will be deleted
+      {% endblocktranslate %}:
+    </p>
     {% include "admin/includes/object_delete_summary.html" %}
     <h2>{% translate "Objects" %}</h2>
     <ul id="deleted-objects">{{ deleted_objects|unordered_list }}</ul>

--- a/rocky/rocky/templates/admin/delete_selected_confirmation.html
+++ b/rocky/rocky/templates/admin/delete_selected_confirmation.html
@@ -20,13 +20,28 @@
 
 {% block content %}
 {% if perms_lacking %}
-    <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would result in deleting related objects, but your account doesn't have permission to delete the following types of objects{% endblocktranslate %}:</p>
+    <p>
+        {% blocktranslate trimmed %}
+            Deleting the selected {{ objects_name }} would result in deleting related objects,
+            but your account doesn't have permission to delete the following types of objects
+        {% endblocktranslate %}:
+    </p>
     <ul>{{ perms_lacking|unordered_list }}</ul>
 {% elif protected %}
-    <p>{% blocktranslate %}Deleting the selected {{ objects_name }} would require deleting the following protected related objects{% endblocktranslate %}:</p>
+    <p>
+        {% blocktranslate trimmed %}
+            Deleting the selected {{ objects_name }} would require deleting the following
+            protected related objects
+        {% endblocktranslate %}:
+    </p>
     <ul>{{ protected|unordered_list }}</ul>
 {% else %}
-    <p>{% blocktranslate %}Are you sure you want to delete the selected {{ objects_name }}? All of the following objects and their related items will be deleted{% endblocktranslate %}:</p>
+    <p>
+        {% blocktranslate trimmed %}
+            Are you sure you want to delete the selected {{ objects_name }}?
+            All of the following objects and their related items will be deleted
+        {% endblocktranslate %}:
+    </p>
     {% include "admin/includes/object_delete_summary.html" %}
     <h2>{% translate "Objects" %}</h2>
     {% for deletable_object in deletable_objects %}

--- a/rocky/rocky/templates/legal/privacy_statement.html
+++ b/rocky/rocky/templates/legal/privacy_statement.html
@@ -9,7 +9,7 @@
     <main id="main-content" tabindex="-1" class="privacy-statement">
         <section>
             <div>
-                <h1>{% blocktranslate %}OpenKAT Privacy Statement{% endblocktranslate %}</h1>
+                <h1>{% translate "OpenKAT Privacy Statement" %}</h1>
                 <p>
                     {% blocktranslate trimmed %}
                         OpenKAT is dedicated to protecting the confidentiality and privacy of information entrusted to it.

--- a/rocky/rocky/templates/oois/ooi_list.html
+++ b/rocky/rocky/templates/oois/ooi_list.html
@@ -26,7 +26,9 @@
                 {% include "partials/ooi_list_filters.html" %}
 
                 <p class="de-emphasized">
-                    {% blocktranslate with length=ooi_list|length total=total_oois %}Showing {{ length }} of {{ total }} objects{% endblocktranslate %}
+                    {% blocktranslate with length=ooi_list|length total=total_oois trimmed %}
+                        Showing {{ length }} of {{ total }} objects
+                    {% endblocktranslate %}
                 </p>
                 <form method="post"
                       id="ooi_list_form"

--- a/rocky/rocky/templates/organizations/organization_crisis_room.html
+++ b/rocky/rocky/templates/organizations/organization_crisis_room.html
@@ -15,7 +15,7 @@
                        role="group"
                        aria-label="{% translate "indemnification warning" %}">
                         {% url "organization_settings" organization.code as organization_settings %}
-                        {% blocktranslate %}
+                        {% blocktranslate trimmed %}
                             <strong>Warning:</strong>
                             Indemnification is not set for this organization.
                             Go to the <a href="{{ organization_settings }}">organization settings page</a> to add one.

--- a/rocky/rocky/templates/organizations/organization_member_list.html
+++ b/rocky/rocky/templates/organizations/organization_member_list.html
@@ -11,7 +11,7 @@
         <section>
             <div>
                 <h1>{% translate "Organization:" %} {{ organization.name }}</h1>
-                {% blocktranslate with organization_name=organization.name %}
+                {% blocktranslate with organization_name=organization.name trimmed %}
                     An overview of "{{ organization_name }}" its members.
                 {% endblocktranslate %}
                 <h2>

--- a/rocky/rocky/templates/organizations/organization_settings.html
+++ b/rocky/rocky/templates/organizations/organization_settings.html
@@ -12,19 +12,19 @@
             <div>
                 <h1>{% translate "Organization:" %} {{ organization.name }}</h1>
                 <p>
-                    {% blocktranslate with organization_name=organization.name %}
-            An overview of "{{ organization_name }}". This shows general information and its settings.
-          {% endblocktranslate %}
+                    {% blocktranslate with organization_name=organization.name trimmed %}
+                        An overview of "{{ organization_name }}". This shows general information and its settings.
+                    {% endblocktranslate %}
                 </p>
                 {% if not indemnification_present %}
                     <p class="warning"
                        role="group"
                        aria-label="{% translate "indemnification warning" %}">
                         {% url "organization_settings" organization.code as organization_settings %}
-                        {% blocktranslate %}
-              <strong>Warning:</strong>
-              Indemnification is not set for this organization.
-            {% endblocktranslate %}
+                        {% blocktranslate trimmed %}
+                            <strong>Warning:</strong>
+                            Indemnification is not set for this organization.
+                        {% endblocktranslate %}
                     </p>
                 {% endif %}
                 <h2>{% translate "Organization details" %}</h2>

--- a/rocky/rocky/templates/partials/ooi_report_findings_block.html
+++ b/rocky/rocky/templates/partials/ooi_report_findings_block.html
@@ -4,7 +4,9 @@
     <div>
         <h2>{% translate "Findings" %}</h2>
         <h3>
-            {% blocktranslate with name=ooi.human_readable total=findings_list.meta.total %}{{ total }} findings on {{ name }}{% endblocktranslate %}
+            {% blocktranslate with name=ooi.human_readable total=findings_list.meta.total trimmed %}
+                {{ total }} findings on {{ name }}
+            {% endblocktranslate %}
         </h3>
         {% if findings_list.meta.total %}
             {% include "partials/ooi_report_findings_block_table.html" %}

--- a/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
+++ b/rocky/rocky/templates/scan_profiles/scan_profile_detail.html
@@ -27,14 +27,15 @@
                 {% endif %}
                 {% if ooi.scan_profile.scan_profile_type == "declared" %}
                     <p class="explanation">
-                        <span>{% translate "Declared:" %}</span>{% blocktranslate with scan_level=ooi.scan_profile.human_readable %}
-              This means that this object will be scanned by Boefjes with scan level
-              {{ scan_level }} and lower. Setting the clearance level from “declared”
-              to “inherit” means that this object will inherit its level from neighbouring
-              objects. This means that the clearance level might stay the same, increase,
-              or decrease depending on other declared clearance levels. Clearance levels
-              of objects that inherit from this clearance level will also be recalculated.
-            {% endblocktranslate %}
+                        <span>{% translate "Declared:" %}</span>
+                        {% blocktranslate with scan_level=ooi.scan_profile.human_readable trimmed %}
+                            This means that this object will be scanned by Boefjes with scan level
+                            {{ scan_level }} and lower. Setting the clearance level from “declared”
+                            to “inherit” means that this object will inherit its level from neighbouring
+                            objects. This means that the clearance level might stay the same, increase,
+                            or decrease depending on other declared clearance levels. Clearance levels
+                            of objects that inherit from this clearance level will also be recalculated.
+                        {% endblocktranslate %}
                     </p>
                     {% if organization_member.max_clearance_level > -1 and organization_indemnification %}
                         <div class="horizontal-view">
@@ -44,11 +45,12 @@
                     {% endif %}
                 {% elif ooi.scan_profile.scan_profile_type == "empty" %}
                     <p class="explanation">
-                        <span>{% translate "Empty:" %}</span> {% blocktranslate %}
-                This object has a clearance level of "L0". This means that this object will not be scanned by any Boefje until that
-                Boefje is run manually for this object again. Objects with a clearance level higher than "L0" will be scanned automatically by Boefjes with
-                corresponding scan levels.
-            {% endblocktranslate %}
+                        <span>{% translate "Empty:" %}</span>
+                        {% blocktranslate trimmed %}
+                            This object has a clearance level of "L0". This means that this object will not be scanned by any Boefje until that
+                            Boefje is run manually for this object again. Objects with a clearance level higher than "L0" will be scanned automatically by Boefjes with
+                            corresponding scan levels.
+                        {% endblocktranslate %}
                         {% include "partials/explanations.html" %}
 
                     </p>

--- a/rocky/rocky/templates/tasks/partials/tasks_overview_header.html
+++ b/rocky/rocky/templates/tasks/partials/tasks_overview_header.html
@@ -3,10 +3,10 @@
 <div>
     <h1>{% translate "Tasks" %}</h1>
     <p class="emphasized">
-        {% blocktranslate %}
+        {% blocktranslate trimmed %}
             An overview of the tasks for {{ organization }}. Tasks are divided in Boefjes, Normalizers and Reports.
             Boefjes scan objects and Normalizers dispatch on the output mime-type. Additionally, there is a Report
             tasks. This task aggregates and presents findings from both Boefjes and Normalizers.
-        {% endblocktranslate%}
+        {% endblocktranslate %}
     </p>
 </div>


### PR DESCRIPTION
### Changes
This PR removes the breaklines ("/n") from the .pot file by adding "trimmed" to the blocktranslates in KAT.

### Issue link
Quick fix

Closes ...

### Demo


### QA notes
- Check the .pot file

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made. **(N/A)**
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
