### PR TITLE
Fix check_requirements workflow for fork PRs

### DIFF
--- a/.github/workflows/check_requirements.yml
+++ b/.github/workflows/check_requirements.yml
@@ -24,15 +24,11 @@ on:
 jobs:
   poetry-dependencies:
     permissions:
-      # Give the default GITHUB_TOKEN write permission to commit and push the
-      # added or changed files to the repository.
-      contents: write
+      contents: read
 
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Set up Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
### Changes

Fix the `check_requirements` (poetry-dependencies) CI workflow to work with fork PRs.

**Problem:** Fork PRs fail because:
1. `ref: ${{ github.head_ref }}` tries to check out the fork's branch name in the base repo, where it doesn't exist
2. `contents: write` permission is not available for fork PRs (GITHUB_TOKEN is read-only)

**Fix:**
- Remove `ref: github.head_ref` — the default checkout (merge commit) works correctly for both fork and non-fork PRs
- Change `contents: write` to `contents: read` — this workflow only checks for drift with `git diff --exit-code`, it doesn't push changes back

The container image workflows already handle forks correctly (login + push are skipped via the `pull_request.head.repo.owner` condition added in #5047).

### QA notes

CI-only change. Verify that the `poetry-dependencies` check passes on this PR itself.