### PR TITLE
Fix dropdown for language selector as a template for other dropdowns

### DIFF
--- a/rocky/assets/css/components/dropdown-form.scss
+++ b/rocky/assets/css/components/dropdown-form.scss
@@ -4,8 +4,8 @@
   form {
     $form-padding-sides: 1rem;
 
+    gap: 0;
     background-color: transparent;
-    padding: 0.75rem $form-padding-sides 0 $form-padding-sides;
 
     .toolbar {
       justify-content: space-between;
@@ -60,8 +60,7 @@
         min-height: var(--collapsing-element-list-item-min-height);
         display: flex;
         align-items: center;
-        padding-left: $form-padding-sides;
-        padding-right: $form-padding-sides;
+        padding: 0;
 
         &:hover {
           background-color: var(--colors-black-05);

--- a/rocky/assets/css/components/dropdown.scss
+++ b/rocky/assets/css/components/dropdown.scss
@@ -49,7 +49,6 @@
       li {
         $icon-width: 1.25rem;
 
-        border-top: 1px $offwhite solid;
         padding: 0;
         width: 100%;
 

--- a/rocky/assets/css/components/dropdown.scss
+++ b/rocky/assets/css/components/dropdown.scss
@@ -1,5 +1,5 @@
 .dropdown {
-  max-width: 50%;
+  max-width: 20rem;
   width: auto;
   padding: 0;
   position: relative;
@@ -9,7 +9,7 @@
   a.button {
     white-space: nowrap;
     text-overflow: ellipsis;
-    overflow: hidden;
+    overflow: auto hidden;
     min-width: 0;
     display: flex;
     width: 100%;
@@ -31,7 +31,7 @@
     border: 1px solid var(--colors-grey-200);
     background-color: var(--colors-white);
     max-height: 90vh;
-    overflow-x: scroll;
+    overflow-x: auto;
 
     > ul {
       margin: 0;

--- a/rocky/assets/css/themes/soft/manon/collapsing-element.scss
+++ b/rocky/assets/css/themes/soft/manon/collapsing-element.scss
@@ -22,10 +22,7 @@ body header nav.collapsible {
         width: 100%;
         max-width: 100%;
         height: var(--header-navigation-button-min-height);
-        padding-top: var(--collapsing-element-list-item-link-padding-top);
-        padding-right: var(--collapsing-element-list-item-link-padding-right);
-        padding-bottom: var(--collapsing-element-list-item-link-padding-bottom);
-        padding-left: var(--collapsing-element-list-item-link-padding-left);
+        padding: var(--spacing-grid-150);
         color: var(--collapsing-element-list-item-link-text-color);
         justify-content: flex-start;
         line-height: var(--header-navigation-link-line-height);
@@ -53,6 +50,10 @@ body header nav.collapsible {
             background-color: var(
               --language-selector-list-item-hover-background-color
             );
+          }
+
+          a {
+            padding: var(--spacing-grid-150);
           }
         }
 

--- a/rocky/rocky/templates/partials/language-switcher.html
+++ b/rocky/rocky/templates/partials/language-switcher.html
@@ -3,25 +3,24 @@
 {% get_language_info for LANGUAGE_CODE as current_language %}
 <div class="dropdown">
     <button type="button"
+            class="dropdown-button ghost"
             data-open-label="{{ current_language.name_local.title }}"
             data-close-label="{{ current_language.name_local.title }}"
-            data-media="(min-width: 100%)"
             aria-label="{% translate "Language Selector" %}"
-            class="dropdown-button ghost"
-            aria-controls="language-switcher"
+            aria-controls="language-list"
             aria-expanded="false"
-            aria-haspopup="menu"
-            aria-labelledby="language-switcher">
+            aria-haspopup="listbox"
+            aria-labelledby="language-list">
         {{ current_language.name_local.title }}<span class="icon ti-chevron-down"></span>
     </button>
-    <div id="language-switcher" class="dropdown-list">
-        <ul>
+    <div id="language-list" class="dropdown-list">
+        <ul role="listbox" aria-labelledby="language-list" tabindex="-1">
             <form action="{% url "set_language" %}" method="post" class="inline">
                 {% csrf_token %}
                 {% for language in languages %}
                     {% get_language_info for language as language %}
                     {% if language.code != current_language.code %}
-                        <li>
+                        <li role="option">
                             <button type="submit" name="language" value={{ language.code }}>
                                 {{ language.name_local.title }}
                             </button>

--- a/rocky/rocky/templates/partials/language-switcher.html
+++ b/rocky/rocky/templates/partials/language-switcher.html
@@ -1,38 +1,34 @@
 {% load i18n %}
 
-{% get_language_info for LANGUAGE_CODE as lang %}
-<div class="language-selector">
-    <div class="dropdown">
-        <button type="button"
-                aria-controls="language-switcher"
-                aria-expanded="false"
-                class="dropdown-button ghost">
-            {{ lang.name_local|title }}
-            <span aria-hidden="true" class="icon ti-chevron-down"></span>
-        </button>
-        <ul id="language-switcher" role="listbox" class="dropdown-list">
-            {% for language in languages %}
-                {% get_language_info for language as lang %}
-                {% if LANGUAGE_CODE != language %}
-                    <li>
-                        <a hreflang="{{ language }}"
-                           href="#"
-                           role="option"
-                           data-value="{{ language }}"
-                           lang="{{ language }}">
-                            <button form="set-language" type="submit" name="language" value={{ language }}>
-                                {{ lang.name_local.title }}
+{% get_language_info for LANGUAGE_CODE as current_language %}
+<div class="dropdown">
+    <button type="button"
+            data-open-label="{{ current_language.name_local.title }}"
+            data-close-label="{{ current_language.name_local.title }}"
+            data-media="(min-width: 100%)"
+            aria-label="{% translate "Language Selector" %}"
+            class="dropdown-button ghost"
+            aria-controls="language-switcher"
+            aria-expanded="false"
+            aria-haspopup="menu"
+            aria-labelledby="language-switcher">
+        {{ current_language.name_local.title }}<span class="icon ti-chevron-down"></span>
+    </button>
+    <div id="language-switcher" class="dropdown-list">
+        <ul>
+            <form action="{% url "set_language" %}" method="post" class="inline">
+                {% csrf_token %}
+                {% for language in languages %}
+                    {% get_language_info for language as language %}
+                    {% if language.code != current_language.code %}
+                        <li>
+                            <button type="submit" name="language" value={{ language.code }}>
+                                {{ language.name_local.title }}
                             </button>
-                        </a>
-                    </li>
-                {% endif %}
-            {% endfor %}
+                        </li>
+                    {% endif %}
+                {% endfor %}
+            </form>
         </ul>
     </div>
-    <form id="set-language"
-          action="{% url "set_language" %}"
-          method="post"
-          class="inline">
-        {% csrf_token %}
-    </form>
 </div>


### PR DESCRIPTION
### Changes
- KAT is now using showing different implementation of drop downs. The standard Manon dropdown: https://minvws.github.io/nl-rdo-manon/components/collapsible

The problem with this implementation is that we cannot use icons in the dropdown, the reason why is that we use the `data-open-label` and `data-close-label` to set the dropdown text, but we can only insert text as values.

We use now buttons to trigger the dropdown, making it more flexible to add text to button with icons.

We need to make sure that the accessibility attributes and values are also set.

This PR is a first approach to use both the Manon style and also the use of buttons including WCAG compatibility.

according to: https://www.w3.org/TR/2017/NOTE-wai-aria-practices-1.1-20171214/examples/listbox/listbox-collapsible.html

I have used some of these attributes to comply with WCAG. This PR shows a change of only 1 dropdown, a way to use this to all other drop downs across KAT



### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
