### PR TITLE
Support multiple ROAs in RPKI boefjes

### DIFF
--- a/boefjes/boefjes/plugins/kat_rpki/main.py
+++ b/boefjes/boefjes/plugins/kat_rpki/main.py
@@ -75,16 +75,19 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
                 )
                 exists = True
 
-                # check validity through bgp json
-                invalid_exists = False
-                for entry in bgp_data:
-                    if IPAddress(ip) in IPNetwork(entry["CIDR"]):
-                        bgp_entries.append(entry)
-                        if entry["ASN"] != asn:
-                            invalid_exists = True
+    if roas:
+        asns = {r["asn"] for r in roas}
 
-                if invalid_exists:
-                    invalid_bgp_entries.append({"ip": ip, "asn": asn})
+        # check validity through bgp json
+        invalid_asns = set()
+        for entry in bgp_data:
+            if IPAddress(ip) in IPNetwork(entry["CIDR"]):
+                bgp_entries.append(entry)
+                if entry["ASN"] not in asns:
+                    invalid_asns.add(entry["ASN"])
+
+        for invalid_asn in invalid_asns:
+            invalid_bgp_entries.append({"ip": ip, "asn": invalid_asn})
 
     results = {
         "vrps_records": roas,


### PR DESCRIPTION
### Changes

Add support multiple ROAs in RPKI boefjes. A subnet can be announced from multiple ASes. This is completely valid as long as there is a separate ROA for each AS. This adds support for multiple ROAs and multiple ASes.

### QA notes

You can use the IP addresses/ranges from here to test:
https://github.com/minvws/nl-kat-coordination/pull/2759#issuecomment-2220231631

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
