### PR TITLE
Stop hardcoding internet

### DIFF
--- a/octopoes/bits/oois_in_headers/oois_in_headers.py
+++ b/octopoes/bits/oois_in_headers/oois_in_headers.py
@@ -37,7 +37,7 @@ def remove_ignored_params(url: str, ignored_params: list[str]) -> str:
 
 
 def run(input_ooi: HTTPHeader, additional_oois: list, config: dict[str, Any]) -> Iterator[OOI]:
-    network = Network(name="internet")
+    network = Network(name=input_ooi.reference.tokenized.resource.web_url.netloc.network.name)
 
     if input_ooi.key.lower() == "location":
         ignored_url_params = get_ignored_url_params(config, "ignored_url_parameters", [])

--- a/octopoes/tests/test_bits.py
+++ b/octopoes/tests/test_bits.py
@@ -7,7 +7,11 @@ from octopoes.models.ooi.web import URL, HTTPHeader, HTTPHeaderURL, Website
 
 
 def test_url_extracted_by_oois_in_headers_url():
-    header = HTTPHeader(resource="resource|url", key="Location", value="https://www.example.com/")
+    header = HTTPHeader(
+        resource="resource|internet|ip|protocol|port|protocol|internet|hostname|protocol|internet|hostname|port|location",
+        key="Location",
+        value="https://www.example.com/",
+    )
 
     results = list(run_oois_in_headers(header, [], {}))
 


### PR DESCRIPTION
### Changes
For `/octopoes/bits/oois_in_headers/oois_in_headers.py`:
```
 def run(input_ooi: HTTPHeader, additional_oois: list, config: dict[str, Any]) -> Iterator[OOI]:
-    network = Network(name="internet")
+    network = Network(name=input_ooi.reference.tokenized.resource.web_url.netloc.network.name)

     if input_ooi.key.lower() == "location":
         ignored_url_params = get_ignored_url_params(config, "ignored_url_parameters", [])
```

With special thanks to @noamblitz!

### Issue link

N/A

### Demo

N/A

### QA notes

We always do everything on "internet", but we shouldn't; that is why this one was never found.
Hence probably not necessary to test for normal usage.

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
