### PR TITLE
Allow filter on multiple organizations in bytes API

### DIFF
--- a/bytes/bytes/api/router.py
+++ b/bytes/bytes/api/router.py
@@ -223,7 +223,7 @@ def get_raw_meta_by_id(
 
 @router.get("/raw", response_model=list[RawDataMeta], tags=[RAW_TAG])
 def get_raw(
-    organization: str | None = None,
+    organization: list[str] | None = None,
     boefje_meta_id: UUID | None = None,
     normalized: bool | None = None,
     raw_ids: list[UUID] | None = Query(None),
@@ -251,7 +251,7 @@ def get_raw(
 
 @router.get("/raws", response_model=BoefjeOutput, tags=[RAW_TAG])
 def get_raws(
-    organization: str | None = None,
+    organization: list[str] | None = Query(None),
     boefje_meta_id: UUID | None = None,
     raw_ids: list[UUID] | None = Query(None),
     normalized: bool | None = None,
@@ -283,7 +283,7 @@ def get_raws(
 
 @router.get("/mime_types", response_model=dict[str, int], tags=[RAW_TAG])
 def get_raw_count_per_mime_type(
-    organization: str | None = None,
+    organization: list[str] | None = None,
     boefje_meta_id: UUID | None = None,
     normalized: bool | None = None,
     mime_types: list[str] | None = Query(None),

--- a/bytes/bytes/models.py
+++ b/bytes/bytes/models.py
@@ -50,6 +50,9 @@ class Job(BaseModel):
     started_at: AwareDatetime
     ended_at: AwareDatetime
 
+    def __hash__(self) -> int:
+        return hash(self.id)
+
 
 class Boefje(BaseModel):
     id: str

--- a/bytes/bytes/repositories/meta_repository.py
+++ b/bytes/bytes/repositories/meta_repository.py
@@ -27,7 +27,7 @@ class NormalizerMetaFilter(BaseModel):
 
 
 class RawDataFilter(BaseModel):
-    organization: str | None = None
+    organization: list[str] | None = None
     boefje_meta_id: UUID | None = None
     raw_ids: list[UUID] | None = None
     normalized: bool | None = None
@@ -40,7 +40,10 @@ class RawDataFilter(BaseModel):
             query = query.filter(RawFileInDB.boefje_meta_id == str(self.boefje_meta_id))
 
         if self.organization:
-            query = query.join(BoefjeMetaInDB).filter(BoefjeMetaInDB.organization == self.organization)
+            if len(self.organization) == 1:
+                query = query.join(BoefjeMetaInDB).filter(BoefjeMetaInDB.organization == self.organization[0])
+            else:
+                query = query.join(BoefjeMetaInDB).filter(BoefjeMetaInDB.organization.in_(self.organization))
 
         if self.normalized:
             query = query.join(NormalizerMetaInDB, isouter=False)


### PR DESCRIPTION
### Changes

This feature is required for performance improvements in https://github.com/minvws/nl-kat-coordination/pull/4007. The Bytes raw API now allows you to filter on a list of organization codes. The change should be backward compatible.

### Issue link

-

### Demo

-

### QA notes

Please verify that there are no regressions for running tasks. The happy-path will be QA'd automatically for https://github.com/minvws/nl-kat-coordination/pull/4007 when the PR has been updated with this feature. 

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
