### PR TITLE
Make nikto boefje + normalizer work end-to-end on Nikto 2.6

### DIFF
--- a/boefjes/boefjes/plugins/kat_kat_finding_types/kat_finding_types.json
+++ b/boefjes/boefjes/plugins/kat_kat_finding_types/kat_finding_types.json
@@ -613,5 +613,45 @@
     "risk": "recommendation",
     "impact": "Depending on what software is outdated this can be critical.",
     "recommendation": "Inspect the software version, determine if additional measures need to be taken and install updates to reduce the attack surface."
+  },
+  "KAT-MISSING-HEADER": {
+    "name":"Missing security header",
+    "description": "A recommended HTTP security header is not present on the response. The exact header was either not recognised by the parser or not specifically mapped to a dedicated finding type.",
+    "source": "https://owasp.org/www-project-secure-headers/",
+    "risk": "recommendation",
+    "impact": "Missing security headers may weaken the browser-side defences of the site against common web attacks such as XSS, clickjacking, or MIME-sniffing.",
+    "recommendation": "Configure the web server or application to emit the missing security header(s) with appropriate values per the OWASP Secure Headers project."
+  },
+  "KAT-NIKTO-FINDING": {
+    "name":"Nikto finding",
+    "description": "Nikto reported an issue that does not yet have a dedicated OpenKAT finding type. The raw message from Nikto is attached to the finding description.",
+    "source": "https://github.com/sullo/nikto",
+    "risk": "recommendation",
+    "impact": "Depends on the specific Nikto finding. Consult the finding description to assess impact.",
+    "recommendation": "Review the finding description and consult the Nikto documentation or your web server vendor for remediation guidance."
+  },
+  "KAT-HTTP-TRACE-METHOD": {
+    "name":"HTTP TRACE method is enabled",
+    "description": "The HTTP TRACE method is enabled on the web server. TRACE can be abused in cross-site tracing (XST) attacks to read security-sensitive headers such as cookies when combined with other client-side vulnerabilities.",
+    "source": "https://owasp.org/www-community/attacks/Cross_Site_Tracing",
+    "risk": "medium",
+    "impact": "An attacker who also exploits a client-side vulnerability (e.g. XSS) can use TRACE to read otherwise HttpOnly cookies or authorization headers.",
+    "recommendation": "Disable the TRACE method on the web server. For Apache: TraceEnable off. For Nginx: do not forward TRACE. For IIS: disable the verb in request filtering."
+  },
+  "KAT-WILDCARD-CERTIFICATE": {
+    "name":"Wildcard TLS certificate in use",
+    "description": "The server presents a wildcard TLS certificate. Wildcard certificates simplify operations but increase blast radius on compromise because the same private key authenticates every subdomain.",
+    "source": "https://en.wikipedia.org/wiki/Wildcard_certificate",
+    "risk": "recommendation",
+    "impact": "Compromise of the wildcard certificate private key allows an attacker to impersonate every matching subdomain.",
+    "recommendation": "Prefer per-host certificates when operationally feasible; automate issuance via ACME. Keep wildcards only where a single key/cert must cover many ephemeral subdomains and protect the key accordingly."
+  },
+  "KAT-EXPOSED-DEFAULT-FILE": {
+    "name":"Default file exposed",
+    "description": "A default file or directory shipped with the web server software is exposed and reachable. These files often disclose software versions or provide an information foothold for attackers.",
+    "source": "https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/01-Information_Gathering/",
+    "risk": "low",
+    "impact": "Information disclosure about the underlying software stack, assisting reconnaissance.",
+    "recommendation": "Remove default files from production deployments or deny-list them at the web server level."
   }
 }

--- a/boefjes/boefjes/plugins/kat_nikto/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_nikto/boefje.Dockerfile
@@ -3,7 +3,7 @@ FROM perl:5.40
 WORKDIR /app
 RUN apt-get update && apt-get install -y --no-install-recommends git nodejs
 
-RUN git clone https://github.com/sullo/nikto
+RUN git clone --depth 1 --branch 2.6.0 https://github.com/sullo/nikto
 RUN cpanm --notest JSON XML::Writer
 
 ARG BOEFJE_PATH=./boefjes/plugins/kat_nikto

