### PR TITLE
Fix onboarding header

### DIFF
--- a/rocky/onboarding/templates/partials/onboarding_header.html
+++ b/rocky/onboarding/templates/partials/onboarding_header.html
@@ -1,0 +1,5 @@
+{% load i18n %}
+{% load static %}
+
+<h1>{% translate "Onboarding" %}</h1>
+{% include "partials/stepper.html" %}

--- a/rocky/onboarding/templates/step_10_report.html
+++ b/rocky/onboarding/templates/step_10_report.html
@@ -10,8 +10,7 @@
     <main id="main-content">
         <section>
             <div>
-                <h1>{% translate "OpenKAT introduction" %}</h1>
-                {% include "partials/stepper.html" %}
+                {% include "partials/onboarding_header" %}
 
                 <h2>{% translate "Report" %}</h2>
                 <h3>{% translate "Boefjes are scanning" %}</h3>

--- a/rocky/onboarding/templates/step_10_report.html
+++ b/rocky/onboarding/templates/step_10_report.html
@@ -10,7 +10,7 @@
     <main id="main-content">
         <section>
             <div>
-                {% include "partials/onboarding_header" %}
+                {% include "partials/onboarding_header.html" %}
 
                 <h2>{% translate "Report" %}</h2>
                 <h3>{% translate "Boefjes are scanning" %}</h3>

--- a/rocky/onboarding/templates/step_1_introduction_registration.html
+++ b/rocky/onboarding/templates/step_1_introduction_registration.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Welcome to OpenKAT!" %}</h2>

--- a/rocky/onboarding/templates/step_1_introduction_registration.html
+++ b/rocky/onboarding/templates/step_1_introduction_registration.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Welcome to OpenKAT!" %}</h2>

--- a/rocky/onboarding/templates/step_1a_introduction.html
+++ b/rocky/onboarding/templates/step_1a_introduction.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Welcome to OpenKAT!" %}</h2>

--- a/rocky/onboarding/templates/step_1a_introduction.html
+++ b/rocky/onboarding/templates/step_1a_introduction.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Welcome to OpenKAT!" %}</h2>

--- a/rocky/onboarding/templates/step_2a_organization_setup.html
+++ b/rocky/onboarding/templates/step_2a_organization_setup.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Organization setup" %}</h2>

--- a/rocky/onboarding/templates/step_2a_organization_setup.html
+++ b/rocky/onboarding/templates/step_2a_organization_setup.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Organization setup" %}</h2>

--- a/rocky/onboarding/templates/step_2b_organization_update.html
+++ b/rocky/onboarding/templates/step_2b_organization_update.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Organization setup" %}</h2>

--- a/rocky/onboarding/templates/step_2b_organization_update.html
+++ b/rocky/onboarding/templates/step_2b_organization_update.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Organization setup" %}</h2>

--- a/rocky/onboarding/templates/step_3_indemnification_setup.html
+++ b/rocky/onboarding/templates/step_3_indemnification_setup.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Indemnification setup" %}</h2>

--- a/rocky/onboarding/templates/step_3_indemnification_setup.html
+++ b/rocky/onboarding/templates/step_3_indemnification_setup.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Indemnification setup" %}</h2>

--- a/rocky/onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+++ b/rocky/onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboardingn" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "User clearance level" %}</h2>

--- a/rocky/onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
+++ b/rocky/onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "User clearance level" %}</h2>

--- a/rocky/onboarding/templates/step_5_add_scan_ooi.html
+++ b/rocky/onboarding/templates/step_5_add_scan_ooi.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Add an object" %}</h2>

--- a/rocky/onboarding/templates/step_5_add_scan_ooi.html
+++ b/rocky/onboarding/templates/step_5_add_scan_ooi.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Add an object" %}</h2>

--- a/rocky/onboarding/templates/step_6_set_clearance_level.html
+++ b/rocky/onboarding/templates/step_6_set_clearance_level.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Set object clearance level" %}</h2>

--- a/rocky/onboarding/templates/step_6_set_clearance_level.html
+++ b/rocky/onboarding/templates/step_6_set_clearance_level.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Set object clearance level" %}</h2>

