### PR TITLE
Fix backup and restore scripts for cross-platform support and correctness

### DIFF
--- a/docs/source/installation-and-deployment/scripts.rst
+++ b/docs/source/installation-and-deployment/scripts.rst
@@ -95,9 +95,6 @@ Below is a description on how these backup scripts can be used.
 How to backup your volume
 -------------------------
 
-.. warning::
-    Please note that this is currently a Linux only script.
-
 In your OpenKAT directory go to the ``scripts/backup`` folder:
 
 ``$ cd scripts/backup``
@@ -108,9 +105,15 @@ Make the script executable:
 
 Run the backup script with root rights. The -p parameter specifies the folder where your backup files will be stored. If this folder doesn't exist yet, it will automatically be created. Change <backup_path> to a descriptive backup name. The full path for this folder will be: ``/<path_to_OpenKAT_files>/scripts/backup/<backup_path>``.
 
+Optionally, use the -n parameter to specify the docker compose project name. This is used to filter which volumes to backup. If not specified, it defaults to the ``COMPOSE_PROJECT_NAME`` environment variable or the current directory name (matching docker compose behavior).
+
 Run the script with the chosen backup path:
 
 ``$ sudo ./backup-volumes.sh -p <backup_path>``
+
+Or with an explicit project name:
+
+``$ sudo ./backup-volumes.sh -p <backup_path> -n <project_name>``
 
 This directory will contain multiple folders each containing the backup file for that specific docker container as archived files (.tar.gz). If you run the command again it will create new archived files into those subdirectories. Your old backup will remain, as each backup name contains the timestamp of moment of creation. An example of such a file is: ``2024-03-28_173258_nl-kat-coordination_bytes-data.tar.gz``.
 

--- a/scripts/backup/backup-volumes.sh
+++ b/scripts/backup/backup-volumes.sh
@@ -1,15 +1,38 @@
 #!/usr/bin/env bash
 set -eu
-# creates a backup of the docker volume
+# creates a backup of the docker volumes
+
+generate_uuid() {
+    if command -v uuidgen > /dev/null 2>&1; then
+        uuidgen
+    elif [ -f /proc/sys/kernel/random/uuid ]; then
+        cat /proc/sys/kernel/random/uuid
+    else
+        printf "Error: no UUID generator found\n" >&2
+        exit 1
+    fi
+}
+
+usage() {
+    printf "Usage: %s -p <path> [-n <project-name>]\n" "$(basename "$0")"
+    printf "  -p | --path       path where the backups are stored\n"
+    printf "  -n | --project    docker compose project name\n"
+    printf "                    (default: \$COMPOSE_PROJECT_NAME or current directory name)\n"
+    exit 0
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
     -p | --path)
         backup_path="$2"
+        shift
+        ;;
+    -n | --project)
+        project_name="$2"
+        shift
         ;;
     -h | -help | --help)
-        printf -- "--path  path where the backups are stored\n"
-        exit 1
+        usage
         ;;
     *)
         printf "*******************************\n"
@@ -19,24 +42,46 @@ while [ $# -gt 0 ]; do
         ;;
     esac
     shift
-    shift
 done
 
-for volume in $(docker volume ls --filter name=openkat* --quiet); do
-    uuid="$(cat /proc/sys/kernel/random/uuid)"
+if [ -z "${backup_path:-}" ]; then
+    printf "Error: --path is required\n" >&2
+    exit 1
+fi
+
+# Determine project name for docker volume filtering.
+# Mirrors docker compose behavior: env var, then current directory name.
+if [ -z "${project_name:-}" ]; then
+    project_name="${COMPOSE_PROJECT_NAME:-$(basename "$(pwd)")}"
+fi
+
+volumes="$(docker volume ls --filter "name=${project_name}_" --quiet)"
+
+if [ -z "$volumes" ]; then
+    printf "No volumes found for project '%s'\n" "$project_name"
+    exit 0
+fi
+
+for volume in $volumes; do
+    uuid="$(generate_uuid)"
     if [ ! -d "$backup_path/$volume" ]; then
         mkdir -p "$backup_path/$volume"
     fi
 
     IMAGE=alpine:latest
-    docker run \
+    docker create \
         --mount "type=volume,src=${volume},dst=/data" \
         --name "$uuid" \
         "$IMAGE"
+
+    # Clean up container on failure
+    trap 'rm -rf "/tmp/$uuid"; docker rm "$uuid" >/dev/null 2>&1' EXIT
 
     timestamp="$(date +%Y-%m-%d_%H%M%S)"
     docker cp -a "$uuid:/data" "/tmp/$uuid"
     tar -C "/tmp/$uuid" -czf "$backup_path/$volume/${timestamp}_${volume}.tar.gz" .
     rm -rf "/tmp/$uuid"
     docker rm "$uuid"
+
+    trap - EXIT
 done

--- a/scripts/backup/restore-volumes.sh
+++ b/scripts/backup/restore-volumes.sh
@@ -1,27 +1,58 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # creates a docker volume from a backup
 set -eu
+
+generate_uuid() {
+    if command -v uuidgen > /dev/null 2>&1; then
+        uuidgen
+    elif [ -f /proc/sys/kernel/random/uuid ]; then
+        cat /proc/sys/kernel/random/uuid
+    else
+        printf "Error: no UUID generator found\n" >&2
+        exit 1
+    fi
+}
+
+# Cross-platform stat: get modification time in unix epoch seconds
+get_mtime() {
+    if stat --version > /dev/null 2>&1; then
+        # GNU stat (Linux)
+        stat --format="%Y" "$1"
+    else
+        # BSD stat (macOS)
+        stat -f "%m" "$1"
+    fi
+}
+
+usage() {
+    printf "Usage: %s -v <volume> -p <path> [-n <volume-name>] [-s <snapshot>]\n" "$(basename "$0")"
+    printf "  -v | --volume       the volume name in the backup\n"
+    printf "  -n | --volume-name  (optional) create the restore as this new volume name\n"
+    printf "  -p | --path         the storage path of the backup location\n"
+    printf "  -s | --snapshot     the snapshot to restore\n"
+    exit 0
+}
 
 while [ $# -gt 0 ]; do
     case "$1" in
     -v | -volume | --volume)
         volume="$2"
+        shift
         ;;
     -p | -path | --path)
         backup_path="$2"
