### PR TITLE
Dont allow open redirect in plugin_enable_disable.py

### DIFF
--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -22,9 +22,9 @@ class PluginEnableDisableView(SinglePluginView):
                 messages.WARNING,
                 _("{} '{}' disabled.").format(self.plugin.type.title(), self.plugin.name),
             )
-            redirecturl = request.POST.get("current_url")
-            if url_has_allowed_host_and_scheme(redirecturl, allowed_hosts=None):
-                return HttpResponseRedirect(redirecturl)
+            redirect_url = request.POST.get("current_url")
+            if url_has_allowed_host_and_scheme(redirect_url, allowed_hosts=None):
+                return HttpResponseRedirect(redirect_url)
             return HttpResponseForbidden()
 
         if self.plugin.can_scan(self.organization_member):

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -3,8 +3,8 @@ from django.contrib import messages
 from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls.base import reverse
-from django.utils.translation import gettext_lazy as _
 from django.utils.http import url_has_allowed_host_and_scheme
+from django.utils.translation import gettext_lazy as _
 
 from katalogus.views.mixins import SinglePluginView
 

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -1,6 +1,6 @@
 import structlog
 from django.contrib import messages
-from django.http import HttpResponseRedirect
+from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls.base import reverse
 from django.utils.translation import gettext_lazy as _
@@ -21,7 +21,10 @@ class PluginEnableDisableView(SinglePluginView):
                 messages.WARNING,
                 _("{} '{}' disabled.").format(self.plugin.type.title(), self.plugin.name),
             )
-            return HttpResponseRedirect(request.POST.get("current_url"))
+            redirecturl = request.POST.get("current_url")
+            if redirecturl.startswith("/"): # we want to stay on the same host.
+                return HttpResponseRedirect(redirecturl)
+            return HttpResponseForbidden()
 
         if self.plugin.can_scan(self.organization_member):
             self.katalogus_client.enable_plugin(self.plugin)

--- a/rocky/katalogus/views/plugin_enable_disable.py
+++ b/rocky/katalogus/views/plugin_enable_disable.py
@@ -4,6 +4,7 @@ from django.http import HttpResponseForbidden, HttpResponseRedirect
 from django.shortcuts import redirect
 from django.urls.base import reverse
 from django.utils.translation import gettext_lazy as _
+from django.utils.http import url_has_allowed_host_and_scheme
 
 from katalogus.views.mixins import SinglePluginView
 
@@ -22,7 +23,7 @@ class PluginEnableDisableView(SinglePluginView):
                 _("{} '{}' disabled.").format(self.plugin.type.title(), self.plugin.name),
             )
             redirecturl = request.POST.get("current_url")
-            if redirecturl.startswith("/"): # we want to stay on the same host.
+            if url_has_allowed_host_and_scheme(redirecturl, allowed_hosts=None):
                 return HttpResponseRedirect(redirecturl)
             return HttpResponseForbidden()
 


### PR DESCRIPTION
### Changes

This adds a check to see if the requested redirect url starts with a / and is thus local (relative to this host).
If not, we throw a 403.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/security/code-scanning/33

### QA notes

Enabling a plugin should still work.
Enabling a plugin, and changing the hidden form field 'current_url' to another host should throw a 403.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
