### PR TITLE
Remove duplicate mime-type append in Bytes create_raw

### DIFF
--- a/bytes/bytes/api/router.py
+++ b/bytes/bytes/api/router.py
@@ -210,8 +210,6 @@ async def create_raw(
             logger.exception("Error saving raw data")
             raise HTTPException(status_code=codes.INTERNAL_SERVER_ERROR, detail="Could not save raw data") from error
 
-        all_parsed_mime_types.append(parsed_mime_types)
-
     return raw_ids
 
 


### PR DESCRIPTION
### Changes

`POST /bytes/raw` (`bytes/bytes/api/router.py::create_raw`) appended each saved file's mime-type set to `all_parsed_mime_types` **twice**: once inside the `try` block right after `save_raw`, and once again after the `try/except`. Both statements were introduced together in #3476 (multi-file upload), so this looks like an editing leftover rather than intent.

This PR removes the second append and keeps the one adjacent to `save_raw`, so the dedup list stays correct even if the publish step ever becomes non-fatal.

**Impact:** no behavior change — the list is only used for the `in` membership check that rejects non-unique mime-type sets within a batch, and duplicates don't affect membership. It's purely a correctness-of-intent/readability fix (and the list no longer grows 2× per uploaded file).

### Issue link

No issue; spotted during a code survey of the Bytes API. Introduced in #3476.

### QA notes

- `cd bytes && make utest` — 9 passed, 1 skipped
- `cd bytes && make itest` — 29 passed, 1 skipped (includes `test_bytes_api.py`, which covers the multi-file upload and duplicate-mime-type rejection paths)
- `pre-commit run` on the changed file — clean

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.