### PR TITLE
Do not compress graph js

### DIFF
--- a/rocky/rocky/templates/graph-d3.html
+++ b/rocky/rocky/templates/graph-d3.html
@@ -37,8 +37,8 @@
     {% compress js %}
         <script src="{% static "js/stringHelpers.js" %}" nonce="{{ request.csp_nonce }}"></script>
         <script src="{% static "js/checkboxToggler.js" %}" nonce="{{ request.csp_nonce }}"></script>
-        <script src="{% static "dist/imports/graph.js" %}" nonce="{{ request.csp_nonce }}"></script>
     {% endcompress %}
+    <script src="{% static "dist/imports/graph.js" %}" nonce="{{ request.csp_nonce }}"></script>
     {% compress css %}
         <link href="{% static "dist/imports/graph.css" %}" rel="stylesheet">
     {% endcompress %}


### PR DESCRIPTION
### Changes

Do not compress graph.js because this doesn't work. The graph.js is also already compressed so this also isn't useful.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
