### PR TITLE
Fix for SSL plugins

### DIFF
--- a/boefjes/boefjes/plugins/kat_dnssec/normalize.py
+++ b/boefjes/boefjes/plugins/kat_dnssec/normalize.py
@@ -10,11 +10,12 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
 
     ooi_ref = Reference.from_str(input_ooi["primary_key"])
 
-    # We are looking for the last line that isn't a comment (doesn't start with
-    # ";"), so we reverse the output lines before looping over them.
+    # Find the last status line (not just the last non-comment line)
     for result_line in reversed(result.splitlines()):
-        if not result_line.startswith(";"):
+        if result_line.startswith(("[U]", "[S]", "[B]", "[T]")):
             break
+    else:
+        raise ValueError("No status line found in drill output")
 
     # [S] self sig OK; [B] bogus; [T] trusted; [U] unsigned
     if result_line.startswith("[U]"):
@@ -38,5 +39,3 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
         )
         yield ft
         yield finding
-    elif not result_line.startswith("[T]"):
-        raise ValueError(f"Could not parse drill output: {result_line}")

--- a/boefjes/boefjes/plugins/kat_ssl_scan/normalizer.json
+++ b/boefjes/boefjes/plugins/kat_ssl_scan/normalizer.json
@@ -3,7 +3,6 @@
   "name": "SSL scan",
   "description": "Parses SSL scan version data into findings.",
   "consumes": [
-    "boefje/ssl-version",
     "openkat/ssl-scan-output"
   ],
   "produces": [

--- a/boefjes/boefjes/plugins/kat_testssl_sh_ciphers/normalizer.json
+++ b/boefjes/boefjes/plugins/kat_testssl_sh_ciphers/normalizer.json
@@ -3,7 +3,6 @@
   "name": "SSL test ciphers",
   "description": "Parses TestSSL data into TLS ciphers.",
   "consumes": [
-    "boefje/testssl-sh-ciphers",
     "openkat/testssl-sh-ciphers-output"
   ],
   "produces": [

--- a/boefjes/tests/examples/inputs/dnssec-status-line-not-last-line.txt
+++ b/boefjes/tests/examples/inputs/dnssec-status-line-not-last-line.txt
@@ -1,0 +1,42 @@
+;; Number of trusted keys: 2
+;; Domain: .
+[T] . 172800 IN DNSKEY 257 3 8 ;{id = 20326 (ksk), size = 2048b}
+. 172800 IN DNSKEY 257 3 8 ;{id = 38696 (ksk), size = 2048b}
+. 172800 IN DNSKEY 256 3 8 ;{id = 53148 (zsk), size = 2048b}
+. 172800 IN DNSKEY 256 3 8 ;{id = 46441 (zsk), size = 2048b}
+Checking if signing key is trusted:
+New key: .	172800	IN	DNSKEY	256 3 8 AwEAAbauxLSFZ+KSWi2cT6TJbm3d+GIVqb2N1XnDjMsRme0b6JlGp/cvwmM5CaJ5LQ7tG1r7LuTHjYZadtbNk2nZmclq9r4KInS48ungoAZb0gJXVw8IvBTBb1YWQmiBqD285pJuORwTii7DF++nNJJk3i55HJt9SmBI7m7t8nvx7OOY/w0inxg3fLH2uY0SKO8he4FGwMc4Ubiab8N8Yhyhh+FkKKdD/+oAcuGF75PjlSXO460B4MlNLlEcjDEzIsKauRYx4YVgSaNomGhMMFblmXRzgW+1R6ywvm5mC9+omlyyizZp2GJfPwGMezuKSGDndO6CYYEc5/lsRhvBYsGjdPM= ;{id = 46441 (zsk), size = 2048b}
+	Trusted key: .	3600	IN	DNSKEY	257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU= ;{id = 20326 (ksk), size = 2048b}
+	Trusted key: .	3600	IN	DNSKEY	257 3 8 AwEAAa96jeuknZlaeSrvyAJj6ZHv28hhOKkx3rLGXVaC6rXTsDc449/cidltpkyGwCJNnOAlFNKF2jBosZBU5eeHspaQWOmOElZsjICMQMC3aeHbGiShvZsx4wMYSjH8e7Vrhbu6irwCzVBApESjbUdpWWmEnhathWu1jo+siFUiRAAxm9qyJNg/wOZqqzL/dL/q8PkcRU5oUKEpUge71M3ej2/7CPqpdVwuMoTvoB+ZOT4YeGyxMvHmbrxlFzGOHOijtzN+u1TQNatX2XBuzZNQ1K+s2CXkPIZo7s6JgZyvaBevYtxPvYLw4z9mR7K2vaF18UYH9Z9GNUUeayffKC73PYc= ;{id = 38696 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU= ;{id = 20326 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	257 3 8 AwEAAa96jeuknZlaeSrvyAJj6ZHv28hhOKkx3rLGXVaC6rXTsDc449/cidltpkyGwCJNnOAlFNKF2jBosZBU5eeHspaQWOmOElZsjICMQMC3aeHbGiShvZsx4wMYSjH8e7Vrhbu6irwCzVBApESjbUdpWWmEnhathWu1jo+siFUiRAAxm9qyJNg/wOZqqzL/dL/q8PkcRU5oUKEpUge71M3ej2/7CPqpdVwuMoTvoB+ZOT4YeGyxMvHmbrxlFzGOHOijtzN+u1TQNatX2XBuzZNQ1K+s2CXkPIZo7s6JgZyvaBevYtxPvYLw4z9mR7K2vaF18UYH9Z9GNUUeayffKC73PYc= ;{id = 38696 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	256 3 8 AwEAAbEbGCpGTDrcZTWqWWE72nphyshpRcILdzCVlBGU9Ln1Fui9kkseUOP+g5GLUeVFKdTloeRTA9+EYiQdXgWXmXmuW/nGxZjAikluF/O9NzLVrr5iZnth2xu+F48nrJlAgWWiMNau54NI5sZ3iVQfhFsq2pZmf43RauRPniYMShOLO7EBWWXr5glDSgZGS9fSm6xHwwF+g8D4m8oanjvdCBNxXzSEKS31ibxjLifTfvwCg3y4XXcNW9U6Nu3JmoKUdxqpPPIkBvVQbIz4UO2FwaR13uXC03ALP1Yx2QNSS4SZlcIMtAftQR9wtCiuPWQnFv4jkzWqlhp1Lmf7bcoL9yk= ;{id = 53148 (zsk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	256 3 8 AwEAAbauxLSFZ+KSWi2cT6TJbm3d+GIVqb2N1XnDjMsRme0b6JlGp/cvwmM5CaJ5LQ7tG1r7LuTHjYZadtbNk2nZmclq9r4KInS48ungoAZb0gJXVw8IvBTBb1YWQmiBqD285pJuORwTii7DF++nNJJk3i55HJt9SmBI7m7t8nvx7OOY/w0inxg3fLH2uY0SKO8he4FGwMc4Ubiab8N8Yhyhh+FkKKdD/+oAcuGF75PjlSXO460B4MlNLlEcjDEzIsKauRYx4YVgSaNomGhMMFblmXRzgW+1R6ywvm5mC9+omlyyizZp2GJfPwGMezuKSGDndO6CYYEc5/lsRhvBYsGjdPM= ;{id = 46441 (zsk), size = 2048b}
+Key is now trusted!
+[T] nl. 86400 IN DS 17153 13 2 c5dfddc91e7532562a35f3c2cd30823894be08f20101f1abf45c8ab9739f3f49
+;; Domain: nl.
+[T] nl. 3600 IN DNSKEY 256 3 13 ;{id = 18814 (zsk), size = 256b}
+nl. 3600 IN DNSKEY 257 3 13 ;{id = 17153 (ksk), size = 256b}
+Checking if signing key is trusted:
+New key: nl.	3600	IN	DNSKEY	256 3 13 W+y1b3nqtYmENUIz2smIvZwX4199q/6I+fxP/Uz8IubzKsHLj1UmTYi8rhwV/c2p/BSCjl3DLsZNB6XJ9tqrNQ== ;{id = 18814 (zsk), size = 256b}
+	Trusted key: .	3600	IN	DNSKEY	257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU= ;{id = 20326 (ksk), size = 2048b}
+	Trusted key: .	3600	IN	DNSKEY	257 3 8 AwEAAa96jeuknZlaeSrvyAJj6ZHv28hhOKkx3rLGXVaC6rXTsDc449/cidltpkyGwCJNnOAlFNKF2jBosZBU5eeHspaQWOmOElZsjICMQMC3aeHbGiShvZsx4wMYSjH8e7Vrhbu6irwCzVBApESjbUdpWWmEnhathWu1jo+siFUiRAAxm9qyJNg/wOZqqzL/dL/q8PkcRU5oUKEpUge71M3ej2/7CPqpdVwuMoTvoB+ZOT4YeGyxMvHmbrxlFzGOHOijtzN+u1TQNatX2XBuzZNQ1K+s2CXkPIZo7s6JgZyvaBevYtxPvYLw4z9mR7K2vaF18UYH9Z9GNUUeayffKC73PYc= ;{id = 38696 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	257 3 8 AwEAAaz/tAm8yTn4Mfeh5eyI96WSVexTBAvkMgJzkKTOiW1vkIbzxeF3+/4RgWOq7HrxRixHlFlExOLAJr5emLvN7SWXgnLh4+B5xQlNVz8Og8kvArMtNROxVQuCaSnIDdD5LKyWbRd2n9WGe2R8PzgCmr3EgVLrjyBxWezF0jLHwVN8efS3rCj/EWgvIWgb9tarpVUDK/b58Da+sqqls3eNbuv7pr+eoZG+SrDK6nWeL3c6H5Apxz7LjVc1uTIdsIXxuOLYA4/ilBmSVIzuDWfdRUfhHdY6+cn8HFRm+2hM8AnXGXws9555KrUB5qihylGa8subX2Nn6UwNR1AkUTV74bU= ;{id = 20326 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	257 3 8 AwEAAa96jeuknZlaeSrvyAJj6ZHv28hhOKkx3rLGXVaC6rXTsDc449/cidltpkyGwCJNnOAlFNKF2jBosZBU5eeHspaQWOmOElZsjICMQMC3aeHbGiShvZsx4wMYSjH8e7Vrhbu6irwCzVBApESjbUdpWWmEnhathWu1jo+siFUiRAAxm9qyJNg/wOZqqzL/dL/q8PkcRU5oUKEpUge71M3ej2/7CPqpdVwuMoTvoB+ZOT4YeGyxMvHmbrxlFzGOHOijtzN+u1TQNatX2XBuzZNQ1K+s2CXkPIZo7s6JgZyvaBevYtxPvYLw4z9mR7K2vaF18UYH9Z9GNUUeayffKC73PYc= ;{id = 38696 (ksk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	256 3 8 AwEAAbEbGCpGTDrcZTWqWWE72nphyshpRcILdzCVlBGU9Ln1Fui9kkseUOP+g5GLUeVFKdTloeRTA9+EYiQdXgWXmXmuW/nGxZjAikluF/O9NzLVrr5iZnth2xu+F48nrJlAgWWiMNau54NI5sZ3iVQfhFsq2pZmf43RauRPniYMShOLO7EBWWXr5glDSgZGS9fSm6xHwwF+g8D4m8oanjvdCBNxXzSEKS31ibxjLifTfvwCg3y4XXcNW9U6Nu3JmoKUdxqpPPIkBvVQbIz4UO2FwaR13uXC03ALP1Yx2QNSS4SZlcIMtAftQR9wtCiuPWQnFv4jkzWqlhp1Lmf7bcoL9yk= ;{id = 53148 (zsk), size = 2048b}
+	Trusted key: .	172800	IN	DNSKEY	256 3 8 AwEAAbauxLSFZ+KSWi2cT6TJbm3d+GIVqb2N1XnDjMsRme0b6JlGp/cvwmM5CaJ5LQ7tG1r7LuTHjYZadtbNk2nZmclq9r4KInS48ungoAZb0gJXVw8IvBTBb1YWQmiBqD285pJuORwTii7DF++nNJJk3i55HJt9SmBI7m7t8nvx7OOY/w0inxg3fLH2uY0SKO8he4FGwMc4Ubiab8N8Yhyhh+FkKKdD/+oAcuGF75PjlSXO460B4MlNLlEcjDEzIsKauRYx4YVgSaNomGhMMFblmXRzgW+1R6ywvm5mC9+omlyyizZp2GJfPwGMezuKSGDndO6CYYEc5/lsRhvBYsGjdPM= ;{id = 46441 (zsk), size = 2048b}
+	Trusted key: nl.	3600	IN	DNSKEY	256 3 13 W+y1b3nqtYmENUIz2smIvZwX4199q/6I+fxP/Uz8IubzKsHLj1UmTYi8rhwV/c2p/BSCjl3DLsZNB6XJ9tqrNQ== ;{id = 18814 (zsk), size = 256b}
+Key is now trusted!
+	Trusted key: nl.	3600	IN	DNSKEY	257 3 13 aeDdFmc/JLPyva7Y4bS2SFbfWmxaiSrnqwgs+D1PKSPSruxIRH+6gHLhJ4XYIzrSaT3uk6rsx3c5jV8U4B8O+g== ;{id = 17153 (ksk), size = 256b}
+[T] platformrijksoverheid.nl. 3600 IN DS 17028 13 2 c19909d177c60005198cb55c593fec0c30916a9e271b948a8996539cd2dc281a
+;; Domain: platformrijksoverheid.nl.
+[T] platformrijksoverheid.nl. 86400 IN DNSKEY 257 3 13 ;{id = 17028 (ksk), size = 256b}
+[T] Existence denied: ps4.platformrijksoverheid.nl. DS
+;; No ds record for delegation
+;; Domain: ps4.platformrijksoverheid.nl.
+;; No DNSKEY record found for ps4.platformrijksoverheid.nl.
+[T] ps4.platformrijksoverheid.nl.	14400	IN	A	178.22.85.192
+ps4.platformrijksoverheid.nl.	14400	IN	A	178.22.85.191
+ps4.platformrijksoverheid.nl.	14400	IN	A	178.22.85.193
+ps4.platformrijksoverheid.nl.	14400	IN	A	178.22.85.194
+;;[S] self sig OK; [B] bogus; [T] trusted; [U] unsigned

--- a/boefjes/tests/plugins/test_dnssec.py
+++ b/boefjes/tests/plugins/test_dnssec.py
@@ -23,3 +23,10 @@ def test_dnssec_valid():
     output = list(run(input_ooi.serialize(), get_dummy_data("inputs/dnssec-valid.txt")))
 
     assert len(output) == 0
+
+
+def test_dnssec_status_line_not_last_line():
+    input_ooi = Hostname(network=Network(name="internet").reference, name="ps4.platformrijksoverheid.nl")
+    output = list(run(input_ooi.serialize(), get_dummy_data("inputs/dnssec-status-line-not-last-line.txt")))
+
+    assert len(output) == 0


### PR DESCRIPTION
### Changes

This PR fixes the following issues:

- **SSL scan normalizer**: previously parsed info/debug output instead of the actual results from `sslscan`
- **Test SSL normalizer**: previously parsed info/debug output instead of the actual results from `testssl`
- **DNSSEC normalizer**: incorrect parsing/checking of non-status or comment lines
  - Added a test case to cover this scenario

### QA notes

See unit test (or run it: `cd boefjes/; pytest --no-cov tests/plugins/`)

---

### Code Checklist

<!--- Mandatory: --->

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
