### PR TITLE
Add octopoes_api_scanprofiles to release-example compose

### DIFF
--- a/docker-compose.release-example.yml
+++ b/docker-compose.release-example.yml
@@ -65,6 +65,17 @@ services:
         soft: 262144
         hard: 262144
 
+  octopoes_api_scanprofiles:
+    restart: on-failure
+    depends_on:
+      - octopoes_api
+      - katalogus
+    image: "docker.underdark.nl/librekat/openkat-octopoes:${KAT_VERSION}"
+    command: scanprofiles
+    env_file:
+      - .env-prod
+      - .env
+
   boefje:
     restart: on-failure
     depends_on:


### PR DESCRIPTION
## Summary

PR #5039 moved scan profile propagation out of Celery into its own daemon and added an `octopoes_api_scanprofiles` service to `docker-compose.yml`. The matching change to `docker-compose.release-example.yml` was missed, so production deployments built from the release example are running without the scan profile propagation daemon.

## Impact

Without this service:
- Clearance levels no longer propagate through the OOI graph.
- Newly created OOIs do not receive an inherited scan level.
- Boefjes are not scheduled on derived objects that should inherit clearance.

The failure is silent — no error in logs, just a slow degradation of scanner coverage compared to a `docker-compose.yml`-based dev install.

## Change

Adds the missing service to `docker-compose.release-example.yml`, mirroring the pattern of the other octopoes services in that file (`restart: on-failure`, image tag instead of build, `.env-prod` + `.env` env_files). The `scanprofiles` command is already part of the released `openkat-octopoes` image (added to `octopoes/entrypoint.sh` in #5039), so no image rebuild is required.

## Test plan

- [ ] CI green (`pre-commit`, `CodeQL`).
- [ ] Manual: bring the release example up against an existing `.env-prod`, confirm the new container starts.
- [ ] Manual: trigger a clearance level on a parent OOI, verify it propagates to descendants.