### PR TITLE
Hide more settings and env variables in debug mode

### DIFF
--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -19,6 +19,7 @@ from csp.constants import NONE, SELF
 from django.conf import locale
 from django.core.exceptions import ImproperlyConfigured
 from django.utils.translation import gettext_lazy as _
+from django.views.debug import SafeExceptionReporterFilter
 
 from rocky.otel import OpenTelemetryHelper
 
@@ -44,6 +45,11 @@ KATALOGUS_API = env.url("KATALOGUS_API").geturl()
 BYTES_API = env.url("BYTES_API").geturl()
 BYTES_USERNAME = env("BYTES_USERNAME")
 BYTES_PASSWORD = env("BYTES_PASSWORD")
+
+# See these Django release notes: https://docs.djangoproject.com/en/dev/releases/3.1/#error-reporting
+HIDDEN_DEFAULT = "API|TOKEN|KEY|SECRET|PASS|SIGNATURE|HTTP_COOKIE"
+HIDDEN_ADDITIONAL = "ROCKY|BOEFJES|BYTES|MULA|SCHEDULER|OCTOPOES|RABBITMQ_|_URI"
+SafeExceptionReporterFilter.hidden_settings = re.compile(f"{HIDDEN_DEFAULT}|{HIDDEN_ADDITIONAL}", flags=re.I)
 
 ROCKY_REPORT_PERMALINKS = env.bool("ROCKY_REPORT_PERMALINKS", True)
 


### PR DESCRIPTION
### Changes

This hides more settings and env variables in debug mode though overriding the hidden_settings regex in the `settings.py`.

### Issue link

Closes https://github.com/minvws/nl-kat-coordination/issues/4643

### Demo

Before:
![Scherm­afbeelding 2025-07-08 om 13 36 22](https://github.com/user-attachments/assets/06990e71-f28b-4fdf-b9b3-be3bd7049209)

After:
![Scherm­afbeelding 2025-07-08 om 13 35 47](https://github.com/user-attachments/assets/536ff76f-2050-45af-abd0-1d63c5b85d0a)


### QA notes

- Checkout main
- Create an organization (for this example "test")
- Navigate to a broken url such as [this one](http://localhost:8000/nl/test/objects/detail/?observed_at=2025-07-07T19%3A23%3A2%2B00%3A00&ooi_id=SowareInstance%7CHostnameHTTPURL%7Chttps%7Cinternet%7Cwww.wpbeginner.com%7C443%7C%2F%7CSoftware%7CWordPress%7C%7Ccpe%3A2.3%3Aa%3Awordpress%3Awordpress%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A) where the META and settings are shown.
- See your passwords in e.g. the BYTES_URI settings
- Checkout this PR
- Go to the [broken url](http://localhost:8000/nl/test/objects/detail/?observed_at=2025-07-07T19%3A23%3A2%2B00%3A00&ooi_id=SowareInstance%7CHostnameHTTPURL%7Chttps%7Cinternet%7Cwww.wpbeginner.com%7C443%7C%2F%7CSoftware%7CWordPress%7C%7Ccpe%3A2.3%3Aa%3Awordpress%3Awordpress%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A%3A%2A) again
- See that everything is hidden

Since we should not and typically do not use this debug feature, I decided to just hide everything related to our services until we find the need to show them in the debug page, which is probably highly unlikely.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
