### PR TITLE
Ignore incorrect type assumption from mypy

### DIFF
--- a/mula/scheduler/utils/cron.py
+++ b/mula/scheduler/utils/cron.py
@@ -8,4 +8,4 @@ def next_run(expression: str, start_time: datetime | None = None) -> datetime:
         start_time = datetime.now(timezone.utc)
 
     cron = croniter(expression, start_time)
-    return cron.get_next(datetime)
+    return cron.get_next(datetime)  # type: ignore


### PR DESCRIPTION
### Changes

Suddenly we get `mula/scheduler/utils/cron.py:11: error: Incompatible return value type (got "float", expected "datetime") [return-value]` from mypy. We see this pop-up in the git precommit checks in the CI (https://github.com/minvws/nl-kat-coordination/actions/runs/14471764886/job/40587294315). This is incorrect and the `get_next()` method returns a `datetime`

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4336

### QA notes

The precommit CI step is running correctly.

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_qa.md) into your comment.
