### PR TITLE
Funny "bug" with the limit/offset parameters

### DIFF
--- a/octopoes/octopoes/core/service.py
+++ b/octopoes/octopoes/core/service.py
@@ -127,8 +127,8 @@ class OctopoesService:
         self,
         types: set[type[OOI]],
         valid_time: datetime,
-        limit: int = DEFAULT_LIMIT,
         offset: int = DEFAULT_OFFSET,
+        limit: int = DEFAULT_LIMIT,
         scan_levels: set[ScanLevel] = DEFAULT_SCAN_LEVEL_FILTER,
         scan_profile_types: set[ScanProfileType] = DEFAULT_SCAN_PROFILE_TYPE_FILTER,
         search_string: str | None = None,
@@ -136,7 +136,7 @@ class OctopoesService:
         asc_desc: Literal["asc", "desc"] = "asc",
     ) -> Paginated[OOI]:
         paginated = self.ooi_repository.list_oois(
-            types, valid_time, limit, offset, scan_levels, scan_profile_types, search_string, order_by, asc_desc
+            types, valid_time, offset, limit, scan_levels, scan_profile_types, search_string, order_by, asc_desc
         )
         self._populate_scan_profiles(paginated.items, valid_time)
         return paginated


### PR DESCRIPTION
### Changes

I discovered that we didn't use the offset/limit arguments the right way in the list_ooi function, but couldn't grasp why the system worked in the first place. It turns out the arguments were swapped already one call before..

### Issue link
-

### Demo

-

### QA notes

Please verify that the object list still works!

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
