### PR TITLE
Fix docker warning on mixed case

### DIFF
--- a/boefjes/images/base.Dockerfile
+++ b/boefjes/images/base.Dockerfile
@@ -18,7 +18,7 @@ COPY ./boefjes/logging.json logging.json
 ENTRYPOINT ["/usr/local/bin/python", "-m", "worker"]
 CMD []
 
-FROM base as builder
+FROM base AS builder
 
 ARG BOEFJE_PATH
 


### PR DESCRIPTION
### Changes

This fixes the following warning:

The 'as' keyword should match the case of the 'from' keyword

FromAsCasing: 'as' and 'FROM' keywords' casing do not match
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/contributor/templates/pull_request_template_review_qa.md) into your comment.
