### PR TITLE
Add isolated unit tests for mula BoefjeRanker and NormalizerRanker

### DIFF
--- a/mula/tests/unit/test_rankers.py
+++ b/mula/tests/unit/test_rankers.py
@@ -1,0 +1,92 @@
+import unittest
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from scheduler.schedulers.rankers.boefje import BoefjeRanker, BoefjeRankerTimeBased
+from scheduler.schedulers.rankers.normalizer import NormalizerRanker
+
+
+class BoefjeRankerTestCase(unittest.TestCase):
+    """Isolated unit tests for BoefjeRanker. The ranker is currently only
+    exercised end-to-end via the simulation suite, which makes priority
+    regressions hard to attribute. These tests pin the documented behaviour
+    of `rank()` so future refactors can't silently break it.
+    """
+
+    def setUp(self):
+        self.ctx = mock.MagicMock()
+        self.ctx.config.pq_grace_period = 0  # easier to reason about boundaries
+        self.ranker = BoefjeRanker(ctx=self.ctx)
+
+    def _obj_with_latest_task(self, modified_at: datetime) -> mock.Mock:
+        latest_task = mock.Mock()
+        latest_task.modified_at = modified_at
+        obj = mock.Mock()
+        obj.latest_task = latest_task
+        return obj
+
+    def test_rank_new_task_returns_2(self):
+        obj = mock.Mock()
+        obj.latest_task = None
+        self.assertEqual(2, self.ranker.rank(obj))
+
+    def test_rank_falsy_latest_task_returns_2(self):
+        # The implementation also accepts `not obj.latest_task` for the new-task case.
+        obj = mock.Mock()
+        obj.latest_task = False
+        self.assertEqual(2, self.ranker.rank(obj))
+
+    def test_rank_task_just_ran_is_close_to_max_priority(self):
+        # A task that just ran (no time elapsed) should sit near the top of the
+        # 3..MAX_PRIORITY range. Allow a small tolerance for sub-second jitter.
+        recent = datetime.now(timezone.utc) - timedelta(seconds=1)
+        score = self.ranker.rank(self._obj_with_latest_task(recent))
+        self.assertGreater(score, BoefjeRanker.MAX_PRIORITY - 5)
+        self.assertLessEqual(score, BoefjeRanker.MAX_PRIORITY)
+
+    # NOTE: tests for the documented behaviour below were intentionally NOT
+    # added to this PR because the current implementation is broken in three
+    # ways and a passing test would ratify the bug:
+    #
+    # 1. `time_since_grace_period < 0` (grace-period skip) is unreachable —
+    #    `.seconds` on a timedelta is always 0..86399, never negative.
+    # 2. `time_since_grace_period >= max_days_in_seconds` (the floor-of-3
+    #    return for week-old tasks) is also unreachable because `.seconds`
+    #    truncates the days component, so a 7-day-old task evaluates as 0.
+    # 3. The decay interpolation runs against the truncated `.seconds`,
+    #    so an 8-day-old task gets a HIGHER score than a 1-hour-old task
+    #    instead of decaying. This inverts the documented priority logic.
+    #
+    # Root cause: `boefje.py:37` should call `.total_seconds()`, not
+    # `.seconds`. A separate fix PR will land the one-line correction and
+    # add the three tests that currently fail (grace-period, max-days
+    # ceiling, monotonic decay).
+
+
+class BoefjeRankerTimeBasedTestCase(unittest.TestCase):
+    def test_rank_returns_creation_epoch(self):
+        ranker = BoefjeRankerTimeBased(ctx=mock.MagicMock())
+        obj = mock.Mock()
+        obj.created_at = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        self.assertEqual(int(obj.created_at.timestamp()), ranker.rank(obj))
+
+
+class NormalizerRankerTestCase(unittest.TestCase):
+    """The NormalizerRanker prioritises older raw files so they get processed
+    first. The score is the boefje_meta.ended_at epoch — older = lower number =
+    higher priority on the min-heap PQ.
+    """
+
+    def test_rank_returns_boefje_meta_ended_at_epoch(self):
+        ranker = NormalizerRanker(ctx=mock.MagicMock())
+        obj = mock.Mock()
+        obj.raw_data.boefje_meta.ended_at = datetime(2026, 4, 11, 9, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(int(obj.raw_data.boefje_meta.ended_at.timestamp()), ranker.rank(obj))
+
+    def test_rank_orders_older_raws_lower(self):
+        ranker = NormalizerRanker(ctx=mock.MagicMock())
+        older = mock.Mock()
+        older.raw_data.boefje_meta.ended_at = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        newer = mock.Mock()
+        newer.raw_data.boefje_meta.ended_at = datetime(2026, 4, 1, tzinfo=timezone.utc)
+        self.assertLess(ranker.rank(older), ranker.rank(newer))


### PR DESCRIPTION
## Summary

Adds 6 isolated unit tests for `mula/scheduler/schedulers/rankers/`. Part of the same coverage pass as #5112 (octopoes bits), #5113 (boefjes normalizers) and #5114 (bytes API).

Until now the rankers were only exercised end-to-end via `tests/simulation/test_simulation.py`, which makes priority regressions hard to attribute. These tests pin a few documented behaviours.

Covered:
- `BoefjeRanker` — new-task case (returns 2), falsy `latest_task` case (returns 2), just-ran case (sits near `MAX_PRIORITY`)
- `BoefjeRankerTimeBased` — returns the creation epoch
- `NormalizerRanker` — returns `boefje_meta.ended_at` epoch and orders older raws lower (= higher PQ priority)

## Bugs discovered while writing tests

While writing tests for the rest of the documented behaviour I found that **`BoefjeRanker.rank()` is broken in three ways**, all caused by `boefje.py:37` calling `.seconds` on a `timedelta` instead of `.total_seconds()`:

```python
time_since_grace_period = ((datetime.now(timezone.utc) - obj.latest_task.modified_at) - grace_period).seconds
```

`timedelta.seconds` only returns the H:M:S portion (0..86399), discarding the days component.

Concrete consequences:

| Code branch | Documented behaviour | Actual behaviour |
|---|---|---|
| `time_since_grace_period < 0` (return `-1`) | Skip task that's still in grace period | **Unreachable** — `.seconds` is never negative |
| `>= max_days_in_seconds` (return `3`) | Floor priority for week-old tasks | **Unreachable** — a 7-day-old task evaluates to 0 because the days are truncated |
| Linear decay | Older task → lower priority | **Inverted** — an 8-day-old task gets a higher score than a 1-hour-old task |

In other words, mula's task prioritisation is currently mostly broken: priorities don't decay over time, the grace-period skip never fires, and the week-old floor never fires. The simulation suite did not catch this because it only checks "is each task scheduled at all", not the actual scoring.

To keep this PR scoped to test additions only, the three failing tests (grace-period, max-days ceiling, monotonic decay) have been replaced with an explanatory `NOTE` comment in `test_rankers.py`. A follow-up PR will:
1. Change `.seconds` → `.total_seconds()` (one-line fix in `boefje.py:37`)
2. Land the three deferred tests

## Test plan

- [x] `cd mula && make utest file=test_rankers.py` — **6/6 passed**
- [x] `pre-commit run` — passed
- [ ] CI (`mula-tests`) green

## Notes

- No production code changed; tests-only PR.
- Draft until Jan has reviewed.
- The decay-bug fix is non-trivial in impact: it changes how priorities are assigned in production, so it deserves its own PR with explicit before/after numbers and probably a functional test.