### PR TITLE
Update text "Enable plugins" button in report flow

### DIFF
--- a/rocky/reports/templates/partials/report_setup_scan.html
+++ b/rocky/reports/templates/partials/report_setup_scan.html
@@ -107,7 +107,7 @@
                 {% include "forms/report_form_fields.html" %}
 
                 <button type="submit">
-                    {% translate "Enable plugins and continue" %}<span class="icon ti-chevron-right"></span>
+                    {% translate "Enable selected plugins and continue" %}<span class="icon ti-chevron-right"></span>
                 </button>
             </form>
         {% else %}

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-03-14 10:43+0000\n"
+"POT-Creation-Date: 2025-03-20 09:42+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -3934,7 +3934,7 @@ msgid "There are no optional plugins."
 msgstr ""
 
 #: reports/templates/partials/report_setup_scan.html
-msgid "Enable plugins and continue"
+msgid "Enable selected plugins and continue"
 msgstr ""
 
 #: reports/templates/partials/report_severity_totals.html


### PR DESCRIPTION
### Changes
Updates the 'Enable plugins button' in the Report Flow to make it less confusing if not all plugins are selected. 

### Issue link
Issue was introduced by @zcrt 

### Demo
Old: 

![image](https://github.com/user-attachments/assets/78367998-10ef-42fe-8ffb-6301a9f7b6da)

New:

![image](https://github.com/user-attachments/assets/a6ff2d5d-f004-49c4-9f97-284e57dcb04e)


### QA notes
Verify that the button name is logical when not all plugins are selected. 
Could someone run 'make lang' on the PR? I run into permission errors for some reason. 

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
