### PR TITLE
Add organisation queryparameter for tasks endpoint in scheduler

### DIFF
--- a/mula/scheduler/server/handlers/tasks.py
+++ b/mula/scheduler/server/handlers/tasks.py
@@ -56,6 +56,7 @@ class TaskAPI:
         self,
         request: fastapi.Request,
         scheduler_id: str | None = None,
+        organisation: str | None = None,
         task_type: str | None = None,
         status: str | None = None,
         offset: int = 0,
@@ -69,6 +70,7 @@ class TaskAPI:
 
         results, count = self.ctx.datastores.task_store.get_tasks(
             scheduler_id=scheduler_id,
+            organisation=organisation,
             task_type=task_type,
             status=status,
             offset=offset,

--- a/mula/scheduler/storage/stores/task.py
+++ b/mula/scheduler/storage/stores/task.py
@@ -20,6 +20,7 @@ class TaskStore:
     def get_tasks(
         self,
         scheduler_id: str | None = None,
+        organisation: str | None = None,
         task_type: str | None = None,
         status: str | None = None,
         min_created_at: datetime | None = None,
@@ -33,6 +34,9 @@ class TaskStore:
 
             if scheduler_id is not None:
                 query = query.filter(models.TaskDB.scheduler_id == scheduler_id)
+
+            if organisation is not None:
+                query = query.filter(models.TaskDB.organisation == organisation)
 
             if task_type is not None:
                 query = query.filter(models.TaskDB.type == task_type)


### PR DESCRIPTION
### Changes

Add organisation queryparameter for tasks endpoint in scheduler

### QA notes

1. Create 2 orgs
2. Do some scan in both orgs
3. `curl 'http://localhost:8004/tasks?scheduler_id=boefje&organisation={your-org-id}'`
4. This should only list boefje tasks for that organisation

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
