### PR TITLE
crisis_room: skip dashboard items with deleted organization

### DIFF
--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -106,6 +106,13 @@ class DashboardService:
 
         # First collect al data, if recipe id is found then fetch recipe ids to get reports later.
         for dashboard_item in dashboard_items:
+            # Dashboard.organization uses on_delete=SET_NULL, so a deleted
+            # organization leaves orphan dashboards/items. Skip them — every
+            # downstream branch needs `dashboard.organization.code`, and
+            # without this guard the crisis room 500s on the next visit
+            # after any organization deletion (#5140).
+            if dashboard_item.dashboard.organization is None:
+                continue
             if not dashboard_item.recipe and dashboard_item.source == "object_list":
                 item_data = DashboardItemView(dashboard_item, self.get_ooi_list(dashboard_item))
                 dashboard_items_with_data.append(item_data)

--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -107,7 +107,7 @@ class DashboardService:
         # First collect al data, if recipe id is found then fetch recipe ids to get reports later.
         for dashboard_item in dashboard_items:
             # Dashboard.organization uses on_delete=SET_NULL, so a deleted
-            # organization leaves orphan dashboards/items. Skip them — every
+            # organization leaves orphan dashboards/items. Skip them, every
             # downstream branch needs `dashboard.organization.code`, and
             # without this guard the crisis room 500s on the next visit
             # after any organization deletion (#5140).


### PR DESCRIPTION
Fixes #5140.

`Dashboard.organization` uses `on_delete=SET_NULL`, so deleting an organization leaves orphan dashboards. `get_dashboard_items` then accesses `dashboard.organization.code` and 500s the crisis room on the next visit. Skip orphan items in the loop, every downstream branch needs `organization.code`, so a single guard at the top covers them all.

Option B per the issue body. Option A (cascade-delete or explicit cleanup in `OrganizationViewSet.destroy`) would also clean up storage, but it's a bigger schema-migration call I'd leave to the maintainers; this fix gets users out of the immediate crash on existing orphans.