### PR TITLE
Build the RDO packages for Python 3.11 only (1.19)

### DIFF
--- a/.github/workflows/build-rdo-package.yml
+++ b/.github/workflows/build-rdo-package.yml
@@ -21,7 +21,7 @@ jobs:
       packages: write
     strategy:
       matrix:
-        python_version: ["3.10", "3.11"]
+        python_version: ["3.11"]
 
     # Generic bits
     steps:


### PR DESCRIPTION
Backport of #4600 to release 1.19