### PR TITLE
fix(crisis_room): cascade-delete dashboards with their organization

### DIFF
--- a/rocky/crisis_room/migrations/0008_alter_dashboard_organization.py
+++ b/rocky/crisis_room/migrations/0008_alter_dashboard_organization.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+def delete_orphan_dashboards(apps, schema_editor):
+    Dashboard = apps.get_model("crisis_room", "Dashboard")
+    Dashboard.objects.filter(organization__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("crisis_room", "0007_alter_dashboarditem_source"),
+        ("tools", "0047_alter_organization_code_alter_organization_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_orphan_dashboards, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="dashboard",
+            name="organization",
+            field=models.ForeignKey(
+                null=True, on_delete=models.CASCADE, to="tools.organization"
+            ),
+        ),
+    ]

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -17,7 +17,7 @@ logger = structlog.get_logger(__name__)
 
 class Dashboard(models.Model):
     name = models.CharField(blank=False, max_length=126)
-    organization = models.ForeignKey(Organization, on_delete=models.SET_NULL, null=True)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 


### PR DESCRIPTION
### Changes

`Dashboard.organization` uses `on_delete=SET_NULL`, so deleting an organization leaves orphan dashboards and items. The crisis room then 500s on `dashboard.organization.code` (the surface PR #5146 patches defensively in the view). This is the storage-side root-cause fix per Option A in the issue: switch the FK to `CASCADE` and clean up any pre-existing orphans in the same migration. Complementary to #5146, not a replacement.

### Issue link

Closes #5140.

### QA notes

1. On main, create an organization and delete it via the API or admin; visit `/nl/crisis-room/` to reproduce the `AttributeError`.
2. Apply this branch and run `python manage.py migrate` in `rocky/`. Existing orphan dashboards are removed by the data migration.
3. Repeat the create/delete cycle; the crisis room loads cleanly. Verify `crisis_room_dashboard` rows are gone for the deleted org's id.

---

### Code Checklist

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.