### PR TITLE
Fix DNSSEC boefje for CNAME / AAAA records

### DIFF
--- a/boefjes/boefjes/plugins/kat_dnssec/normalize.py
+++ b/boefjes/boefjes/plugins/kat_dnssec/normalize.py
@@ -19,9 +19,6 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
 
     # [S] self sig OK; [B] bogus; [T] trusted; [U] unsigned
     if result_line.startswith("[U]"):
-        if f"No DS record found for {ooi_ref.human_readable}., but valid CNAME" in result:
-            # hostname is a cname to another point, drill does not follow the cname.
-            return
         ft = KATFindingType(id="KAT-NO-DNSSEC")
         finding = Finding(
             finding_type=ft.reference,


### PR DESCRIPTION
### Changes

The DNSSEC boefje didn't work on CNAME or AAAA records. For CNAME records there was a workaround in the normalizer to prevent false positives, but this didn't work for all CNAME records.

Drill can only look up a single record type. If the A record does not exist, with this fix the boefje will execute drill a second time for CNAME record. If that also doesn't exist it will do a third call for the AAAA record in case the hostname only has an AAAA record.

### QA notes

Check if the boefje still works, create findings when DNSSEC is missing or invalid and doesn't generate false positives.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