--- a/rocky/onboarding/templates/step_7_clearance_level_introduction.html
+++ b/rocky/onboarding/templates/step_7_clearance_level_introduction.html
@@ -8,7 +8,7 @@
 
     <main id="main-content" class="explanation-page">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Plugin introduction" %}</h2>

--- a/rocky/onboarding/templates/step_7_clearance_level_introduction.html
+++ b/rocky/onboarding/templates/step_7_clearance_level_introduction.html
@@ -8,8 +8,7 @@
 
     <main id="main-content" class="explanation-page">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Plugin introduction" %}</h2>

--- a/rocky/onboarding/templates/step_8_setup_scan_select_plugins.html
+++ b/rocky/onboarding/templates/step_8_setup_scan_select_plugins.html
@@ -9,8 +9,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Enabling plugins and start scanning" %}</h2>

--- a/rocky/onboarding/templates/step_8_setup_scan_select_plugins.html
+++ b/rocky/onboarding/templates/step_8_setup_scan_select_plugins.html
@@ -9,7 +9,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Enabling plugins and start scanning" %}</h2>

--- a/rocky/onboarding/templates/step_9_choose_report_type.html
+++ b/rocky/onboarding/templates/step_9_choose_report_type.html
@@ -8,8 +8,7 @@
 
     <main id="main-content">
         <section>
-            <h1>{% translate "Onboarding" %}</h1>
-            {% include "partials/stepper.html" %}
+            {% include "partials/onboarding_header" %}
 
             <div>
                 <h2>{% translate "Generate a report" %}</h2>

--- a/rocky/onboarding/templates/step_9_choose_report_type.html
+++ b/rocky/onboarding/templates/step_9_choose_report_type.html
@@ -8,7 +8,7 @@
 
     <main id="main-content">
         <section>
-            {% include "partials/onboarding_header" %}
+            {% include "partials/onboarding_header.html" %}
 
             <div>
                 <h2>{% translate "Generate a report" %}</h2>

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-07-16 11:12+0000\n"
+"POT-Creation-Date: 2025-07-17 08:12+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -2196,8 +2196,8 @@ msgstr ""
 msgid "Please enter a valid URL starting with 'http://' or 'https://'."
 msgstr ""
 
-#: onboarding/templates/step_10_report.html
-msgid "OpenKAT introduction"
+#: onboarding/templates/partials/onboarding_header.html
+msgid "Onboarding"
 msgstr ""
 
 #: onboarding/templates/step_10_report.html
@@ -2223,19 +2223,6 @@ msgstr ""
 
 #: onboarding/templates/step_10_report.html
 msgid "Continue to OpenKAT"
-msgstr ""
-
-#: onboarding/templates/step_1_introduction_registration.html
-#: onboarding/templates/step_1a_introduction.html
-#: onboarding/templates/step_2a_organization_setup.html
-#: onboarding/templates/step_2b_organization_update.html
-#: onboarding/templates/step_3_indemnification_setup.html
-#: onboarding/templates/step_5_add_scan_ooi.html
-#: onboarding/templates/step_6_set_clearance_level.html
-#: onboarding/templates/step_7_clearance_level_introduction.html
-#: onboarding/templates/step_8_setup_scan_select_plugins.html
-#: onboarding/templates/step_9_choose_report_type.html
-msgid "Onboarding"
 msgstr ""
 
 #: onboarding/templates/step_1_introduction_registration.html
@@ -2309,10 +2296,6 @@ msgstr ""
 
 #: onboarding/templates/step_3_indemnification_setup.html
 msgid "Indemnification on the organization is already present."
-msgstr ""
-
-#: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html
-msgid "Onboardingn"
 msgstr ""
 
 #: onboarding/templates/step_4_trusted_acknowledge_clearance_level.html


### PR DESCRIPTION
### Changes
Fixes the onboarding header. Used to say "Onboardingn" in step 2.

### Issue link
Closes ...

### Demo
<img width="1141" height="692" alt="afbeelding" src="https://github.com/user-attachments/assets/d1251f51-0e94-40ea-b23d-80c442caec05" />


### QA notes
Walk through the onboarding and check if the headers are correct.
---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made. **N/A**
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
