### PR TITLE
Remove can_access_all_organizations User property and use has_perm()

### DIFF
--- a/rocky/account/models.py
+++ b/rocky/account/models.py
@@ -105,10 +105,6 @@ class KATUser(AbstractBaseUser, PermissionsMixin):
         """
         return self.members.select_related("organization")
 
-    @property
-    def can_access_all_organizations(self) -> bool:
-        return self.has_perm("tools.can_access_all_organizations")
-
     @cached_property
     def organizations(self) -> list[Organization]:
         """

--- a/rocky/rocky/views/tasks.py
+++ b/rocky/rocky/views/tasks.py
@@ -124,7 +124,7 @@ class AllTaskListView(SchedulerListView, PageActionsView):
         return [org.code for org in self.request.user.organizations]
 
     def get_organization_filter(self) -> dict[str, dict[str, list[dict[str, str | list[str]]]]]:
-        if self.request.user.can_access_all_organizations:
+        if self.request.user.has_perm("tools.can_access_all_organizations"):
             # We don't need to add a filter if the user can access all organizations
             return {}
 
@@ -152,7 +152,7 @@ class AllTaskListView(SchedulerListView, PageActionsView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["task_filter_form"] = self.task_filter_form(self.request.GET)
-        if self.request.user.can_access_all_organizations:
+        if self.request.user.has_perm("tools.can_access_all_organizations"):
             context["stats"] = self.client.get_task_stats_for_all_organizations(self.task_type)
         else:
             context["stats"] = self.client.get_combined_schedulers_stats(self.task_type, self.get_user_organizations())


### PR DESCRIPTION
### Changes

As discussed we will do permissions checks using `has_perm()` and not with a property. I've removed the property can_access_all_organizations and changed the check to `has_perm()`.

### Issue link

Closes #4462 

### QA notes

Test if the all organization task list still works because that is the only place this was used.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
