### PR TITLE
remove url input for nuclei_cve scan

### DIFF
--- a/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.json
+++ b/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.json
@@ -3,8 +3,7 @@
   "name": "Nuclei CVE scan",
   "description": "Nuclei is used to send requests across targets based on a template, providing fast scanning. (CVE scanning).",
   "consumes": [
-    "Hostname",
-    "HostnameHTTPURL"
+    "Hostname"
   ],
   "scan_level": 3,
   "oci_image": "ghcr.io/minvws/openkat/nuclei:latest",


### PR DESCRIPTION
hostnames give the same results, as nuclei already does a deeper scan for various urls.

### Changes

This removes the url as input for nuclei cve scanner, as it would mean double requests if various urls are known for the same host/website.

### Issue link

Found by Stichting Surf.

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