--- a/boefjes/boefjes/plugins/kat_nikto/main.js
+++ b/boefjes/boefjes/plugins/kat_nikto/main.js
@@ -12,7 +12,8 @@ function get_config_content(scheme) {
 
   // Setup config file
   try {
-    let config_contents = `PROMPTS=no\nUPDATES=no\nCLIOPTS=-404code=301,302,307,308 -Tuning ${TUNING} -maxtime ${MAX_TIME} -o ./output.json`;
+    // Nikto 2.6 appends ".json" to the -o path, so pass base name + explicit -Format json.
+    let config_contents = `PROMPTS=no\nUPDATES=no\nCLIOPTS=-404code=301,302,307,308 -Tuning ${TUNING} -maxtime ${MAX_TIME} -o ./output -Format json`;
 
     if (scheme == "https") config_contents += " -ssl";
     if (IS_USING_PROXY) config_contents += " -useproxy";

--- a/boefjes/boefjes/plugins/kat_nikto/normalize.py
+++ b/boefjes/boefjes/plugins/kat_nikto/normalize.py
@@ -1,4 +1,5 @@
 import json
+import re
 from collections.abc import Iterable
 from typing import Any
 
@@ -15,50 +16,118 @@ MISSING_HEADER_TO_KAT_FINDING_TYPE = {
     "permissions-policy": "KAT-NO-PERMISSIONS-POLICY",
 }
 
+# Nikto vulnerability IDs dispatched to the "missing security header" branch.
+# Covers both legacy (013587) and Nikto 2.6+ plugin IDs.
+MISSING_HEADER_IDS = {"013587", "999100", "999103", "999984"}
+
+# HSTS-specific finding, kept separate so its msg doesn't run through the header regex.
+HSTS_IDS = {"999970"}
+
+# HTTP TRACE method enabled / XST exposure.
+TRACE_METHOD_IDS = {"000434"}
+
+# Nikto 2.6 "Allowed HTTP Methods" notice — only a finding when TRACE is among them.
+ALLOWED_METHODS_ID = "999990"
+
+# Wildcard TLS certificate in use.
+WILDCARD_CERT_IDS = {"999992"}
+
+# Known default file exposed (e.g. /icons/README on Apache).
+DEFAULT_FILE_IDS = {"003584"}
+
+# Server banner / disclosure headers (x-powered-by, Server:, etc.) — useful for SoftwareInstance.
+BANNER_DISCLOSURE_IDS = {"999986"}
+
+# Matches the outdated-software wording Nikto uses, e.g. in the message
+# Apache/2.4.49 appears to be outdated (current is at least 2.4.66).
+OUTDATED_SOFTWARE_RE = re.compile(r"^([\w.\-]+)/([\w.\-]+)\s+appears to be outdated")
+
+# Matches software/version disclosed in a response header, e.g. in the message
+# Retrieved x-powered-by header: Apache/2.4.49.
+BANNER_SOFTWARE_RE = re.compile(r"header:\s+([\w.\-]+)/([\w.\-]+)")
+
+# Missing-header message extractor, tolerant to Nikto 2.5 and 2.6+ wording.
+MISSING_HEADER_NEW_RE = re.compile(r"missing:\s+([A-Za-z-]+)", re.IGNORECASE)
+MISSING_HEADER_OLD_RE = re.compile(r"\bThe\s+([A-Za-z-]+)\s+header", re.IGNORECASE)
+
+
+def _extract_missing_header(msg: str) -> str | None:
+    match = MISSING_HEADER_NEW_RE.search(msg) or MISSING_HEADER_OLD_RE.search(msg)
+    return match.group(1).lower() if match else None
+
+
+def _outdated_software(msg: str, ooi_ref: Reference) -> Iterable[NormalizerOutput]:
+    match = OUTDATED_SOFTWARE_RE.match(msg)
+    if not match:
+        yield from _generic_finding(msg, ooi_ref)
+        return
+
+    software = Software(name=match.group(1), version=match.group(2))
+    software_instance = SoftwareInstance(ooi=ooi_ref, software=software.reference)
+    finding_type = KATFindingType(id="KAT-OUTDATED-SOFTWARE")
+    yield software
+    yield software_instance
+    yield finding_type
+    yield Finding(finding_type=finding_type.reference, ooi=software_instance.reference, description=msg)
+
+
+def _missing_header(msg: str, ooi_ref: Reference) -> Iterable[NormalizerOutput]:
+    header = _extract_missing_header(msg)
+    finding_type_id = MISSING_HEADER_TO_KAT_FINDING_TYPE.get(header) if header else None
+    yield from _simple_finding(finding_type_id or "KAT-MISSING-HEADER", msg, ooi_ref)
+
+
+def _banner_disclosed(msg: str, ooi_ref: Reference) -> Iterable[NormalizerOutput]:
+    match = BANNER_SOFTWARE_RE.search(msg)
+    if match:
+        software = Software(name=match.group(1), version=match.group(2))
+        software_instance = SoftwareInstance(ooi=ooi_ref, software=software.reference)
+        yield software
+        yield software_instance
+    yield from _generic_finding(msg, ooi_ref)
+
+
+def _simple_finding(finding_type_id: str, msg: str, ooi_ref: Reference) -> Iterable[NormalizerOutput]:
+    finding_type = KATFindingType(id=finding_type_id)
+    yield finding_type
+    yield Finding(finding_type=finding_type.reference, ooi=ooi_ref, description=msg)
+
+
+def _generic_finding(msg: str, ooi_ref: Reference) -> Iterable[NormalizerOutput]:
+    yield from _simple_finding("KAT-NIKTO-FINDING", msg, ooi_ref)
+
 
 def scan_nikto_output(data: list[dict[str, Any]], ooi_ref: Reference) -> Iterable[NormalizerOutput]:
     for scan in data:
-        for vulnerability in scan["vulnerabilities"]:
-            vulnerability_id = str(vulnerability["id"])
+        for vulnerability in scan.get("vulnerabilities", []):
+            vulnerability_id = str(vulnerability.get("id", ""))
+            msg = str(vulnerability.get("msg", ""))
 
-            # If the scanned vulnerability has to do with outdated software
             if vulnerability_id.startswith("6"):
-                # Example of `vulnerability["msg"]`
-                # @SOFTWARE/@RUNNING_VER appears to be outdated (current is at least @CURRENT_VER)
-                software_name, found_version = vulnerability["msg"].split()[0].split("/")
-
-                software = Software(name=software_name, version=found_version)
-                software_instance = SoftwareInstance(ooi=ooi_ref, software=software.reference)
-                yield software
-                yield software_instance
-
-                finding_type = KATFindingType(id="KAT-OUTDATED-SOFTWARE")
-                yield finding_type
-                yield Finding(
-                    finding_type=finding_type.reference,
-                    ooi=software_instance.reference,
-                    description=vulnerability["msg"],
-                )
-
-            # If the scanned vulnerability has to do with security headers missing
-            elif vulnerability_id == "013587":
-                missing_header = vulnerability["msg"].split()[-1].strip(".")
-
-                kat_finding_type_id = MISSING_HEADER_TO_KAT_FINDING_TYPE.get(missing_header)
-                if kat_finding_type_id is None:
-                    kat_finding_type_id = "KAT-MISSING-HEADER"
-                finding_type = KATFindingType(id=kat_finding_type_id)
-                yield finding_type
-                yield Finding(finding_type=finding_type.reference, ooi=ooi_ref, description=vulnerability["msg"])
-            # if the site uses TLS and the Strict-Transport-Security HTTP header is not defined
-            elif vulnerability_id == "999970":
-                finding_type = KATFindingType(id="KAT-HSTS-VULNERABILITIES")
-                yield Finding(finding_type=finding_type.reference, ooi=ooi_ref, description=vulnerability["msg"])
+                yield from _outdated_software(msg, ooi_ref)
+            elif vulnerability_id in MISSING_HEADER_IDS:
+                yield from _missing_header(msg, ooi_ref)
+            elif vulnerability_id in HSTS_IDS:
+                yield from _simple_finding("KAT-HSTS-VULNERABILITIES", msg, ooi_ref)
+            elif (
+                vulnerability_id in TRACE_METHOD_IDS
+                or vulnerability_id == ALLOWED_METHODS_ID
+                and "TRACE" in msg.upper()
+            ):
+                yield from _simple_finding("KAT-HTTP-TRACE-METHOD", msg, ooi_ref)
+            elif vulnerability_id in WILDCARD_CERT_IDS:
+                yield from _simple_finding("KAT-WILDCARD-CERTIFICATE", msg, ooi_ref)
+            elif vulnerability_id in DEFAULT_FILE_IDS:
+                yield from _simple_finding("KAT-EXPOSED-DEFAULT-FILE", msg, ooi_ref)
+            elif vulnerability_id in BANNER_DISCLOSURE_IDS:
+                yield from _banner_disclosed(msg, ooi_ref)
+            else:
+                # Never silently drop a Nikto finding — emit a generic finding so the
+                # signal reaches reports and the UI even for IDs we haven't mapped yet.
+                yield from _generic_finding(msg, ooi_ref)
 
 
 def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
     data = json.loads(raw)
-
     ooi_ref = Reference.from_str(input_ooi["primary_key"])
-
     yield from scan_nikto_output(data, ooi_ref)

--- a/boefjes/tests/examples/raw/nikto-apache.dvwa.cloud.json
+++ b/boefjes/tests/examples/raw/nikto-apache.dvwa.cloud.json
@@ -1,0 +1,56 @@
+[
+  {
+    "host": "apache.dvwa.cloud",
+    "ip": "192.0.2.10",
+    "port": "443",
+    "banner": "Apache/2.4.49 (Unix)",
+    "vulnerabilities": [
+      {
+        "id": "999986",
+        "method": "GET",
+        "url": "/",
+        "msg": "Retrieved x-powered-by header: Apache/2.4.49."
+      },
+      {
+        "id": "013587",
+        "references": "https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options",
+        "method": "GET",
+        "url": "/",
+        "msg": "Suggested security header missing: x-content-type-options. See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Content-Type-Options"
+      },
+      {
+        "id": "600050",
+        "method": "GET",
+        "url": "/",
+        "msg": "Apache/2.4.49 appears to be outdated (current is at least 2.4.66)."
+      },
+      {
+        "id": "999992",
+        "references": "https://en.wikipedia.org/wiki/Wildcard_certificate",
+        "method": "GET",
+        "url": "/",
+        "msg": "Server is using a wildcard certificate: *.dvwa.cloud. See: https://en.wikipedia.org/wiki/Wildcard_certificate"
+      },
+      {
+        "id": "999990",
+        "method": "OPTIONS",
+        "url": "/",
+        "msg": "Allowed HTTP Methods: HEAD, GET, POST, OPTIONS, TRACE ."
+      },
+      {
+        "id": "000434",
+        "references": "https://owasp.org/www-community/attacks/Cross_Site_Tracing",
+        "method": "TRACE",
+        "url": "/",
+        "msg": "HTTP TRACE method is active and replies which suggests the host is vulnerable to XST. See: https://owasp.org/www-community/attacks/Cross_Site_Tracing"
+      },
+      {
+        "id": "003584",
+        "references": "https://www.vntweb.co.uk/apache-restricting-access-to-iconsreadme/",
+        "method": "GET",
+        "url": "/icons/README",
+        "msg": "Apache default file found. See: https://www.vntweb.co.uk/apache-restricting-access-to-iconsreadme/"
+      }
+    ]
+  }
+]

--- a/boefjes/tests/test_nikto_normalizer.py
+++ b/boefjes/tests/test_nikto_normalizer.py
@@ -2,35 +2,90 @@ from unittest import TestCase
 
 from boefjes.plugins.kat_nikto.normalize import run
 from octopoes.models import Reference
-from octopoes.models.ooi.findings import KATFindingType
+from octopoes.models.ooi.findings import Finding, KATFindingType
 from octopoes.models.ooi.software import Software, SoftwareInstance
-from octopoes.models.types import Finding
 from tests.loading import get_dummy_data
 
 
-class CVETest(TestCase):
-    def test_outdated_found(self):
+class NiktoNormalizerTest(TestCase):
+    def test_outdated_and_legacy_missing_header(self):
+        # The legacy fixture (Nikto 2.5-era message format) exercises two branches:
+        # - id 600575 → outdated software
+        # - id 999103 → missing security header, with the "The <Header> header is not set." wording
+        # The old-format regex should still extract the header name.
         input_ooi = {"primary_key": "Hostname|internet|example.com"}
         ooi_ref = Reference.from_str(input_ooi["primary_key"])
 
         oois = list(run(input_ooi, get_dummy_data("raw/nikto-example.com.json")))
 
         software = Software(name="nginx", version="1.18.0")
-        finding_type = KATFindingType(id="KAT-OUTDATED-SOFTWARE")
         software_instance = SoftwareInstance(ooi=ooi_ref, software=software.reference)
-        finding = Finding(
-            finding_type=finding_type.reference,
+        outdated_type = KATFindingType(id="KAT-OUTDATED-SOFTWARE")
+        outdated_finding = Finding(
+            finding_type=outdated_type.reference,
             ooi=software_instance.reference,
             description="nginx/1.18.0 appears to be outdated (current is at least 1.25.3).",
         )
+        missing_header_type = KATFindingType(id="KAT-NO-X-CONTENT-TYPE-OPTIONS")
+        missing_header_finding = Finding(
+            finding_type=missing_header_type.reference,
+            ooi=ooi_ref,
+            description=(
+                "The X-Content-Type-Options header is not set. This could allow the user agent "
+                "to render the content of the site in a different fashion to the MIME type."
+            ),
+        )
 
-        expected = [software, software_instance, finding_type, finding]
+        expected = [
+            software,
+            software_instance,
+            outdated_type,
+            outdated_finding,
+            missing_header_type,
+            missing_header_finding,
+        ]
 
         self.assertEqual(expected, oois)
 
-    def test_nothing_found(self):
+    def test_unmapped_id_yields_generic_finding(self):
+        # Even an unmapped id (here "0": connection failure) is surfaced as a generic finding
+        # rather than silently dropped — fixes the symptom reported by Kennisnet.
         input_ooi = {"primary_key": "Hostname|internet|non-existing.com"}
+        ooi_ref = Reference.from_str(input_ooi["primary_key"])
 
         oois = list(run(input_ooi, get_dummy_data("raw/nikto-non-existing.com.json")))
 
-        self.assertEqual([], oois)
+        self.assertEqual(2, len(oois))
+        self.assertEqual("KATFindingType", oois[0].object_type)
+        self.assertEqual("KAT-NIKTO-FINDING", oois[0].id)
+        self.assertEqual("Finding", oois[1].object_type)
+        self.assertEqual(ooi_ref, oois[1].ooi)
+
+    def test_nikto_2_6_full_coverage(self):
+        # Fixture captured from a real `nikto 2.6.0` run against apache.dvwa.cloud with
+        # Tuning=3b. Asserts that every vulnerability id in the fixture produces a
+        # finding — this is the exact regression reported by Kennisnet.
+        input_ooi = {"primary_key": "Website|internet|192.0.2.10|tcp|443|https|internet|apache.dvwa.cloud"}
+
+        oois = list(run(input_ooi, get_dummy_data("raw/nikto-apache.dvwa.cloud.json")))
+
+        finding_type_ids = {o.id for o in oois if o.object_type == "KATFindingType"}
+        findings = [o for o in oois if o.object_type == "Finding"]
+        software = [o for o in oois if o.object_type == "Software"]
+
+        # 013587 → specific mapped type for x-content-type-options (new Nikto 2.6 message format)
+        self.assertIn("KAT-NO-X-CONTENT-TYPE-OPTIONS", finding_type_ids)
+        # 600050 → outdated software
+        self.assertIn("KAT-OUTDATED-SOFTWARE", finding_type_ids)
+        # 999992 → wildcard certificate
+        self.assertIn("KAT-WILDCARD-CERTIFICATE", finding_type_ids)
+        # 999990 with TRACE in msg AND 000434 both map to TRACE method finding
+        self.assertIn("KAT-HTTP-TRACE-METHOD", finding_type_ids)
+        # 003584 → default file exposed
+        self.assertIn("KAT-EXPOSED-DEFAULT-FILE", finding_type_ids)
+        # 999986 → banner disclosure, yields a Software + generic catch-all finding
+        self.assertIn("KAT-NIKTO-FINDING", finding_type_ids)
+        self.assertTrue(any(s.name == "Apache" and s.version == "2.4.49" for s in software))
+
+        # Every vulnerability in the fixture should surface exactly one Finding (seven in total).
+        self.assertEqual(7, len(findings))


### PR DESCRIPTION
### Changes

Closes #5136 — reported by Kennisnet: "no Nikto data coming back" on scanned targets.

Three independent bugs in the `kat_nikto` plugin combined to silently break Nikto on real scans once the upstream image was rebuilt with Nikto 2.6. Fix:

- **Boefje no longer finds its output file.** Nikto 2.6 appends `".json"` to the `-o` path, so the existing `"-o ./output.json"` produced `output.json.json` and `main.js` threw `ENOENT` when reading `./output.json`. Without this the normalizer is never reached on real scans — the rest of the work in this PR is dead code in the running stack until that's resolved. Fixed in `main.js` by passing a base name plus an explicit `-Format json`.
- **Broader id dispatch with catch-all in the normalizer.** Old code handled only `6xxxxx` (outdated software), `013587` (one missing-header id) and `999970` (HSTS); everything else produced no OOI and no log line. Now also dispatches `999100 / 999103 / 999984` (other missing-header ids), `000434` and `999990`-with-TRACE (HTTP TRACE method), `999992` (wildcard TLS cert), `003584` (default file exposed), `999986` (server banner → `Software` OOI). Every unmapped id falls through to a new `KAT-NIKTO-FINDING` catch-all so no signal is silently lost.
- **Robust missing-header extractor.** The split-on-whitespace extractor broke on Nikto 2.6's new `"Suggested security header missing: x-..."` wording (it picked the trailing docs URL instead of the header name). Replaced with a regex that handles both the Nikto 2.5 wording (`"The X-... header is not set."`) and the 2.6 wording.
- **Five new `KATFindingType` entries.** `KAT-MISSING-HEADER` (was already referenced as a fallback but never defined), plus `KAT-NIKTO-FINDING`, `KAT-HTTP-TRACE-METHOD`, `KAT-WILDCARD-CERTIFICATE`, `KAT-EXPOSED-DEFAULT-FILE` for the new dispatch cases.
- **Pin Nikto upstream to `2.6.0`** in `boefje.Dockerfile` (`git clone --depth 1 --branch 2.6.0 …`). The unpinned `git clone` picked `master` each rebuild, which is how the 2.5 → 2.6 output-format change slipped in and broke the normalizer in the first place.
- **Regression fixture + assertions.** Added `nikto-apache.dvwa.cloud.json` captured from a real Nikto 2.6 run against `https://apache.dvwa.cloud/` with Tuning=3b. Asserts every id in the fixture produces the expected finding type. Kept the existing fixture and updated its test so the 2.5-era "The X header is not set." wording is also covered.

### Operational note

The runtime references `docker.underdark.nl/librekat/openkat-nikto:latest` from `boefje.json`, so `main.js` and the `boefje.Dockerfile` change only take effect once that image is rebuilt and pushed. The normalizer change ships immediately because normalizers run inside the boefjes container itself.

### Issue link

Closes #5136

### Demo

Reproduction before the fix, from `docker.underdark.nl/librekat/openkat-nikto:latest` against `https://apache.dvwa.cloud/`, Tuning=3b (7 findings in Nikto JSON output):

| Nikto id | Message | Normalizer (before) | Normalizer (after) |
|---|---|---|---|
| `999986` | Retrieved x-powered-by header: Apache/2.4.49 | *dropped* | `Software(Apache, 2.4.49)` + `SoftwareInstance` + `KAT-NIKTO-FINDING` |
| `013587` | Suggested security header missing: x-content-type-options | `KAT-MISSING-HEADER` (generic, wrong extractor) | `KAT-NO-X-CONTENT-TYPE-OPTIONS` |
| `600050` | Apache/2.4.49 appears to be outdated | ✅ `KAT-OUTDATED-SOFTWARE` | ✅ `KAT-OUTDATED-SOFTWARE` |
| `999992` | Server is using a wildcard certificate | *dropped* | `KAT-WILDCARD-CERTIFICATE` |
| `999990` | Allowed HTTP Methods: HEAD, GET, POST, OPTIONS, TRACE | *dropped* | `KAT-HTTP-TRACE-METHOD` (msg contains TRACE) |
| `000434` | HTTP TRACE method active (XST) | *dropped* | `KAT-HTTP-TRACE-METHOD` |
| `003584` | Apache default file found | *dropped* | `KAT-EXPOSED-DEFAULT-FILE` |

### QA notes

1. On this branch, enable the `nikto` boefje and point it at a Website OOI served by Apache (`https://apache.dvwa.cloud/` works well).
2. After the scan completes, verify that **every** finding id in the bytes raw output has produced at least one finding in octopoes. Before this fix only the `600050` outdated-software case made it through, and only when the boefje managed to write its output file at all.
3. `cd boefjes && make itest` — the new `tests/test_nikto_normalizer.py::NiktoNormalizerTest::test_nikto_2_6_full_coverage` asserts the full id coverage; `test_outdated_and_legacy_missing_header` keeps the old Nikto 2.5 wording exercised.
4. End-to-end functional test requires `docker.underdark.nl/librekat/openkat-nikto:latest` to be rebuilt with the `main.js` and `boefje.Dockerfile` changes from this PR.

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

- [x] Tickets have been created for newly discovered issues. (#5136)
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly. (none)
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself.