### PR TITLE
Some refactoring and set the poll interval back

### DIFF
--- a/boefjes/boefjes/app.py
+++ b/boefjes/boefjes/app.py
@@ -88,7 +88,7 @@ class SchedulerWorkerManager(WorkerManager):
 
     def _fill_queue(self, queue_type: WorkerManager.Queue) -> None:
         """Fill the local task queue with tasks from the scheduler.
-        We only sleep for the poll interval if the queue is empty."""
+        We only sleep for the poll interval if the scheduler has no (relevant) tasks in its queue."""
         logger.debug("Popping from queue %s", queue_type.value)
 
         try:

--- a/boefjes/boefjes/app.py
+++ b/boefjes/boefjes/app.py
@@ -5,7 +5,6 @@ import sys
 import time
 from multiprocessing.context import ForkContext
 from multiprocessing.process import BaseProcess
-from queue import Queue
 
 import structlog
 from httpx import HTTPError
@@ -63,8 +62,15 @@ class SchedulerWorkerManager(WorkerManager):
 
         while True:
             try:
-                self._check_workers()
-                self._fill_queue(self.task_queue, queue_type)
+                self._replace_broken_workers()
+
+                if self.task_queue.qsize() > self.settings.pool_size:
+                    # We have one new task for each worker in the local task queue, so we don't have to ask the
+                    # scheduler for new tasks.
+                    time.sleep(self.settings.worker_heartbeat)
+                    continue
+
+                self._fill_queue(queue_type)
             except Exception as e:  # noqa
                 logger.exception("Unhandled Exception:")
                 logger.info("Continuing worker...")
@@ -80,28 +86,26 @@ class SchedulerWorkerManager(WorkerManager):
 
                 raise
 
-    def _fill_queue(self, task_queue: Queue, queue_type: WorkerManager.Queue) -> None:
-        if task_queue.qsize() > self.settings.pool_size:
-            time.sleep(self.settings.worker_heartbeat)
-            return
-
+    def _fill_queue(self, queue_type: WorkerManager.Queue) -> None:
+        """Fill the local task queue with tasks from the scheduler.
+        We only sleep for the poll interval if the queue is empty."""
         logger.debug("Popping from queue %s", queue_type.value)
 
         try:
             p_item = self.scheduler_client.pop_item(queue_type.value)
         except (HTTPError, ValidationError):
-            logger.exception("Popping task from scheduler failed, sleeping 10 seconds")
-            time.sleep(self.settings.worker_heartbeat)
+            logger.exception("Popping task from scheduler failed, sleeping %s seconds", self.settings.poll_interval)
+            time.sleep(self.settings.poll_interval)
             return
 
         if p_item is None:
-            time.sleep(self.settings.worker_heartbeat)
+            time.sleep(self.settings.poll_interval)
             return
 
         logger.info("Handling task[%s]", p_item.data.id)
 
         try:
-            task_queue.put(p_item)
+            self.task_queue.put(p_item)
             logger.info("Dispatched task[%s]", p_item.data.id)
         except:  # noqa
             logger.exception("Exiting worker...")
@@ -113,7 +117,9 @@ class SchedulerWorkerManager(WorkerManager):
             except HTTPError:
                 logger.exception("Could not patch scheduler task to %s", TaskStatus.FAILED.value)
 
-    def _check_workers(self) -> None:
+    def _replace_broken_workers(self) -> None:
+        """Clean up any closed workers, replacing them by a new one to keep the pool size constant."""
+
         new_workers = []
 
         for worker in self.workers:


### PR DESCRIPTION
### Changes

A small issue that arose. A trivial change.

### Issue link

-

### Demo

See the tests!

### QA notes

If this should be QA'd, please verify that the polls to the KATalogus are now every 10 seconds for an empty queue instead of every second!

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
