### PR TITLE
Fix get_tree(search_types) dropping findings on descendant OOIs

### DIFF
--- a/octopoes/octopoes/repositories/ooi_repository.py
+++ b/octopoes/octopoes/repositories/ooi_repository.py
@@ -582,6 +582,15 @@ class XTDBOOIRepository(OOIRepository):
             reference_node = results[0]
         except IndexError:
             raise ObjectNotFoundException(str(reference))
+
+        # _get_tree_level keeps intermediate levels unfiltered to preserve the path to
+        # descendant matches. Re-apply a path-preserving filter here so a branch survives only
+        # if it (or one of its descendants) is of a requested type - restoring the pre-#5088
+        # filter_children semantics for both the OOI-detail tree view and findings collection.
+        if search_types:
+            search_type_names = {search_type.__name__ for search_type in search_types}
+            reference_node.filter_children(lambda node: node.reference.class_ in search_type_names)
+
         store = self.load_bulk(reference_node.collect_references(), valid_time, include_scan_levels=include_scan_levels)
         return ReferenceTree(root=reference_node, store=store)
 
@@ -615,8 +624,16 @@ class XTDBOOIRepository(OOIRepository):
         if exclude is None:
             exclude = set()
 
+        # Only prune the traversal by search_types on the deepest level (the largest fan-out).
+        # search_types prunes incoming/outgoing relations *during* construction, so applying it on
+        # intermediate levels destroys the path to findings attached to descendant OOIs (e.g.
+        # Hostname -> Website -> HTTPResource -> HTTPHeader -> Finding), the regression from #5088.
+        # Keeping intermediate levels unfiltered preserves the path; get_tree() then re-applies a
+        # path-preserving filter so branches that never reach a search_type are dropped.
+        level_search_types = search_types if depth == 1 else None
+
         # Query 1-depth related objects
-        reference_nodes = self._get_related_objects(references, valid_time=valid_time, search_types=search_types)
+        reference_nodes = self._get_related_objects(references, valid_time=valid_time, search_types=level_search_types)
 
         # Filter exclusions from results
         for reference_node in reference_nodes:

--- a/octopoes/octopoes/xtdb/related_field_generator.py
+++ b/octopoes/octopoes/xtdb/related_field_generator.py
@@ -59,7 +59,7 @@ class RelatedFieldNode:
         if depth > 0:
             self.construct_outgoing_relations(search_types)
             for child_node in self.relations_out.values():
-                child_node.build_tree(depth - 1)
+                child_node.build_tree(depth - 1, search_types)
 
             self.construct_incoming_relations(search_types)
             for child_node in self.relations_in.values():

--- a/octopoes/tests/integration/test_ooi_repository.py
+++ b/octopoes/tests/integration/test_ooi_repository.py
@@ -4,8 +4,9 @@ from datetime import datetime
 import pytest
 
 from octopoes.models import DeclaredScanProfile, ScanLevel
-from octopoes.models.ooi.dns.zone import Hostname
-from octopoes.models.ooi.network import Network
+from octopoes.models.ooi.dns.zone import Hostname, ResolvedHostname
+from octopoes.models.ooi.findings import Finding, KATFindingType
+from octopoes.models.ooi.network import IPAddressV4, Network
 from octopoes.models.pagination import Paginated
 from octopoes.models.path import Path
 from octopoes.repositories.ooi_repository import XTDBOOIRepository
