### PR TITLE
Make the list of boefjes unqiue when queriying the KATalogus for info on them

### DIFF
--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -79,14 +79,14 @@ class NormalizersTaskListView(TaskListView):
             },
         ]
 
-        # Search for the corresponding Boefje names and add those to the task_list
+        # Search for the corresponding Normalizer names and add those to the task_list
         task_list = context.get("task_list", [])
         ids = [
             task.data.raw_data.boefje_meta.boefje.id
             for task in task_list
             if task.data.raw_data.boefje_meta.boefje.id != "manual"
         ]
-        plugins = self.get_katalogus().get_plugins(ids=ids)
+        plugins = self.get_katalogus().get_plugins(ids=set(ids))
         plugin_dict = {p.id: p.name for p in plugins}
 
         for task in task_list:


### PR DESCRIPTION
We seem to be querying the katalogus for the same boefje info repeatedly when dealing with task pages that have lost of similar jobs.

### Changes

Make the list of boefjes we want info on unique before constructing the url.

### Issue link

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

Boefje names on the normaliser task list should still be visible, even for the Nth task using a given boefje.
The queries to the katalogus from Rocky on the /plugins endpoint should now no longer contain the same boefje multiple times.

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
