### PR TITLE
Hotfix crisis room for all organizations

### DIFF
--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -121,11 +121,6 @@ class DashboardService:
         if recipes_data:
             # Returns for each recipe id, its Hydrated report.
             reports: dict[UUID, HydratedReport] = self.get_reports(datetime.now(timezone.utc), report_filters)
-            octopoes_client = OctopoesAPIConnector(
-                settings.OCTOPOES_API,
-                dashboard_item.dashboard.organization.code,
-                timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT,
-            )
 
             # After reports are collected, collect data raw ids to fetch data from Bytes later.
             for dashboard_item, recipe_id in recipes_data.items():
@@ -135,6 +130,11 @@ class DashboardService:
                     ):  # Report section from aggregate report
                         hydrated_report = reports[recipe_id]
                     else:  # Report section from a normal report
+                        octopoes_client = OctopoesAPIConnector(
+                            settings.OCTOPOES_API,
+                            dashboard_item.dashboard.organization.code,
+                            timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT,
+                        )
                         hydrated_report = octopoes_client.get(
                             Reference.from_str(dashboard_item.source), datetime.now(timezone.utc)
                         )
@@ -149,6 +149,11 @@ class DashboardService:
             # Finally merge all data necessary and create dashboard items to show on the dashboard.
             for dashboard_item, hydrated_report in reports_data.items():
                 item_data = DashboardItemView(dashboard_item, {"report": hydrated_report})
+                octopoes_client = OctopoesAPIConnector(
+                    settings.OCTOPOES_API,
+                    dashboard_item.dashboard.organization.code,
+                    timeout=settings.ROCKY_OUTGOING_REQUEST_TIMEOUT,
+                )
 
                 try:
                     report_data = report_data_from_bytes[hydrated_report.data_raw_id]


### PR DESCRIPTION
### Changes
This PR fixes the Crisis Room for all organizations, which couldn't be opened with >1 organization.
OctopoesAPIConnector wasn't positioned correctly. 

### QA notes
Make sure you have at least 2 organizations.
- Check if you can open the general crisis room (for all organizations)
- Check if you can still open the crisis room for a single organization

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
