### PR TITLE
Fix hanging sessions in the boefje worker upon database disconnects

### DIFF
--- a/boefjes/boefjes/app.py
+++ b/boefjes/boefjes/app.py
@@ -242,7 +242,7 @@ def _start_working(
     logger.info("Started listening for tasks from worker[pid=%s]", os.getpid())
 
     while True:
-        p_item = task_queue.get()
+        p_item = task_queue.get()  # blocks until tasks are pushed in the main process
         status = TaskStatus.FAILED
         handling_tasks[os.getpid()] = str(p_item.id)
 
@@ -268,7 +268,7 @@ def _start_working(
 def get_runtime_manager(settings: Settings, queue: WorkerManager.Queue, log_level: str) -> WorkerManager:
     local_repository = get_local_repository()
 
-    session = sessionmaker(bind=get_engine())()
+    session = sessionmaker(bind=get_engine())
     plugin_service = PluginService(create_plugin_storage(session), create_config_storage(session), local_repository)
 
     item_handler: Handler

--- a/boefjes/boefjes/dependencies/plugins.py
+++ b/boefjes/boefjes/dependencies/plugins.py
@@ -19,7 +19,6 @@ from boefjes.storage.interfaces import (
     PluginNotFound,
     PluginStorage,
     SettingsNotConformingToSchema,
-    UniqueViolation,
 )
 
 logger = structlog.get_logger(__name__)
@@ -115,17 +114,9 @@ class PluginService:
                 if plugin.type == "boefje":
                     raise DuplicatePlugin("name")
                 else:
-                    try:
-                        with self.plugin_storage as storage:
-                            storage.create_boefje(boefje)
-                    except UniqueViolation as error:
-                        raise DuplicatePlugin(error.field)
+                    self.plugin_storage.create_boefje(boefje)
             except KeyError:
-                try:
-                    with self.plugin_storage as storage:
-                        storage.create_boefje(boefje)
-                except UniqueViolation as error:
-                    raise DuplicatePlugin(error.field)
+                self.plugin_storage.create_boefje(boefje)
 
     def create_normalizer(self, normalizer: Normalizer) -> None:
         try:

--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -97,8 +97,9 @@ class BoefjeHandler(Handler):
     def handle(self, boefje_meta: BoefjeMeta) -> None:
         logger.info("Handling boefje %s[task_id=%s]", boefje_meta.boefje.id, str(boefje_meta.id))
 
-        # Check if this boefje is container-native, if so, continue using the Docker boefjes runner
-        plugin = self.plugin_service.by_plugin_id(boefje_meta.boefje.id, boefje_meta.organization)
+        with self.plugin_service as service:
+            # Check if this boefje is container-native, if so, continue using the Docker boefjes runner
+            plugin = service.by_plugin_id(boefje_meta.boefje.id, boefje_meta.organization)
 
         if plugin.type != "boefje":
             raise ValueError("Plugin id does not belong to a boefje")

--- a/boefjes/boefjes/katalogus/plugins.py
+++ b/boefjes/boefjes/katalogus/plugins.py
@@ -17,7 +17,7 @@ from boefjes.dependencies.plugins import (
 from boefjes.models import FilterParameters, PaginationParameters, PluginType
 from boefjes.sql.db_models import RunOn
 from boefjes.sql.plugin_storage import get_plugin_storage
-from boefjes.storage.interfaces import DuplicatePlugin, IntegrityError, NotAllowed, PluginStorage
+from boefjes.storage.interfaces import DuplicatePlugin, IntegrityError, NotAllowed, PluginStorage, UniqueViolation
 
 router = APIRouter(prefix="/organisations/{organisation_id}", tags=["plugins"])
 
@@ -101,6 +101,10 @@ def add_plugin(plugin: PluginType, plugin_service: PluginService = Depends(get_p
 
             if plugin.type == "normalizer":
                 return service.create_normalizer(plugin)
+    except UniqueViolation as error:
+        raise HTTPException(
+            status.HTTP_400_BAD_REQUEST, f"Duplicate plugin: a plugin with this {error.field} already exists"
+        )
     except DuplicatePlugin as error:
         raise HTTPException(status.HTTP_400_BAD_REQUEST, error.message)
 

--- a/boefjes/boefjes/sql/session.py
+++ b/boefjes/boefjes/sql/session.py
@@ -1,7 +1,7 @@
 import structlog
 from psycopg2 import errors
 from sqlalchemy import exc
-from sqlalchemy.orm import Session
+from sqlalchemy.orm import Session, sessionmaker
 from typing_extensions import Self
 
 from boefjes.storage.interfaces import IntegrityError, StorageError, UniqueViolation
@@ -23,12 +23,22 @@ class SessionMixin:
     """
 
     def __init__(self, session: Session):
-        self.session: Session = session
+        # Allow both shared sessions and ad-hoc sessions.
+        self._session: Session | sessionmaker = session
+        self.session: Session = session if isinstance(session, Session) else session()
 
     def __enter__(self) -> Self:
+        if isinstance(self._session, Session):
+            self.session = self._session
+        else:
+            self.session = self._session()
+
         return self
 
     def __exit__(self, exc_type: type[Exception], exc_value: str, exc_traceback: str) -> None:  # noqa: F841
+        if self.session is None:
+            raise StorageError("Nested sessions detected, make sure to scope transactions properly!")
+
         if exc_type is not None:
             logger.error("An error occurred: %s. Rolling back session", exc_value)
             self.session.rollback()
@@ -45,6 +55,11 @@ class SessionMixin:
         except exc.DatabaseError as e:
             raise StorageError("A storage error occurred") from e
         finally:
-            if exc_type is not None or self.session.is_active:
+            if self.session.is_active:
                 logger.debug("Committing failed, rolling back")
                 self.session.rollback()
+
+            if isinstance(self._session, sessionmaker):
+                self.session.close()
+
+            self.session = None

--- a/boefjes/tests/integration/test_get_environment.py
+++ b/boefjes/tests/integration/test_get_environment.py
@@ -9,7 +9,8 @@ from tests.loading import get_boefje_meta
 @pytest.mark.skipif("os.environ.get('CI') != '1'")
 def test_environment_builds_up_correctly(plugin_service: PluginService, organisation: Organisation):
     plugin_id = "dns-records"
-    schema = plugin_service.schema(plugin_id)
+    with plugin_service:
+        schema = plugin_service.schema(plugin_id)
     environment = get_environment_settings(get_boefje_meta(boefje_id=plugin_id), schema)
 
     assert environment == {}

--- a/boefjes/tests/integration/test_settings_to_boefje_config_migration.py
+++ b/boefjes/tests/integration/test_settings_to_boefje_config_migration.py
@@ -89,12 +89,14 @@ def test_fail_on_wrong_plugin_ids(migration_6f99834a4a5a):
     session.close()
 
     config_storage = SQLConfigStorage(session, encrypter)
-    assert config_storage.get_all_settings("dev1", "dns-records") == {"key1": "val1"}
-    assert config_storage.get_all_settings("dev1", "nmap-udp") == {}
-    assert config_storage.get_all_settings("dev2", "dns-records") == {"key1": "val1", "key2": "val2"}
 
-    assert config_storage.is_enabled_by_id("dns-records", "dev1")
-    assert config_storage.is_enabled_by_id("nmap-udp", "dev1")
+    with config_storage:
+        assert config_storage.get_all_settings("dev1", "dns-records") == {"key1": "val1"}
+        assert config_storage.get_all_settings("dev1", "nmap-udp") == {}
+        assert config_storage.get_all_settings("dev2", "dns-records") == {"key1": "val1", "key2": "val2"}
+
+        assert config_storage.is_enabled_by_id("dns-records", "dev1")
+        assert config_storage.is_enabled_by_id("nmap-udp", "dev1")
 
     session.commit()
     session.close()

--- a/boefjes/tests/integration/test_sql_repositories.py
+++ b/boefjes/tests/integration/test_sql_repositories.py
@@ -16,16 +16,19 @@ def test_organisation_storage(organisation_storage):
     with organisation_storage as storage:
         storage.create(org)
 
-    returned_org = storage.get_by_id(organisation_id)
+    with organisation_storage as storage:
+        returned_org = storage.get_by_id(organisation_id)
     assert org == returned_org
 
-    all_organisations = storage.get_all()
+    with organisation_storage as storage:
+        all_organisations = storage.get_all()
+
     assert org == all_organisations[organisation_id]
 
     with organisation_storage as storage:
         storage.delete_by_id(organisation_id)
 
-    with pytest.raises(OrganisationNotFound):
+    with pytest.raises(OrganisationNotFound), organisation_storage as storage:
         storage.get_by_id(organisation_id)
 
 
@@ -45,22 +48,26 @@ def test_settings_storage(plugin_storage, organisation_storage, config_storage):
 
     with config_storage as settings_storage:
         settings_storage.upsert(organisation_id, plugin_id, {"TEST_SETTING": "123.9", "TEST_SETTING2": 13})
-
-    returned_settings = settings_storage.get_all_settings(organisation_id, plugin_id)
+    with config_storage as settings_storage:
+        returned_settings = settings_storage.get_all_settings(organisation_id, plugin_id)
     assert returned_settings["TEST_SETTING"] == "123.9"
     assert returned_settings["TEST_SETTING2"] == 13
 
-    with pytest.raises(ConfigNotFound):
+    with pytest.raises(ConfigNotFound), config_storage:
         config_storage.delete("no organisation!", plugin_id)
 
-    assert settings_storage.get_all_settings(org.id, plugin_id) == {"TEST_SETTING": "123.9", "TEST_SETTING2": 13}
-    assert config_storage.get_all_settings(org.id, "wrong") == {}
-    assert config_storage.get_all_settings("wrong", plugin_id) == {}
+    with config_storage as settings_storage:
+        assert settings_storage.get_all_settings(org.id, plugin_id) == {"TEST_SETTING": "123.9", "TEST_SETTING2": 13}
+    with config_storage:
+        assert config_storage.get_all_settings(org.id, "wrong") == {}
+    with config_storage:
+        assert config_storage.get_all_settings("wrong", plugin_id) == {}
 
     with config_storage as settings_storage:
         settings_storage.delete(org.id, plugin_id)
 
-    assert settings_storage.get_all_settings(org.id, plugin_id) == {}
+    with config_storage as settings_storage:
+        assert settings_storage.get_all_settings(org.id, plugin_id) == {}
 
     with pytest.raises(StorageError), config_storage as settings_storage:
         settings_storage.upsert(organisation_id, 65 * "a", {"TEST_SETTING": "123.9"})
@@ -91,14 +98,15 @@ def test_settings_storage_values_field_limits(plugin_storage, organisation_stora
             },
         )
 
-    assert settings_storage.get_all_settings(org.id, plugin_id) == {
-        "TEST_SETTING": 12 * "123.9",
-        "TEST_SETTING2": 12000,
-        "TEST_SETTING3": 30 * "b",
-        "TEST_SETTING4": 30 * "b",
-        "TEST_SETTING5": 10 * "b",
-        "TEST_SETTING6": 123456789,
-    }
+    with config_storage as settings_storage:
+        assert settings_storage.get_all_settings(org.id, plugin_id) == {
+            "TEST_SETTING": 12 * "123.9",
+            "TEST_SETTING2": 12000,
+            "TEST_SETTING3": 30 * "b",
+            "TEST_SETTING4": 30 * "b",
+            "TEST_SETTING5": 10 * "b",
+            "TEST_SETTING6": 123456789,
+        }
 
 
 def test_plugin_enabled_storage(organisation_storage, plugin_storage, config_storage):
@@ -121,22 +129,24 @@ def test_plugin_enabled_storage(organisation_storage, plugin_storage, config_sto
     with config_storage as storage:
         storage.upsert(org.id, plugin.id, enabled=plugin.enabled)
 
-    returned_state = storage.is_enabled_by_id(plugin.id, org.id)
+    with config_storage as storage:
+        returned_state = storage.is_enabled_by_id(plugin.id, org.id)
     assert returned_state is True
 
     with config_storage as storage:
         storage.upsert(org.id, plugin.id, enabled=False)
 
-    returned_state = storage.is_enabled_by_id(plugin.id, org.id)
+    with config_storage as storage:
+        returned_state = storage.is_enabled_by_id(plugin.id, org.id)
     assert returned_state is False
 
-    with pytest.raises(ConfigNotFound):
+    with pytest.raises(ConfigNotFound), config_storage as storage:
         storage.is_enabled_by_id("wrong", org.id)
 
-    with pytest.raises(ConfigNotFound):
+    with pytest.raises(ConfigNotFound), config_storage as storage:
         storage.is_enabled_by_id("wrong", org.id)
 
-    with pytest.raises(ConfigNotFound):
+    with pytest.raises(ConfigNotFound), config_storage as storage:
         storage.is_enabled_by_id(plugin.id, "wrong")
 
 
@@ -146,39 +156,45 @@ def test_bare_boefje_storage(plugin_storage):
     with plugin_storage as storage:
         storage.create_boefje(boefje)
 
-    returned_boefje = storage.boefje_by_id(boefje.id)
+    with plugin_storage as storage:
+        returned_boefje = storage.boefje_by_id(boefje.id)
     assert boefje == returned_boefje
 
     with plugin_storage as storage:
         storage.update_boefje(boefje.id, {"description": "4"})
 
-    assert storage.boefje_by_id(boefje.id).description == "4"
+    with plugin_storage as storage:
+        assert storage.boefje_by_id(boefje.id).description == "4"
 
     with plugin_storage as storage:
         storage.update_boefje(boefje.id, {"scan_level": 3})
 
-    assert storage.boefje_by_id(boefje.id).scan_level == 3
+    with plugin_storage as storage:
+        assert storage.boefje_by_id(boefje.id).scan_level == 3
 
     boefje.description = "4"
     boefje.scan_level = 3
 
-    assert storage.boefje_by_id(boefje.id).description == "4"
+    with plugin_storage as storage:
+        assert storage.boefje_by_id(boefje.id).description == "4"
     boefje.description = "4"
 
     with plugin_storage as storage:
         storage.update_boefje(boefje.id, {"scan_level": 3})
 
-    assert storage.boefje_by_id(boefje.id).scan_level == 3
+    with plugin_storage as storage:
+        assert storage.boefje_by_id(boefje.id).scan_level == 3
 
     boefje.description = "4"
     boefje.scan_level = 3
-    all_plugins = storage.get_all()
+    with plugin_storage as storage:
+        all_plugins = storage.get_all()
     assert all_plugins == [boefje]
 
     with plugin_storage as storage:
         storage.delete_boefje_by_id(boefje.id)
 
-    with pytest.raises(PluginNotFound):
+    with pytest.raises(PluginNotFound), plugin_storage as storage:
         storage.boefje_by_id(boefje.id)
 
 
@@ -206,7 +222,9 @@ def test_rich_boefje_storage(plugin_storage):
     with plugin_storage as storage:
         storage.create_boefje(boefje)
 
-    returned_boefje = storage.boefje_by_id(boefje.id)
+    with plugin_storage as storage:
+        returned_boefje = storage.boefje_by_id(boefje.id)
+
     assert boefje == returned_boefje
 
 
@@ -216,20 +234,24 @@ def test_bare_normalizer_storage(plugin_storage):
     with plugin_storage as storage:
         storage.create_normalizer(normalizer)
 
-    returned_normalizer = storage.normalizer_by_id(normalizer.id)
+    with plugin_storage as storage:
+        returned_normalizer = storage.normalizer_by_id(normalizer.id)
     assert normalizer == returned_normalizer
 
-    storage.update_normalizer(normalizer.id, {"version": "v4"})
-    assert storage.normalizer_by_id(normalizer.id).version == "v4"
+    with plugin_storage as storage:
+        storage.update_normalizer(normalizer.id, {"version": "v4"})
+    with plugin_storage as storage:
+        assert storage.normalizer_by_id(normalizer.id).version == "v4"
     normalizer.version = "v4"
 
-    all_plugins = storage.get_all()
+    with plugin_storage as storage:
+        all_plugins = storage.get_all()
     assert all_plugins == [normalizer]
 
     with plugin_storage as storage:
         storage.delete_normalizer_by_id(normalizer.id)
 
-    with pytest.raises(PluginNotFound):
+    with pytest.raises(PluginNotFound), plugin_storage as storage:
         storage.normalizer_by_id(normalizer.id)
 
 
@@ -254,8 +276,9 @@ def test_rich_normalizer_storage(plugin_storage):
 
     with plugin_storage as storage:
         storage.create_normalizer(normalizer)
+    with plugin_storage as storage:
+        returned_normalizer = storage.normalizer_by_id(normalizer.id)
 
-    returned_normalizer = storage.normalizer_by_id(normalizer.id)
     assert normalizer == returned_normalizer
 
 
@@ -267,4 +290,5 @@ def test_plugin_storage(plugin_storage):
         storage.create_boefje(boefje)
         storage.create_normalizer(normalizer)
 
-    assert storage.get_all() == [boefje, normalizer]
+    with plugin_storage as storage:
+        assert storage.get_all() == [boefje, normalizer]


### PR DESCRIPTION
### Changes

- Enhance the `SessionMixin` to allow a `sessionmaker` to be passed if you want fresh sessions when entering the context manager.
- Change the boefje handler accordingly.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4308 (hopefully)

### Demo

-

### QA notes

-
---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_qa.md) into your comment.
