### PR TITLE
Use TaskPush model for scheduling tasks in rocky

### DIFF
--- a/rocky/rocky/scheduler.py
+++ b/rocky/rocky/scheduler.py
@@ -146,6 +146,14 @@ class Task(BaseModel):
         raise ValueError("No organization found related to task")
 
 
+class TaskPush(BaseModel):
+    id: uuid.UUID | None = None
+    scheduler_id: str | None = None
+    organisation: str
+    priority: int | None = None
+    data: dict
+
+
 class ScheduleRequest(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/rocky/rocky/views/scheduler.py
+++ b/rocky/rocky/views/scheduler.py
@@ -253,7 +253,10 @@ class SchedulerView(OctopoesView):
             )
 
             new_task = TaskPush(
-                priority=1, data=normalizer_task, scheduler_id="normalizer", organisation=self.organization.code
+                priority=1,
+                data=normalizer_task.model_dump(),
+                scheduler_id="normalizer",
+                organisation=self.organization.code,
             )
 
             self.schedule_task(new_task)
@@ -269,7 +272,7 @@ class SchedulerView(OctopoesView):
             )
 
             new_task = TaskPush(
-                priority=1, data=boefje_task, scheduler_id="boefje", organisation=self.organization.code
+                priority=1, data=boefje_task.model_dump(), scheduler_id="boefje", organisation=self.organization.code
             )
 
             self.schedule_task(new_task)

--- a/rocky/rocky/views/scheduler.py
+++ b/rocky/rocky/views/scheduler.py
@@ -237,7 +237,7 @@ class SchedulerView(OctopoesView):
                     scheduler_id=task.scheduler_id,
                     organisation=self.organization.code,
                     priority=1,
-                    data=task.data,
+                    data=task.data.model_dump(),
                 )
 
                 self.schedule_task(new_task)

--- a/rocky/rocky/views/scheduler.py
+++ b/rocky/rocky/views/scheduler.py
@@ -5,9 +5,6 @@ from typing import Any
 from django.contrib import messages
 from django.http import Http404, JsonResponse
 from django.utils.translation import gettext_lazy as _
-from octopoes.models import OOI
-from octopoes.models.ooi.reports import ReportRecipe
-
 from katalogus.client import Boefje, Normalizer
 from reports.forms import (
     ReportNameForm,
@@ -15,10 +12,14 @@ from reports.forms import (
     ReportScheduleStartDateChoiceForm,
     ReportScheduleStartDateForm,
 )
+from tools.forms.scheduler import TaskFilterForm
+
+from octopoes.models import OOI
+from octopoes.models.ooi.reports import ReportRecipe
 from rocky.scheduler import Boefje as SchedulerBoefje
-from rocky.scheduler import BoefjeTask, LazyTaskList
-from rocky.scheduler import Normalizer as SchedulerNormalizer
 from rocky.scheduler import (
+    BoefjeTask,
+    LazyTaskList,
     NormalizerTask,
     RawData,
     ReportTask,
@@ -30,8 +31,8 @@ from rocky.scheduler import (
     TaskPush,
     scheduler_client,
 )
+from rocky.scheduler import Normalizer as SchedulerNormalizer
 from rocky.views.mixins import OctopoesView
-from tools.forms.scheduler import TaskFilterForm
 
 
 def get_date_time(date: str | None) -> datetime | None:


### PR DESCRIPTION
### Changes

- Fix rocky references to use `TaskPush` instead of `Task` when creating / rescheduling tasks for the scheduler

### Issue link

Related: https://github.com/minvws/nl-kat-coordination/pull/4165

### QA notes

Check from rocky if rescheduling of tasks, and explicitly starting tasks will work.Prior to this pr we saw that there were 422 error  codes returned from the scheduler.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
