### PR TITLE
Updated `django_compressor`

### DIFF
--- a/rocky/poetry.lock
+++ b/rocky/poetry.lock
@@ -600,9 +600,9 @@ rjsmin = "1.2.1"
 
 [package.source]
 type = "git"
-url = "https://github.com/dekkers/django-compressor"
-reference = "620bc0ab86590f8981dd24456a70951c9bdbf91f"
-resolved_reference = "620bc0ab86590f8981dd24456a70951c9bdbf91f"
+url = "https://github.com/dekkers/django-compressor.git"
+reference = "csp-nonce"
+resolved_reference = "fefae9d412018432f3b73b8c77109e1873dc88e0"
 
 [[package]]
 name = "django-csp"
@@ -3441,4 +3441,4 @@ test = ["pytest"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9f30721c6a32535f9f77e7d3e7a9fcf0c4f77298f516f909b6bbf3d05dc02caa"
+content-hash = "f9d4c148e67611b62d05374393a1fc460fc40f1d47c8835e238c352fe5d3001f"

--- a/rocky/pyproject.toml
+++ b/rocky/pyproject.toml
@@ -21,7 +21,7 @@ django-csp = "^3.7"
 djangorestframework = "^3.15.2"
 django-tagulous = "^1.3.3"
 drf-standardized-errors = "^0.12.5"
-django-compressor = { git = "https://github.com/dekkers/django-compressor", rev = "620bc0ab86590f8981dd24456a70951c9bdbf91f" }
+django-compressor = {git = "https://github.com/dekkers/django-compressor.git", rev = "csp-nonce"}
 django-weasyprint = "^2.4.0"
 strenum = "^0.4.15"
 django-rest-knox = { git = "https://github.com/jazzband/django-rest-knox", rev = "dd7b062147bc4b9718e22d5acd6cf1301a1036b9" }

--- a/rocky/requirements-dev.txt
+++ b/rocky/requirements-dev.txt
@@ -326,7 +326,7 @@ django-appconf==1.0.6 ; python_version >= "3.10" and python_version < "4.0" \
 django-components==0.88 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:19641759bcbdafeaf48d4363c11639201fc893946745799b12b77cd7996da8fc \
     --hash=sha256:a796077706423b491234625d95bb8084761211ae022df159ead8472a1a256c7a
-django-compressor @ git+https://github.com/dekkers/django-compressor@620bc0ab86590f8981dd24456a70951c9bdbf91f ; python_version >= "3.10" and python_version < "4.0"
+django-compressor @ git+https://github.com/dekkers/django-compressor.git@fefae9d412018432f3b73b8c77109e1873dc88e0 ; python_version >= "3.10" and python_version < "4.0"
 django-csp==3.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
     --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0

--- a/rocky/requirements.txt
+++ b/rocky/requirements.txt
@@ -259,7 +259,7 @@ django-appconf==1.0.6 ; python_version >= "3.10" and python_version < "4.0" \
 django-components==0.88 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:19641759bcbdafeaf48d4363c11639201fc893946745799b12b77cd7996da8fc \
     --hash=sha256:a796077706423b491234625d95bb8084761211ae022df159ead8472a1a256c7a
-django-compressor @ git+https://github.com/dekkers/django-compressor@620bc0ab86590f8981dd24456a70951c9bdbf91f ; python_version >= "3.10" and python_version < "4.0"
+django-compressor @ git+https://github.com/dekkers/django-compressor.git@fefae9d412018432f3b73b8c77109e1873dc88e0 ; python_version >= "3.10" and python_version < "4.0"
 django-csp==3.8 ; python_version >= "3.10" and python_version < "4.0" \
     --hash=sha256:19b2978b03fcd73517d7d67acbc04fbbcaec0facc3e83baa502965892d1e0719 \
     --hash=sha256:ef0f1a9f7d8da68ae6e169c02e9ac661c0ecf04db70e0d1d85640512a68471c0


### PR DESCRIPTION
### Changes

This PR bumps the [forked version](https://github.com/dekkers/django-compressor/tree/csp-nonce) of `django-compressor`

### QA notes

Run Rocky with `debug=False` and see if the pages load as usual (e.g. styling is correct and no 404 errors when requesting static resources)

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/about-openkat/templates/pull_request_template_review_qa.md) into your comment.
