### PR TITLE
Update build-rdo-package.yml

### DIFF
--- a/.github/workflows/build-rdo-package.yml
+++ b/.github/workflows/build-rdo-package.yml
@@ -15,7 +15,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: write
       packages: write


### PR DESCRIPTION
Revert change to run packaging workflow on ubuntu 24, due to target being debian 12, and ubuntu 24 having a too new glibc version.
