### PR TITLE
Remove unused scan profile increment queues

### DIFF
--- a/octopoes/tests/robot/01_scan_profiles.robot
+++ b/octopoes/tests/robot/01_scan_profiles.robot
@@ -19,9 +19,6 @@ Inheritance Of Two Declared Scan Profiles
     Verify Scan Level    ${REF_HOSTNAME}    ${4}
     Verify Scan Level    ${REF_IPADDR}    ${2}
     Verify Scan Level    ${REF_RESOLVEDHOSTNAME}    ${4}
-    Verify Scan Profile Increment Queue    ${REF_HOSTNAME}    ${4}
-    Verify Scan Profile Increment Queue    ${REF_IPADDR}    ${2}
-    Verify Scan Profile Increment Queue    ${REF_RESOLVEDHOSTNAME}    ${4}
     Verify Scan LeveL Filter    1    ${0}
     Verify Scan LeveL Filter    2    ${2}
     Verify Scan LeveL Filter    3    ${0}
@@ -45,9 +42,6 @@ Recalculate Inheritance After Modification
     Verify Scan Level    ${REF_HOSTNAME}    ${0}
     Verify Scan Level    ${REF_IPADDR}    ${2}
     Verify Scan Level    ${REF_RESOLVEDHOSTNAME}    ${0}
-    Verify Scan Profile Increment Queue    ${REF_HOSTNAME}    ${4}
-    Verify Scan Profile Increment Queue    ${REF_IPADDR}    ${2}
-    Verify Scan Profile Increment Queue    ${REF_RESOLVEDHOSTNAME}    ${4}
     Verify Scan Profile Mutation Queue    ${REF_HOSTNAME}    ${{[0, 4, 0]}}
     Verify Scan Profile Mutation Queue    ${REF_IPADDR}    ${{[0, 2]}}
     Verify Scan Profile Mutation Queue    ${REF_RESOLVEDHOSTNAME}    ${{[0, 4, 0]}}
@@ -92,23 +86,6 @@ Verify Scan Level
     ...    ${response_data["scan_profile"]["level"]}
     ...    ${scan_level}
     ...    Scan Level of ${reference} should be ${scan_level} in the database
-
-Verify Scan Profile Increment Queue
-    [Arguments]    ${reference}    ${scan_level}
-    ${messages}    Get Messages From Queue    ${SCAN_PROFILE_INCREMENT_QUEUE}    ack_requeue_true
-    FOR    ${message}    IN    @{messages}
-        ${payload}    Evaluate    json.loads("""${message["payload"]}""")    json
-        IF    "${payload['primary_key']}" == "${reference}"
-            Should Be Equal As Integers
-            ...    ${payload["scan_profile"]["level"]}
-            ...    ${scan_level}
-            ...    Scan Level of ${reference} should be ${scan_level} in the increment queue
-            @{reference_parts}    Split String    ${reference}    |
-            Should Be Equal    ${payload["object_type"]}    ${reference_parts}[0]
-            RETURN
-        END
-    END
-    Fail    Scan Level of ${reference} should be incremented to ${scan_level}
 
 Verify Scan LeveL Filter
     [Arguments]    ${scan_level}    ${expected_count}

--- a/octopoes/tests/robot/robot.resource
+++ b/octopoes/tests/robot/robot.resource
@@ -17,7 +17,6 @@ ${QUEUE_URI}                        amqp://ci_user:ci_pass@localhost:29004/kat
 ${RABBIT_MQ_API_URI}                http://ci_user:ci_pass@localhost:29003/api
 ${VALID_TIME}                       2022-01-01T00:00:00+00:00
 
-${SCAN_PROFILE_INCREMENT_QUEUE}     _dev__scan_profile_increments
 ${SCAN_PROFILE_MUTATION_QUEUE}      scan_profile_mutations
 
 
@@ -101,7 +100,6 @@ Setup Test
 Teardown Test
     Delete XTDB node
     Get Messages From Queue    octopoes    ack_requeue_false
-    Get Messages From Queue    ${SCAN_PROFILE_INCREMENT_QUEUE}    ack_requeue_false
     Get Messages From Queue    ${SCAN_PROFILE_MUTATION_QUEUE}    ack_requeue_false
     Stop Monitoring
 

--- a/octopoes/tests/test_event_manager.py
+++ b/octopoes/tests/test_event_manager.py
@@ -122,16 +122,8 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
         task_id="1754a4c8-f0b8-42c8-b294-5706ce23a47d",
     )
 
-    assert channel_mock.basic_publish.call_count == 2
+    assert channel_mock.basic_publish.call_count == 1
     channel_mock.basic_publish.asset_has_calls(
-        mocker.call(
-            "",
-            "test__scan_profile_increments",
-            b'{"primary_key": "test|reference", "object_type": "test",'
-            b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
-            "level": 2, "user_id": None}}',
-            properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
-        ),
         mocker.call(
             "",
             "scan_profile_mutations",
@@ -141,7 +133,7 @@ def test_event_manager_create_declared_scan_profile(mocker, declared_scan_profil
             b'"scan_profile": {"scan_profile_type": "declared", "reference": "test|reference",\
             "level": 2, "user_id": None}}, "client_id": "test"}',
             properties=pika.BasicProperties(delivery_mode=pika.DeliveryMode.Persistent),
-        ),
+        )
     )
 
 


### PR DESCRIPTION
### Changes

Nobody listens to the scan profile increment queues anymore, so we don't have to publish to these queues.

It might be nice to also delete the already existing RabbitMQ queues, but I am not sure if there is an easy way to do this.

### QA notes

This PR removes functionality that wasn't used anymore, so there isn't really any PR specific QA to do.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
