### PR TITLE
Disable `rich` tracebacks

### DIFF
--- a/boefjes/boefjes/__main__.py
+++ b/boefjes/boefjes/__main__.py
@@ -1,37 +1,12 @@
-import json
-import logging.config
-
 import click
 import structlog
 
 from boefjes.app import get_runtime_manager
 from boefjes.config import settings
+from boefjes.logging import configure_logging
 from boefjes.runtime_interfaces import WorkerManager
 
-with settings.log_cfg.open() as f:
-    logging.config.dictConfig(json.load(f))
-
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.dev.set_exc_info,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper("iso", utc=False),
-        (
-            structlog.dev.ConsoleRenderer(
-                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
-            )
-            if settings.logging_format == "text"
-            else structlog.processors.JSONRenderer()
-        ),
-    ],
-    context_class=dict,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
-)
+configure_logging()
 
 logger = structlog.get_logger(__name__)
 

--- a/boefjes/boefjes/__main__.py
+++ b/boefjes/boefjes/__main__.py
@@ -20,7 +20,9 @@ structlog.configure(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper("iso", utc=False),
         (
-            structlog.dev.ConsoleRenderer(colors=True, pad_level=False)
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
             if settings.logging_format == "text"
             else structlog.processors.JSONRenderer()
         ),

--- a/boefjes/boefjes/katalogus/root.py
+++ b/boefjes/boefjes/katalogus/root.py
@@ -1,5 +1,3 @@
-import json
-import logging.config
 from typing import Any
 
 import structlog
@@ -19,35 +17,12 @@ from boefjes.config import settings
 from boefjes.katalogus import organisations, plugins
 from boefjes.katalogus import settings as settings_router
 from boefjes.katalogus.version import __version__
+from boefjes.logging import configure_logging
 from boefjes.storage.interfaces import IntegrityError, NotAllowed, NotFound, StorageError
 
-with settings.log_cfg.open() as f:
-    logging.config.dictConfig(json.load(f))
-
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.dev.set_exc_info,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper("iso", utc=False),
-        (
-            structlog.dev.ConsoleRenderer(
-                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
-            )
-            if settings.logging_format == "text"
-            else structlog.processors.JSONRenderer()
-        ),
-    ],
-    context_class=dict,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
-)
+configure_logging()
 
 logger = structlog.get_logger(__name__)
-
 app = FastAPI(title="KAT-alogus API", version=__version__)
 
 if settings.span_export_grpc_endpoint is not None:

--- a/boefjes/boefjes/katalogus/root.py
+++ b/boefjes/boefjes/katalogus/root.py
@@ -33,7 +33,9 @@ structlog.configure(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper("iso", utc=False),
         (
-            structlog.dev.ConsoleRenderer(pad_level=False)
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
             if settings.logging_format == "text"
             else structlog.processors.JSONRenderer()
         ),

--- a/boefjes/boefjes/logging.py
+++ b/boefjes/boefjes/logging.py
@@ -1,0 +1,33 @@
+import json
+import logging.config
+
+import structlog
+
+from boefjes.config import settings
+
+with settings.log_cfg.open() as f:
+    logging.config.dictConfig(json.load(f))
+
+
+def configure_logging():
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper("iso", utc=False),
+            (
+                structlog.dev.ConsoleRenderer(
+                    colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+                )
+                if settings.logging_format == "text"
+                else structlog.processors.JSONRenderer()
+            ),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )

--- a/bytes/bytes/api/__init__.py
+++ b/bytes/bytes/api/__init__.py
@@ -30,7 +30,9 @@ structlog.configure(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper("iso", utc=False),
         (
-            structlog.dev.ConsoleRenderer(colors=True, pad_level=False)
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
             if settings.logging_format == "text"
             else structlog.processors.JSONRenderer()
         ),

--- a/mula/scheduler/context/context.py
+++ b/mula/scheduler/context/context.py
@@ -102,7 +102,7 @@ class AppContext:
                     structlog.dev.set_exc_info,
                     structlog.stdlib.PositionalArgumentsFormatter(),
                     structlog.processors.TimeStamper("iso", utc=False),
-                    structlog.dev.ConsoleRenderer(),
+                    structlog.dev.ConsoleRenderer(pad_level=False, exception_formatter=structlog.dev.plain_traceback),
                 ],
                 context_class=dict,
                 # `logger_factory` is used to create wrapped loggers that are used

--- a/octopoes/octopoes/api/api.py
+++ b/octopoes/octopoes/api/api.py
@@ -48,7 +48,9 @@ structlog.configure(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper("iso", utc=False),
         (
-            structlog.dev.ConsoleRenderer(colors=True, pad_level=False)
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
             if settings.logging_format == "text"
             else structlog.processors.JSONRenderer()
         ),

--- a/octopoes/octopoes/tasks/tasks.py
+++ b/octopoes/octopoes/tasks/tasks.py
@@ -39,7 +39,9 @@ structlog.configure(
         structlog.stdlib.PositionalArgumentsFormatter(),
         structlog.processors.TimeStamper("iso", utc=False),
         (
-            structlog.dev.ConsoleRenderer(colors=True, pad_level=False)
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
             if settings.logging_format == "text"
             else structlog.processors.JSONRenderer()
         ),

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -59,13 +59,15 @@ LOGGING = {
         "json_formatter": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer()},
         "plain_console": {
             "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(colors=True, pad_level=False),
+            "processor": structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            ),
         },
     },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
-            "formatter": "json_formatter" if LOGGING_FORMAT == "json" else "plain_console",
+            "formatter": ("json_formatter" if LOGGING_FORMAT == "json" else "plain_console"),
         }
     },
     "loggers": {"root": {"handlers": ["console"], "level": env("LOG_LEVEL", default="INFO").upper()}},


### PR DESCRIPTION
> [!NOTE]
> Should be back ported to `1.18`

### Changes

This PR removes the Rich traceback formatting which is used by structlog by default. While Rich provides nice formatted tracebacks, it can sometimes flood the logs with excessive text, making them harder to read and (potentially) slows down the application. This issue was also observed by Kennisnet.

This PR also fixes a duplicate logging configuration in Boefjes. Additionally, some consistency improvements have been applied.

### QA notes

Check if exception logs are not rich-like.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
