### PR TITLE
Add organisation queryparam for schedules endpoint

### DIFF
--- a/mula/scheduler/server/handlers/schedules.py
+++ b/mula/scheduler/server/handlers/schedules.py
@@ -75,6 +75,7 @@ class ScheduleAPI:
         self,
         request: fastapi.Request,
         scheduler_id: str | None = None,
+        organisation: str | None = None,
         schedule_hash: str | None = None,
         enabled: bool | None = None,
         offset: int = 0,
@@ -92,6 +93,7 @@ class ScheduleAPI:
 
         results, count = self.ctx.datastores.schedule_store.get_schedules(
             scheduler_id=scheduler_id,
+            organisation=organisation,
             schedule_hash=schedule_hash,
             enabled=enabled,
             min_deadline_at=min_deadline_at,

--- a/mula/scheduler/storage/stores/schedule.py
+++ b/mula/scheduler/storage/stores/schedule.py
@@ -20,6 +20,7 @@ class ScheduleStore:
     def get_schedules(
         self,
         scheduler_id: str | None = None,
+        organisation: str | None = None,
         schedule_hash: str | None = None,
         enabled: bool | None = None,
         min_deadline_at: datetime | None = None,
@@ -35,6 +36,9 @@ class ScheduleStore:
 
             if scheduler_id is not None:
                 query = query.filter(models.ScheduleDB.scheduler_id == scheduler_id)
+
+            if organisation is not None:
+                query = query.filter(models.ScheduleDB.organisation == organisation)
 
             if enabled is not None:
                 query = query.filter(models.ScheduleDB.enabled == enabled)

--- a/mula/tests/integration/test_api.py
+++ b/mula/tests/integration/test_api.py
@@ -7,10 +7,10 @@ from unittest import mock
 from urllib.parse import quote
 
 from fastapi.testclient import TestClient
+
 from scheduler import config, models, server, storage, utils
 from scheduler.server import schemas
 from scheduler.storage import stores
-
 from tests.factories import OrganisationFactory
 from tests.mocks import queue as mock_queue
 from tests.mocks import scheduler as mock_scheduler
@@ -978,6 +978,17 @@ class APIScheduleEndpointTestCase(APITemplateTestCase):
         self.assertEqual(1, response.json()["count"])
         self.assertEqual(1, len(response.json()["results"]))
         self.assertEqual(str(self.first_schedule.id), response.json()["results"][0]["id"])
+
+    def test_list_schedules_organisation(self):
+        response = self.client.get(f"/schedules?organisation={self.organisation.id}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, response.json()["count"])
+        self.assertEqual(2, len(response.json()["results"]))
+
+        response = self.client.get(f"/schedules?organisation={uuid.uuid4()}")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(0, response.json()["count"])
+        self.assertEqual(0, len(response.json()["results"]))
 
     def test_post_schedule(self):
         item = functions.create_task(self.scheduler.scheduler_id, self.organisation.id)

--- a/mula/tests/integration/test_api.py
+++ b/mula/tests/integration/test_api.py
@@ -7,10 +7,10 @@ from unittest import mock
 from urllib.parse import quote
 
 from fastapi.testclient import TestClient
-
 from scheduler import config, models, server, storage, utils
 from scheduler.server import schemas
 from scheduler.storage import stores
+
 from tests.factories import OrganisationFactory
 from tests.mocks import queue as mock_queue
 from tests.mocks import scheduler as mock_scheduler


### PR DESCRIPTION
### Changes

Add organisation queryparam for schedules endpoint

### QA notes

- start kat, make sure some schedules are created in 2 different orgs (either from reporting, or regular scanning)
- `curl http://scheduler:8004/schedules` - should list all schedules
- `curl http://scheduler:8004/schedules?organisation=org1` - should list schedules from org1
---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
