### PR TITLE
Remove compress from javascript in report_history_table.html

### DIFF
--- a/rocky/reports/templates/report_overview/report_history_table.html
+++ b/rocky/reports/templates/report_overview/report_history_table.html
@@ -237,9 +237,7 @@
 {% endif %}
 {% block html_at_end_body %}
     <script src="{% static "modal/script.js" %}" nonce="{{ request.csp_nonce }}" type="module"></script>
-    {% compress js %}
-        <script src="{% static "js/grabSelectionOnModalOpen.js" %}" nonce="{{ request.csp_nonce }}" type="module"></script>
-        <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
-        <script src="{% static "js/renameReports.js" %}" nonce="{{ request.csp_nonce }}" type="module"></script>
-    {% endcompress %}
+    <script src="{% static "js/grabSelectionOnModalOpen.js" %}" nonce="{{ request.csp_nonce }}" type="module"></script>
+    <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
+    <script src="{% static "js/renameReports.js" %}" nonce="{{ request.csp_nonce }}" type="module"></script>
 {% endblock html_at_end_body %}


### PR DESCRIPTION
### Changes

Compress doesn't work with modules that import other javascript, so remove compress from all javascript in report_history_table.html 

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/templates/pull_request_template_review_qa.md) into your comment.
