### PR TITLE
crisis_room: fix 500 after organization deletion (view guard + cascade delete)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ write_to = "_version.py"
 
 [tool.vulture]
 min_confidence = 90
-exclude = ["/tests/", "*venv*", "rocky/tools/migrations"]
+exclude = ["/tests/", "*venv*", "rocky/tools/migrations", "rocky/crisis_room/migrations"]
 paths = ["."]
 
 [tool.ruff]

--- a/rocky/crisis_room/migrations/0008_alter_dashboard_organization.py
+++ b/rocky/crisis_room/migrations/0008_alter_dashboard_organization.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+def delete_orphan_dashboards(apps, schema_editor):
+    Dashboard = apps.get_model("crisis_room", "Dashboard")
+    Dashboard.objects.filter(organization__isnull=True).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("crisis_room", "0007_alter_dashboarditem_source"),
+        ("tools", "0047_alter_organization_code_alter_organization_name"),
+    ]
+
+    operations = [
+        migrations.RunPython(delete_orphan_dashboards, migrations.RunPython.noop),
+        migrations.AlterField(
+            model_name="dashboard",
+            name="organization",
+            field=models.ForeignKey(null=True, on_delete=models.CASCADE, to="tools.organization"),
+        ),
+    ]

--- a/rocky/crisis_room/models.py
+++ b/rocky/crisis_room/models.py
@@ -17,7 +17,7 @@ logger = structlog.get_logger(__name__)
 
 class Dashboard(models.Model):
     name = models.CharField(blank=False, max_length=126)
-    organization = models.ForeignKey(Organization, on_delete=models.SET_NULL, null=True)
+    organization = models.ForeignKey(Organization, on_delete=models.CASCADE, null=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
 

--- a/rocky/crisis_room/views.py
+++ b/rocky/crisis_room/views.py
@@ -106,6 +106,12 @@ class DashboardService:
 
         # First collect al data, if recipe id is found then fetch recipe ids to get reports later.
         for dashboard_item in dashboard_items:
+            # Dashboard.organization is nullable. Organization deletion now
+            # cascades (migration 0008), but a dashboard without organization
+            # would crash every downstream branch on
+            # `dashboard.organization.code`, so skip them defensively (#5140).
+            if dashboard_item.dashboard.organization is None:
+                continue
             if not dashboard_item.recipe and dashboard_item.source == "object_list":
                 item_data = DashboardItemView(dashboard_item, self.get_ooi_list(dashboard_item))
                 dashboard_items_with_data.append(item_data)


### PR DESCRIPTION
### Changes

Combines #5146 and #5148 by @SAY-5 into one signed PR — all credit for the analysis and the fixes goes to SAY-5; the original PRs could not be merged because the commits were not PGP-signed (and SAY-5 has been unresponsive since). The original commits are cherry-picked with **SAY-5 preserved as author**, signed by the committer.

Two complementary fixes for the crisis room 500 after deleting an organization:

1. **View guard** (from #5146): `get_dashboard_items` skips dashboard items whose dashboard has no organization, since every downstream branch dereferences `dashboard.organization.code`. The guard comment is updated to reflect the combined state (cascade is now the rule, the guard is defense-in-depth for the nullable FK).
2. **Root cause** (from #5148): `Dashboard.organization` FK switches from `SET_NULL` to `CASCADE`, with a data migration (`crisis_room 0008`) that removes any pre-existing orphan dashboards. Jan confirmed this direction in https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/pull/5148#issuecomment-4378102967; SAY-5 traced the original `SET_NULL` back to #4007.

On top of the cherry-picks: one housekeeping commit adding `rocky/crisis_room/migrations` to the vulture exclude list (this is the first data migration in that app; `tools/migrations` is already excluded for the same `(apps, schema_editor)` signature reason).

### Issue link

Closes #5140. Supersedes #5146 and #5148.

### QA notes

Verified on a fresh `make kat` stack:
- `showmigrations crisis_room` → 0008 applied
- Create org → "Findings Dashboard" created → delete org → dashboard + items cascade-deleted (audit log shows the cascade events), zero orphans left
- Manually created orphan dashboard (`organization=None`) + item → `DashboardService.get_dashboard_items` returns cleanly instead of raising `AttributeError`
- `rocky make utest`: 470 passed; `pre-commit` green on the diff

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made. *(carried over from the original PRs; the QA scenario above covers the behaviour)*
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.