### PR TITLE
Use existing organization property on request.user, and dont filter i…

### DIFF
--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -22,7 +22,6 @@ from httpx import HTTPStatusError, ReadTimeout
 from pydantic import Field
 from reports.report_types.findings_report.report import SEVERITY_OPTIONS
 from tools.forms.ooi_form import _EXCLUDED_OOI_TYPES
-from tools.models import Organization, OrganizationMember
 
 from crisis_room.forms import AddDashboardForm
 from crisis_room.models import MAX_POSITION, Dashboard, DashboardItem
@@ -308,9 +307,8 @@ class CrisisRoomView(TemplateView):
         if self.request.user.has_perm("tools.can_access_all_organizations"):
             dashboard_items = DashboardItem.objects.filter(findings_dashboard=True)
         else:
-            organizations = [org.code for org in self.request.user.organizations]
             dashboard_items = DashboardItem.objects.filter(
-                dashboard__organization__in=organizations, findings_dashboard=True
+                dashboard__organization__in=self.request.user.organizations, findings_dashboard=True
             )
 
         self.organizations_findings = dashboard_service.get_dashboard_items(dashboard_items)


### PR DESCRIPTION
### Changes
Uses the existing organizations property on the request.user. Also skips filtering if the user can see all organizations.

### Issue link

_You have to create an issue to link to this PR. If this really is not possible, write a very detailed description here and add this PR to the project board directly._

_Please add the link to the issue after "Closes"._

Closes #4724

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
