### PR TITLE
Fix exceptions and permission checks in katalogus client

### DIFF
--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-05-07 14:35+0000\n"
+"POT-Creation-Date: 2025-05-13 14:08+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -740,6 +740,42 @@ msgstr ""
 
 #: katalogus/client.py
 msgid "Boefje with this ID already exists."
+msgstr ""
+
+#: katalogus/client.py
+msgid "Access to resource not allowed"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to see plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to set plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to delete plugin settings"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to access the other organization"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to enable plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to disable plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to create plugins"
+msgstr ""
+
+#: katalogus/client.py
+msgid "User is not allowed to edit plugins"
 msgstr ""
 
 #: katalogus/forms/katalogus_filter.py


### PR DESCRIPTION
### Changes

Fix for checking permissions on clone katalogus settings. It would always raise a `KATalogusNotAllowedError` for superusers because of a logic error. It also did not check whether the user has permissions to set katalogus settings in the destination organization. I also removed unnecessary checks if the user is superuser. Superusers always have all permissions, so it is not necessary to check if user has permissions or is superuser, `has_perm` will always return `True` for superusers.

Fix for `KATalogusNotAllowedError` calling `_()` on a dynamic string. This doesn't work because those strings aren't made available for translation and results in that the exception itself fails with
```
katalogus.client.KATalogusNotAllowedError: <exception str() failed>
```

### QA notes

- Check if you can clone settings as superuser
- Check if you get a proper error message if you don't have permissions to clone settings

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
