### PR TITLE
Fix broken image link in README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ OpenKAT aims to monitor, record and analyze the status of information systems. T
 
 OpenKAT scans, collects, analyzes and reports in an ongoing process:
 
-.. image:: docs/source/introduction/img/flowopenkat.png
+.. image:: docs/source/basics/img/flowopenkat.png
   :alt: flow of OpenKAT
 
 OpenKAT scans networks, finds vulnerabilities and creates accessible reports. It integrates the most widely used network tools and scanning software into a modular framework, accesses external databases such as shodan, and combines the information from all these sources into clear reports. It also includes lots of cat hair.


### PR DESCRIPTION
### Changes

The flow image linked to from the project README no longer lives at `docs/source/introduction/img/flowopenkat.png`.

This MR changes the link to the new URL.

### Demo

| Before | After |
| --- | -- |
| ![image](https://github.com/user-attachments/assets/3014ee86-a2f1-4756-a945-650ca11f4da1) | ![image](https://github.com/user-attachments/assets/63f8e29f-d080-44a0-afb7-1b9089d26786) |

### QA notes

The change can be seen working by comparing the `main` branch with the `fixe/README-image-link` branch.

Live demo: https://github.com/potherca-contrib/nl-kat-coordination/tree/fixe/README-image-link

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made. 
  - Not sure how/what to unit test for. URL Checker might be wanted? :shrug: 
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
