### PR TITLE
Skip Docker registry login for fork PRs

### DIFF
--- a/.github/workflows/boefjes_container_image.yml
+++ b/.github/workflows/boefjes_container_image.yml
@@ -43,6 +43,7 @@ jobs:
         id: buildx
 
       - name: Login to Librekat Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl

--- a/.github/workflows/bytes_container_image.yml
+++ b/.github/workflows/bytes_container_image.yml
@@ -41,6 +41,7 @@ jobs:
         id: buildx
 
       - name: Login to librekat Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl

--- a/.github/workflows/containerized_boefjes.yml
+++ b/.github/workflows/containerized_boefjes.yml
@@ -98,6 +98,7 @@ jobs:
             type=ref,event=pr
 
       - name: Login to librekat Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl

--- a/.github/workflows/mula_container_image.yml
+++ b/.github/workflows/mula_container_image.yml
@@ -41,6 +41,7 @@ jobs:
         id: buildx
 
       - name: Login to the Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl

--- a/.github/workflows/octopoes_container_image.yml
+++ b/.github/workflows/octopoes_container_image.yml
@@ -41,6 +41,7 @@ jobs:
         id: buildx
 
       - name: Login to GitHub Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl

--- a/.github/workflows/rocky_container_image.yml
+++ b/.github/workflows/rocky_container_image.yml
@@ -43,6 +43,7 @@ jobs:
         id: buildx
 
       - name: Login to the Container Registry
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login
         uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: docker.underdark.nl


### PR DESCRIPTION
## Summary

All 6 container image workflows (`boefjes`, `containerized_boefjes`, `bytes`, `mula`, `octopoes`, `rocky`) fail for fork PRs because the `docker/login-action` step runs unconditionally while `secrets.librekat_user` / `secrets.librekat_password` are not available to forks.

The `docker/build-push-action` already correctly skips pushing for fork PRs using:
```yaml
push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.owner.login == github.event.pull_request.base.repo.owner.login }}
```

This PR adds the same `if` condition to the login step so that:
- **Fork PRs**: skip login, build without pushing (validates Dockerfile correctness)
- **Same-repo PRs and pushes**: login and push as before (no behavior change)

## Changes

- `boefjes_container_image.yml` — add `if` to login step
- `containerized_boefjes.yml` — add `if` to login step
- `bytes_container_image.yml` — add `if` to login step
- `mula_container_image.yml` — add `if` to login step
- `octopoes_container_image.yml` — add `if` to login step
- `rocky_container_image.yml` — add `if` to login step

## Test plan

- [ ] Verify fork PRs no longer fail on the login step
- [ ] Verify pushes to main/release branches still build and push images correctly