+        shift
         ;;
     -n | -volume-name | --volume-name)
         volume_name="$2"
+        shift
         ;;
     -s | -snapshot | --snapshot)
         snapshot="$2"
+        shift
         ;;
     -h | -help | --help)
-        printf -- "-v | --volume: the volume name in the backup\n"
-        printf -- "-n | --volume-name (optional): create the restore as this new volume name\n"
-        printf -- "-p | --path: the storage path of the backup location\n"
-        printf -- "-s | --snapshot: the snapshot to restore\n"
-        exit 1
+        usage
         ;;
     *)
         printf "***************************\n"
@@ -31,15 +62,23 @@ while [ $# -gt 0 ]; do
         ;;
     esac
     shift
-    shift
 done
+
+if [ -z "${volume:-}" ]; then
+    printf "Error: --volume is required\n"
+    exit 1
+fi
+
+if [ -z "${backup_path:-}" ]; then
+    printf "Error: --path is required\n"
+    exit 1
+fi
 
 if [ -z "${volume_name:-}" ]; then
     volume_name="$volume"
 fi
 
-volume_exists="$(docker volume ls | grep -q "$volume_name")"
-if [ "$volume_exists" ]; then
+if docker volume inspect "$volume_name" > /dev/null 2>&1; then
     printf "***********************************\n"
     printf "Error: volume %s exists. \n" "$volume_name"
     printf "Please delete before proceeding    \n"
@@ -54,7 +93,7 @@ if [ -z "${snapshot:-}" ]; then
     NEWEST=0
     for dirent in "${backup_path}/${volume}"/*; do
         # Get the modification time of the directory entry with stat in unix time
-        MTIME="$(stat --format="%Y" "$dirent")"
+        MTIME="$(get_mtime "$dirent")"
         if [ "$MTIME" -gt "$NEWEST" ]; then
             NEWEST="$MTIME"
             snapshot="$dirent"
@@ -72,16 +111,17 @@ else
     echo "creating from snapshot: ${snapshot}"
 fi
 
-uuid="$(cat /proc/sys/kernel/random/uuid)"
+uuid="$(generate_uuid)"
+dir="$(mktemp -d)"
+
+# Clean up temp directory and container on exit
+trap 'rm -rf "$dir"; docker rm "$uuid" >/dev/null 2>&1' EXIT
 
 IMAGE=alpine:latest
-docker run \
+docker create \
     --mount "type=volume,src=${volume_name},dst=/data" \
     --name "$uuid" \
     "$IMAGE"
 
-dir="$(mktemp -d -t "$uuid")"
 tar -xf "$backup_path/$volume/$snapshot" -C "$dir"
-
-docker cp -a "$dir" "$uuid:/data"
-docker rm "$uuid"
+docker cp -a "$dir/." "$uuid:/data"


### PR DESCRIPTION
## Summary

- Replace hardcoded `openkat*` volume filter with configurable `--project` flag, falling back to `$COMPOSE_PROJECT_NAME` or current directory name (fixes backup when project directory has a different name)
- Fix broken volume existence check in restore (`grep -q` in command substitution never produces output, replaced with `docker volume inspect`)
- Fix restore `docker cp` placing data in wrong directory (`$dir` instead of `$dir/.`)
- Replace Linux-only `/proc/sys/kernel/random/uuid` with cross-platform `uuidgen` fallback
- Replace GNU-only `stat --format` with cross-platform `get_mtime` helper
- Use `docker create` instead of `docker run` for temporary containers
- Add cleanup traps for containers and temp directories on failure
- Add input validation for required arguments
- Fix help exit codes (1 -> 0)
- Update documentation to reflect new `--project` flag and remove Linux-only warning

## Test plan

- [x] Argument parsing: `--help` (exit 0), missing args (exit 1), invalid args (exit 1)
- [x] Backup filters volumes by project name (`--project` flag)
- [x] Backup picks up `COMPOSE_PROJECT_NAME` env var
- [x] Wrong project name gives informative message
- [x] Restore refuses to overwrite existing volume
- [x] Backup + restore roundtrip preserves file contents (verified with test volume)
- [x] Full end-to-end: backup OpenKAT volumes, `docker compose down --volumes`, restore all volumes, `docker compose up` — all services healthy (Rocky, Bytes, Katalogus, Scheduler)