### PR TITLE
Fix DKIM false positives by reverting PR 3997

### DIFF
--- a/boefjes/boefjes/plugins/kat_dns/main.py
+++ b/boefjes/boefjes/plugins/kat_dns/main.py
@@ -83,8 +83,6 @@ def get_parent_zone_soa(resolver: dns.resolver.Resolver, name: Name) -> Answer:
 def get_email_security_records(resolver: dns.resolver.Resolver, hostname: str, record_subdomain: str) -> str:
     try:
         answer = resolver.resolve(f"{record_subdomain}.{hostname}", "TXT", raise_on_no_answer=False)
-        if answer.rrset is None:
-            return "NXDOMAIN"
         return answer.response.to_text()
     except dns.resolver.NoNameservers as error:
         # no servers responded happily, we'll check the response from the first


### PR DESCRIPTION
### Changes

This reverts PR #3997 because it caused almost every domain to get a false positive "No DKIM records found" finding.

The check for DKIM works a bit different than the other checks because we lookup the records because we don't know the selectors. What we can do is query `_domainkey.example.com` and if we get NXDOMAIN back we can conclude that there is no DKIM configured:
- If there is a DKIM key configured under `selector._domainkey.example.com` then if we query `_domainkey.example.com` there are no records, but because `selector._domainkey.example.com` this means we get NOERROR back in stead of NXDOMAIN.
- If there are no DKIM keys configured we will get NXDOMAIN, unless there is another reason such as a wildcard record which will give back a record or NOERROR. This means the check can only conclude that there is no DKIM, but can't say for certain that there is. That the current code creates a DKIMExist in this case is thus not completely correct because can't conclude that from the data, but this PR doesn't change that because it would be a big refactor.

What PR did #3997 is raise NXDOMAIN when no records were returned with NOERROR status, but this always caused a DKIM finding to be created unless the lookup returned a record because a wildcard record was created. The old code was correct although it might create DKIMExists objects when that might not be true as explained above.

### QA notes

You can check with mispo.es that DKIM findings are still found and check with almost every other domain that there are no false positives.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
