### PR TITLE
Disable concatenated report if asset reports are disabled

### DIFF
--- a/rocky/reports/templates/partials/new_report_action_button.html
+++ b/rocky/reports/templates/partials/new_report_action_button.html
@@ -14,10 +14,12 @@
          class="dropdown-list"
          aria-labelledby="add-item-dropdown-button">
         <ul>
-            {% url "generate_report_landing" organization.code as index_url_generate_report %}
-            <li {% if index_url_generate_report in request.path|urlencode %}aria-current="page"{% endif %}>
-                <a href="{{ index_url_generate_report }}?{{ request.GET.urlencode }}">{% translate "Separate report(s)" %}</a>
-            </li>
+            {% if asset_reports_enabled %}
+                {% url "generate_report_landing" organization.code as index_url_generate_report %}
+                <li {% if index_url_generate_report in request.path|urlencode %}aria-current="page"{% endif %}>
+                    <a href="{{ index_url_generate_report }}?{{ request.GET.urlencode }}">{% translate "Separate report(s)" %}</a>
+                </li>
+            {% endif %}
             {% url "aggregate_report_landing" organization.code as index_url_aggregate_report %}
             <li {% if index_url_aggregate_report in request.path|urlencode %}aria-current="page"{% endif %}>
                 <a href="{{ index_url_aggregate_report }}?{{ request.GET.urlencode }}">{% translate "Aggregate report" %}</a>

--- a/rocky/reports/views/report_overview.py
+++ b/rocky/reports/views/report_overview.py
@@ -4,6 +4,7 @@ from uuid import UUID
 
 import structlog
 from account.mixins import OrganizationPermissionRequiredMixin
+from django.conf import settings
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import redirect
@@ -134,6 +135,7 @@ class ScheduledReportsView(BreadcrumbsReportOverviewView, SchedulerView, ListVie
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["total_report_schedules"] = len(self.object_list)
+        context["asset_reports_enabled"] = settings.ASSET_REPORTS
         return context
 
 
@@ -336,6 +338,7 @@ class ReportHistoryView(BreadcrumbsReportOverviewView, SchedulerView, OctopoesVi
         context = super().get_context_data(**kwargs)
         context["total_reports"] = len(self.object_list)
         context["selected_reports"] = self.request.GET.getlist("report", [])
+        context["asset_reports_enabled"] = settings.ASSET_REPORTS
         return context
 
 


### PR DESCRIPTION
### Changes

Concatenated report are saved as individual asset reports so they don't work if asset reports are disabled. This disabled the menu option if ASSET_REPORTS is set to False.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
