### PR TITLE
Only run sslscan on https

### DIFF
--- a/boefjes/boefjes/plugins/kat_ssl_scan/main.py
+++ b/boefjes/boefjes/plugins/kat_ssl_scan/main.py
@@ -5,6 +5,10 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
     input_ = boefje_meta["arguments"]["input"]
     hostname = input_["hostname"]["name"]
 
+    scheme = input_["ip_service"]["service"]["name"]
+    if scheme != "https":
+        return [({"info/boefje"}, "Skipping check due to non-TLS scheme")]
+
     output = subprocess.run(["/usr/bin/sslscan", "--xml=-", hostname], capture_output=True)
     output.check_returncode()
 


### PR DESCRIPTION
### Changes

We should only run sslscan on https Website objects instead of all Website objects. This check is the same as we already do in the ssl certificates boefje.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
