### PR TITLE
Make it possible to configure logging using ROCKY_LOG_CFG

### DIFF
--- a/rocky/logging.json
+++ b/rocky/logging.json
@@ -1,0 +1,23 @@
+{
+  "version": 1,
+  "disable_existing_loggers": 0,
+  "formatters": {
+    "default": {
+      "format": "%(message)s"
+    }
+  },
+  "handlers": {
+    "console": {
+      "class": "logging.StreamHandler",
+      "formatter": "default",
+      "level": "INFO",
+      "stream": "ext://sys.stdout"
+    }
+  },
+  "root": {
+    "level": "INFO",
+    "handlers": [
+      "console"
+    ]
+  }
+}

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -78,7 +78,7 @@ LOGGING = {
 
 
 def configure_logging(logging_settings):
-    log_cfg = env("ROCKY_LOG_CFG", default="")
+    log_cfg = env.path("ROCKY_LOG_CFG", default="")
     if log_cfg:
         with Path(log_cfg).open() as f:
             logging.config.dictConfig(json.load(f))

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -78,7 +78,7 @@ LOGGING = {
 
 
 def configure_logging(logging_settings):
-    log_cfg = env.path("ROCKY_LOG_CFG", default="")
+    log_cfg = env("ROCKY_LOG_CFG", default="")
     if log_cfg:
         with Path(log_cfg).open() as f:
             logging.config.dictConfig(json.load(f))

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -10,6 +10,8 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/4.2/ref/settings/
 """
 
+import json
+import logging.config
 import re
 from pathlib import Path
 
@@ -69,23 +71,44 @@ LOGGING_FORMAT = env("LOGGING_FORMAT", default="text")
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
-    "formatters": {
-        "json_formatter": {"()": structlog.stdlib.ProcessorFormatter, "processor": structlog.processors.JSONRenderer()},
-        "plain_console": {
-            "()": structlog.stdlib.ProcessorFormatter,
-            "processor": structlog.dev.ConsoleRenderer(
-                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
-            ),
-        },
-    },
-    "handlers": {
-        "console": {
-            "class": "logging.StreamHandler",
-            "formatter": ("json_formatter" if LOGGING_FORMAT == "json" else "plain_console"),
-        }
-    },
+    "formatters": {"default": {"format": "%(message)s"}},
+    "handlers": {"console": {"class": "logging.StreamHandler", "formatter": "default"}},
     "loggers": {"root": {"handlers": ["console"], "level": env("LOG_LEVEL", default="INFO").upper()}},
 }
+
+
+def configure_logging(logging_settings):
+    log_cfg = env("ROCKY_LOG_CFG", default="")
+    if log_cfg:
+        with Path(log_cfg).open() as f:
+            logging.config.dictConfig(json.load(f))
+    else:
+        logging.config.dictConfig(logging_settings)
+
+    structlog.configure(
+        processors=[
+            structlog.contextvars.merge_contextvars,
+            structlog.processors.add_log_level,
+            structlog.processors.StackInfoRenderer(),
+            structlog.dev.set_exc_info,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper("iso", utc=False),
+            (
+                structlog.dev.ConsoleRenderer(
+                    colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+                )
+                if LOGGING_FORMAT == "text"
+                else structlog.processors.JSONRenderer()
+            ),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+
+
+LOGGING_CONFIG = "rocky.settings.configure_logging"
 
 # Make sure this header can never be set by an attacker, see also the security
 # warning at https://docs.djangoproject.com/en/4.2/howto/auth-remote-user/
@@ -493,21 +516,6 @@ KNOX_TOKEN_MODEL = "account.AuthToken"
 
 FORMS_URLFIELD_ASSUME_HTTPS = True
 
-structlog.configure(
-    processors=[
-        structlog.contextvars.merge_contextvars,
-        structlog.processors.add_log_level,
-        structlog.processors.StackInfoRenderer(),
-        structlog.dev.set_exc_info,
-        structlog.stdlib.PositionalArgumentsFormatter(),
-        structlog.processors.TimeStamper("iso", utc=False),
-        structlog.stdlib.ProcessorFormatter.wrap_for_formatter,
-    ],
-    context_class=dict,
-    logger_factory=structlog.stdlib.LoggerFactory(),
-    wrapper_class=structlog.stdlib.BoundLogger,
-    cache_logger_on_first_use=True,
-)
 
 # Number of workers to run for the report queue
 POOL_SIZE = env.int("POOL_SIZE", default=2)

--- a/rocky/rocky/settings.py
+++ b/rocky/rocky/settings.py
@@ -85,27 +85,28 @@ def configure_logging(logging_settings):
     else:
         logging.config.dictConfig(logging_settings)
 
-    structlog.configure(
-        processors=[
-            structlog.contextvars.merge_contextvars,
-            structlog.processors.add_log_level,
-            structlog.processors.StackInfoRenderer(),
-            structlog.dev.set_exc_info,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.TimeStamper("iso", utc=False),
-            (
-                structlog.dev.ConsoleRenderer(
-                    colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
-                )
-                if LOGGING_FORMAT == "text"
-                else structlog.processors.JSONRenderer()
-            ),
-        ],
-        context_class=dict,
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
+
+structlog.configure(
+    processors=[
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.StackInfoRenderer(),
+        structlog.dev.set_exc_info,
+        structlog.stdlib.PositionalArgumentsFormatter(),
+        structlog.processors.TimeStamper("iso", utc=False),
+        (
+            structlog.dev.ConsoleRenderer(
+                colors=True, pad_level=False, exception_formatter=structlog.dev.plain_traceback
+            )
+            if LOGGING_FORMAT == "text"
+            else structlog.processors.JSONRenderer()
+        ),
+    ],
+    context_class=dict,
+    logger_factory=structlog.stdlib.LoggerFactory(),
+    wrapper_class=structlog.stdlib.BoundLogger,
+    cache_logger_on_first_use=True,
+)
 
 
 LOGGING_CONFIG = "rocky.settings.configure_logging"


### PR DESCRIPTION
### Changes

Make it possible to configure logging by specifying a logging configuration file using ROCKY_LOG_CFG in the same way as we do in the other services.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
