### PR TITLE
Chore/add debian13 ubuntu24.04 build image

### DIFF
--- a/.github/workflows/build-debian-docker-image.yml
+++ b/.github/workflows/build-debian-docker-image.yml
@@ -20,7 +20,7 @@ jobs:
   build-debian-image:
     strategy:
       matrix:
-        dist: [debian12, ubuntu22.04]
+        dist: [debian12, debian13, ubuntu22.04, ubuntu24.04]
     runs-on: ubuntu-24.04
     permissions:
       contents: read

--- a/packaging/debian13/Dockerfile
+++ b/packaging/debian13/Dockerfile
@@ -1,0 +1,20 @@
+FROM debian:trixie
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+ARG NODE_VERSION=20.11.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates xz-utils
+RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
+ | tar -xJ -C /usr/local --strip-components=1
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install -y --no-install-recommends \
+    gettext devscripts debhelper equivs \
+    python3-setuptools python3-pip python3-dev \
+    dh-sequence-python3 pybuild-plugin-pyproject python3-poetry \
+    libssl-dev dh-virtualenv libpq-dev libssl-dev \
+    build-essential nodejs git openssh-client \
+    libfreetype-dev zlib1g-dev libjpeg-dev libffi-dev
+RUN corepack enable

--- a/packaging/debian13/Dockerfile
+++ b/packaging/debian13/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get -y upgrade && \
     gettext devscripts debhelper equivs \
     python3-setuptools python3-pip python3-dev \
     dh-sequence-python3 pybuild-plugin-pyproject python3-poetry \
-    libssl-dev dh-virtualenv libpq-dev libssl-dev \
+    dh-virtualenv libpq-dev libssl-dev \
     build-essential nodejs git openssh-client \
     libfreetype-dev zlib1g-dev libjpeg-dev libffi-dev
 RUN corepack enable

--- a/packaging/ubuntu24.04/Dockerfile
+++ b/packaging/ubuntu24.04/Dockerfile
@@ -1,0 +1,19 @@
+FROM ubuntu:24.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+SHELL ["/bin/bash", "-c"]
+ARG NODE_VERSION=20.11.1
+
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates xz-utils
+RUN curl -fsSL https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz \
+ | tar -xJ -C /usr/local --strip-components=1
+
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install -y --no-install-recommends \
+    gettext devscripts debhelper equivs \
+    python3-setuptools python3-pip python3-dev \
+    libssl-dev dh-virtualenv libpq-dev libssl-dev \
+    build-essential nodejs git openssh-client \
+    libfreetype-dev zlib1g-dev libjpeg-dev libffi-dev
+RUN corepack enable

--- a/packaging/ubuntu24.04/Dockerfile
+++ b/packaging/ubuntu24.04/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y --no-install-recommends \
     gettext devscripts debhelper equivs \
     python3-setuptools python3-pip python3-dev \
-    libssl-dev dh-virtualenv libpq-dev libssl-dev \
+    dh-virtualenv libpq-dev libssl-dev \
     build-essential nodejs git openssh-client \
     libfreetype-dev zlib1g-dev libjpeg-dev libffi-dev
 RUN corepack enable


### PR DESCRIPTION
### Changes

This creates the Docker images used to build the venvs when creating our debian 13 and ubuntu24.04 deb files as required for https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/pull/5179

### Issue link

closes #5194 

Once merged, https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/pull/5179 should be able to build using these containers tagged as latest.