### PR TITLE
Fix findings history in findings report

### DIFF
--- a/rocky/reports/report_types/findings_report/report.py
+++ b/rocky/reports/report_types/findings_report/report.py
@@ -65,12 +65,10 @@ class FindingsReport(Report):
             total_by_severity[severity] += 1
 
             if finding.reference not in history_cache:
-                history_cache[finding.reference] = self.octopoes_api_connector.get_history(reference=reference)
+                history_cache[finding.reference] = self.octopoes_api_connector.get_history(finding.reference)
 
-            time_history = [transaction.valid_time for transaction in history_cache[finding.reference]]
-
-            if time_history:
-                first_seen = str(time_history[0])
+            if history_cache[finding.reference]:
+                first_seen = str(history_cache[finding.reference][0].valid_time)
             else:
                 first_seen = "-"
 

--- a/rocky/reports/report_types/vulnerability_report/report.py
+++ b/rocky/reports/report_types/vulnerability_report/report.py
@@ -49,7 +49,6 @@ class VulnerabilityReport(Report):
                 total_findings = sum(occurrences.values())
                 terms = list(occurrences)
                 recommendations = []
-                first_seen = ""
 
                 # remove duplicate findings and finding types
                 finding_types = list(set(findings_data["finding_types"]))
@@ -62,15 +61,15 @@ class VulnerabilityReport(Report):
                         if finding.finding_type.tokenized.id != finding_type.id:
                             continue
 
-                        if finding.primary_key not in history_cache:
+                        if finding.reference not in history_cache:
                             history_cache[finding.reference] = self.octopoes_api_connector.get_history(
                                 finding.reference
                             )
 
-                        time_history = [transaction.valid_time for transaction in history_cache[finding.reference]]
-
-                        if time_history:
-                            first_seen = str(time_history[0])
+                        if history_cache[finding.reference]:
+                            first_seen = str(history_cache[finding.reference][0].valid_time)
+                        else:
+                            first_seen = ""
 
                         if finding.reference not in origin_cache:
                             origin_cache[finding.reference] = self.octopoes_api_connector.list_origins(


### PR DESCRIPTION
### Changes

The findings report called get_history with the reference of the input OOI instead of the finding reference.

The vulnerability report used finding.reference and finding.primary_key for the history cache. While this is not a problem because they compare equal, I've changed it to finding.reference so the code is more clear.

The vulnerability report would use the first_seen of a previous finding if there was no history. Although I also don't understand how this could happen, because as far as I understand it an object can't exist without a transaction that creates it.

I also removed the unnecessary creation of the time_history object which is a minor optimization.

### QA notes

Check the first seen of the findings in the vulnerability and findings reports.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
