### PR TITLE
Fix save raw call

### DIFF
--- a/boefjes/boefjes/job_handler.py
+++ b/boefjes/boefjes/job_handler.py
@@ -65,7 +65,7 @@ class DockerBoefjeHandler(BoefjeHandler):
             if task.status == TaskStatus.RUNNING:
                 boefje_meta.ended_at = datetime.now(timezone.utc)
                 self.bytes_api_client.save_boefje_meta(boefje_meta)  # The task didn't create a boefje_meta object
-                self.bytes_api_client.save_raws(task_id, container_logs, stderr_mime_types.union({"error/boefje"}))
+                self.bytes_api_client.save_raw(task_id, container_logs, stderr_mime_types.union({"error/boefje"}))
                 self.scheduler_client.patch_task(task_id, TaskStatus.FAILED)
 
                 # have to raise exception to prevent _start_working function from setting status to completed


### PR DESCRIPTION
### Changes

Fixes the following exception:

```
[2025-07-21 15:50:09 +0200] [1537] [ERROR] [manager] 2025-07-21T15:50:09.153092 [error] An error occurred handling scheduler item task=>
Traceback (most recent call last):
  File "/opt/venvs/kat-boefjes/lib/python3.11/site-packages/boefjes/worker/manager.py", line 242, in _start_working
    out = handler.handle(p_item)
          ^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/venvs/kat-boefjes/lib/python3.11/site-packages/boefjes/job_handler.py", line 68, in handle
    self.bytes_api_client.save_raws(task_id, container_logs, stderr_mime_types.union({"error/boefje"}))
  File "/opt/venvs/kat-boefjes/lib/python3.11/site-packages/boefjes/clients/bytes_client.py", line 25, in wrapper
    return function(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: BytesAPIClient.save_raws() takes 3 positional arguments but 4 were given
```

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
