### PR TITLE
Fix possible html reinterpretation issues in javascript files

### DIFF
--- a/rocky/assets/js/jsonSchemaToForm.js
+++ b/rocky/assets/js/jsonSchemaToForm.js
@@ -45,7 +45,7 @@ function loadform(className) {
     let form = schemafield.closest("form");
     form.addEventListener("submit", (event) => {
       event.preventDefault();
-      schemafield.innerHTML = JSON.stringify(
+      schemafield.value = JSON.stringify(
         form2json(form, schema, identifier),
       );
       form.submit();

--- a/rocky/assets/js/jsonSchemaToForm.js
+++ b/rocky/assets/js/jsonSchemaToForm.js
@@ -45,9 +45,7 @@ function loadform(className) {
     let form = schemafield.closest("form");
     form.addEventListener("submit", (event) => {
       event.preventDefault();
-      schemafield.value = JSON.stringify(
-        form2json(form, schema, identifier),
-      );
+      schemafield.value = JSON.stringify(form2json(form, schema, identifier));
       form.submit();
     });
   });

--- a/rocky/assets/vendors/graph/js/graph-render.js
+++ b/rocky/assets/vendors/graph/js/graph-render.js
@@ -140,7 +140,7 @@ const goToOoi = (ooiId) => {
 
   window.location.href = window.location.href.replace(
     rootObj["xt/id"],
-    ooiId
+    encodeURIComponent(ooiId)
   );
 };
 


### PR DESCRIPTION
### Changes

This uses the value property instead of the innerHTML property of the form's textarea to collect and store the form's user input. 
For the graph, it urlencodes the new OOI ID when clicking on a node.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/security/code-scanning/29
Closes https://github.com/minvws/nl-kat-coordination/security/code-scanning/30

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes
Saving question forms should still result in config's with the user's input.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
