### PR TITLE
Feat/cleanup add ooi form

### DIFF
--- a/rocky/rocky/templates/oois/ooi_add.html
+++ b/rocky/rocky/templates/oois/ooi_add.html
@@ -13,16 +13,9 @@
                 <p>{% translate "Here you can add the asset of the client. Findings can be added to these in the findings page." %}</p>
                 <form method="post">
                     {% csrf_token %}
+                    <input id="ooi_type" type="hidden" name="ooi_type" value="{{ type }}">
                     {% if form.non_field_errors %}<div class="warning">{{ form.non_field_errors }}</div>{% endif %}
                     <fieldset>
-                        <div>
-                            <label for="ooi_type">Type</label>
-                            <input id="ooi_type" type="text" name="ooi_type" value="{{ type }}" readonly>
-                        </div>
-                        <div>
-                            <label for="user">Owner</label>
-                            <input id="user" type="text" name="user" value="{{ user }}" readonly>
-                        </div>
                         {% for field in form %}
                             {% include "partials/form/field_input_wrapper.html" %}
 


### PR DESCRIPTION
### Changes

This removes empty optional choice fields from the add_ooi form,
It also select the only valid option for required fields, if there is only one option.
It also removes the unneeded owner and hides the type field.

### Issue link

Closes #625

### Demo

![image](https://github.com/user-attachments/assets/3d24ae98-9653-42b8-bd93-27c28c6876b2)

### QA notes

See if we can still add / create ooi's of various types.
See if the owner/user is still saved.
See if the do in fact hide/show optional related OOI selectors based on the database contents (eg, no web-urls available, vs web-urls available).
See if the choice to select a required option is still available when two choices are present (eg, two networks exists and show up when adding a URL)
---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
