### PR TITLE
Fix broken normaliser list view link in plugins.html

### DIFF
--- a/rocky/katalogus/templates/partials/plugins.html
+++ b/rocky/katalogus/templates/partials/plugins.html
@@ -20,7 +20,11 @@
                 {% for plugin in object_list %}
                     <tr id="plugin_{{ plugin.id|slugify }}">
                         <td scope="row">
-                            <a href="{% url "boefje_detail" organization_code=organization.code plugin_id=plugin.id %}">{{ plugin.name }}</a>
+                            {% if plugin.scan_level != None %}
+                                <a href="{% url "boefje_detail" organization_code=organization.code plugin_id=plugin.id %}">{{ plugin.name }}</a>
+                            {% else %}
+                                <a href="{% url "normalizer_detail" organization_code=organization.code plugin_id=plugin.id %}">{{ plugin.name }}</a>
+                            {% endif %}
                         </td>
                         {% if active == "all" %}
                             <td scope="row">


### PR DESCRIPTION
### Changes

Uses the correct link for normalizers.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4327

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

Follow the path described in the issue, this should now work. The url was using the boefjes url.
Boefjes (on the list view) should also still work.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_qa.md) into your comment.
