### PR TITLE
Add missing report_type field in report recipe serializer

### DIFF
--- a/rocky/reports/serializers.py
+++ b/rocky/reports/serializers.py
@@ -24,6 +24,7 @@ class ReportRecipeSerializer(serializers.Serializer):
     report_name_format = serializers.CharField()
 
     input_recipe = serializers.DictField()
+    report_type = serializers.CharField()
     asset_report_types = serializers.ListField(child=serializers.CharField())
 
     cron_expression = serializers.CharField()


### PR DESCRIPTION
### Changes

With the changes of the reports and recipesthe report_type field was forgotten in the REST API 

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
