### PR TITLE
Do not create finding if sslscan doesn't return any protocol

### DIFF
--- a/boefjes/boefjes/plugins/kat_ssl_scan/normalize.py
+++ b/boefjes/boefjes/plugins/kat_ssl_scan/normalize.py
@@ -19,6 +19,12 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
 
         protocols.append((type_, version, enabled))
 
+    if not any(protocol[2] for protocol in protocols):
+        # No protocol is enabled. This might happen if we send a hostname that
+        # is not configured for TLS. We shouldn't create a false positive
+        # finding for this.
+        return
+
     if ("ssl", "2", True) in protocols:
         kft = KATFindingType(id="KAT-SSL-2-SUPPORT")
         yield kft


### PR DESCRIPTION
### Changes

If no TLS configured for a hostname then sslscan might return no protocols at all. We shouldn't create a false positive finding in this case.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
