### PR TITLE
Fix command substitution syntax in systemd service files

### DIFF
--- a/boefjes/debian/rules
+++ b/boefjes/debian/rules
@@ -45,7 +45,7 @@ override_dh_installsystemd:
 	dh_installsystemd --name=kat-boefjes
 	dh_installsystemd --name=kat-normalizers
 	dh_installsystemd --name=kat-katalogus
-	sed -i "s/python3\.[0-9]\+/$(py3versions -d)/g" debian/kat-boefjes/lib/systemd/system/*.service
+	sed -i "s/python3\.[0-9]\+/`py3versions -d`/g" debian/kat-boefjes/lib/systemd/system/*.service
 
 # Disables dh_strip_nondeterminism because it very slow and not useful for us
 override_dh_strip_nondeterminism:


### PR DESCRIPTION
The $ syntax was executed at the wrong time when our PATH did not contain a python version at all.

### Changes

In our previous change we moved from backticks to $ style syntax, the latter being executed too early when our python version was not actually available in the path, producing an empty string.

### Issue link

Closes https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/issues/5021

### QA notes

See if the deb files produced by the CI actually contain the correct systemd service files.

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