@@ -71,6 +72,34 @@ def test_load_bulk(
     assert networks[network.reference].scan_profile is not None
     assert networks[network2.reference].scan_profile is not None
     assert networks[network3.reference].scan_profile is not None
+
+
+def test_get_tree_search_types_returns_descendant_findings(
+    xtdb_ooi_repository: XTDBOOIRepository, valid_time: datetime
+):
+    """Regression test for #5202: get_tree(search_types={Finding}) must return findings attached to
+    descendant OOIs, not only findings directly on the root. #5088 pruned the traversal by the leaf
+    type, which destroyed the path to deep findings (e.g. a CVE on an HTTPHeader several hops down)."""
+    network = Network(name="test")
+    hostname = Hostname(network=network.reference, name="example.com")
+    address = IPAddressV4(network=network.reference, address="192.0.2.1")
+    # Hostname <- ResolvedHostname -> IPAddressV4, so the address is two hops from the hostname.
+    resolved = ResolvedHostname(hostname=hostname.reference, address=address.reference)
+    finding_type = KATFindingType(id="KAT-DEEP-FINDING")
+    # A finding three hops down from the hostname (Hostname <- ResolvedHostname -> IPAddressV4 <- Finding)
+    deep_finding = Finding(ooi=address.reference, finding_type=finding_type.reference)
+    # And a finding directly on the hostname, to confirm direct findings still come through.
+    direct_finding = Finding(ooi=hostname.reference, finding_type=finding_type.reference)
+
+    for ooi in [network, hostname, address, resolved, finding_type, deep_finding, direct_finding]:
+        xtdb_ooi_repository.save(ooi, valid_time)
+    xtdb_ooi_repository.session.commit()
+
+    tree = xtdb_ooi_repository.get_tree(hostname.reference, valid_time, search_types={Finding}, depth=5)
+
+    finding_references = {ref for ref, ooi in tree.store.items() if ooi.ooi_type == "Finding"}
+    assert str(direct_finding.reference) in finding_references
+    assert str(deep_finding.reference) in finding_references
 
 
 def test_complex_query(xtdb_ooi_repository: XTDBOOIRepository, valid_time: datetime):


### PR DESCRIPTION
### Changes

This is **part B** of the #5202 fix (the `get_tree(search_types=...)` correctness fix, per the split agreed with @underdarknl in the issue). It restores retrieval of findings attached to **descendant** OOIs — e.g. a CVE on an `HTTPHeader` several hops below the input OOI — which #5088 silently dropped.

#5088 changed `get_tree(types=...)` from *build-full-tree-then-`filter_children`* (path-preserving) to *prune-during-traversal* in `RelatedFieldNode.construct_incoming/outgoing_relations`. Because `Finding`s are graph leaves, restricting the traversal to `Finding`-typed edges prunes every intermediate relation at the root (`Website`, `ResolvedHostname`, …), so the walk never descends `Hostname → Website → HTTPResource → HTTPHeader → Finding`. The report then only ever sees findings attached directly to the input OOI.

This implements @underdarknl's **B**: filter only on the last step's query, then restore path-preserving semantics.

- `_get_tree_level` now applies `search_types` **only on the deepest level** (`depth == 1`, the largest fan-out). Intermediate levels stay unfiltered so the path down to the matching leaves is preserved.
- `get_tree` re-applies a **path-preserving** filter via the existing `ReferenceNode.filter_children`, so branches that never reach a `search_type` are still dropped — restoring the pre-#5088 semantics for both the OOI-detail tree view and findings collection.
- `RelatedFieldNode.build_tree` now passes `search_types` to outgoing children too (latent in/out inconsistency).

The dedicated recursive "all findings under an OOI" query for the report callers is **part C** and will follow as a separate PR, as agreed in the issue. This PR is the correctness unblocker.

### Issue link

Closes #5202
Also fixes #5192 (Crisis room findings overview shows 0) — verified same root cause.

### QA notes

1. On a host whose webserver returns `Server: Apache/2.4.49`, let the bits create the CVE-2021-41773 `Finding` on the `HTTPHeader`.
2. Generate a **Findings Report** (or Aggregate report) for that hostname — the CVE and other web/port/cert findings now appear, not just findings directly on the hostname.
3. Check the **Crisis room** findings overview shows the correct non-zero counts.

Automated coverage: new integration regression test `test_get_tree_search_types_returns_descendant_findings` (Octopoes) builds `Hostname ← ResolvedHostname → IPAddressV4 ← Finding` and asserts `get_tree(search_types={Finding}, depth=5)` returns the finding three hops down. Confirmed RED on the pre-fix code and GREEN with the fix. Full Octopoes suite (140 unit + 37 integration) passes locally.

---

### Code Checklist

- [x] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

- [x] Tickets have been created for newly discovered issues.
- [x] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [x] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.