### PR TITLE
Add `close_old_connections` calls before running a job

### DIFF
--- a/rocky/reports/runner/worker.py
+++ b/rocky/reports/runner/worker.py
@@ -9,6 +9,7 @@ from queue import Queue
 
 import structlog
 from django.conf import settings
+from django.db import close_old_connections
 from httpx import HTTPError
 
 from reports.runner.models import ReportRunner, WorkerManager
@@ -205,6 +206,7 @@ def _start_working(
 
     while True:
         p_item = task_queue.get()
+        close_old_connections()  # See https://github.com/minvws/nl-kat-coordination/issues/4632
         status = TaskStatus.FAILED
         handling_tasks[os.getpid()] = str(p_item.id)
 


### PR DESCRIPTION
### Changes

Close old connections in the rocky worker.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4632

### Demo

-

### QA notes

This cannot be QA'd without a HAProxy setup..

---

### Code Checklist


- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
