### PR TITLE
make sure we can link to the plugins section from the report sidemenu

### DIFF
--- a/rocky/reports/templates/summary/selected_plugins.html
+++ b/rocky/reports/templates/summary/selected_plugins.html
@@ -1,7 +1,7 @@
 {% load i18n %}
 
 {% if plugins %}
-    <h3>{% translate "Plugins" %} ({{ plugins|length }})</h3>
+    <h3 id="selected-plugins">{% translate "Plugins" %} ({{ plugins|length }})</h3>
     <p>
         {% blocktranslate trimmed %}
             The table below shows all required or optional plugins for the selected reports.
@@ -78,6 +78,6 @@
         </table>
     </div>
 {% else %}
-    <h3>{% translate "Plugins" %}</h3>
+    <h3 id="selected-plugins">{% translate "Plugins" %}</h3>
     {% translate "There are no required or optional plugins needed for the selected report types." %}
 {% endif %}


### PR DESCRIPTION
### Changes

Clicking on 'selected plugins' in the sidemenu of an aggregated report did not work.

### QA notes

Clicking on 'selected plugins' in the sidemenu of an aggregated should now scroll the page to the plugins section.

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
