### PR TITLE
Dont crash on that have no PID, when reporting on stopped workers.

### DIFF
--- a/rocky/reports/runner/worker.py
+++ b/rocky/reports/runner/worker.py
@@ -119,9 +119,14 @@ class SchedulerWorkerManager(WorkerManager):
             except ValueError:
                 closed = True  # worker is closed, so we create a new one
 
-            logger.warning(
-                "Worker[pid=%s, %s] not alive, creating new worker...", worker.pid, _format_exit_code(worker.exitcode)
-            )
+            try:
+                logger.warning(
+                    "Worker[pid=%s, %s] not alive, creating new worker...", worker.pid, _format_exit_code(worker.exitcode)
+                )
+            except ValueError:
+                logger.warning(
+                    "Worker[pid=Unknown, %s] not alive, creating new worker...", _format_exit_code(worker.exitcode)
+                )
 
             if not closed:  # Closed workers do not have a pid, so cleaning up would fail
                 self._cleanup_pending_worker_task(worker)


### PR DESCRIPTION
We are seeing errors, and subsequent restart loops for missing workers. Instead of recreating the missing workers, we crash on the missing PID when trying to emit a warning.

### Changes

_Please describe the essence of this PR in a few sentences. Mention any breaking changes or required configuration steps._

### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
