### PR TITLE
Add integration tests for scheduler bounded/partial counts

### DIFF
--- a/mula/tests/integration/test_api.py
+++ b/mula/tests/integration/test_api.py
@@ -629,6 +629,30 @@ class APITasksEndpointTestCase(APITemplateTestCase):
         self.assertEqual(2, response.json()["count"])
         self.assertEqual(2, len(response.json()["results"]))
 
+    def test_get_tasks_bounded_partial_count(self):
+        # With a real count (2) below the cap the response count is exact and not flagged partial.
+        response = self.client.get("/tasks?limit=10&allow_partial_count=true")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, response.json()["count"])
+        self.assertFalse(response.json()["is_partial_count"])
+
+        # max_count = offset(0) + max_pages(1) * limit(1) + 1 = 2, real count 2 >= 2 -> partial.
+        response = self.client.get("/tasks?limit=1&max_pages=1&allow_partial_count=true")
+        self.assertEqual(200, response.status_code)
+        self.assertEqual(2, response.json()["count"])
+        self.assertTrue(response.json()["is_partial_count"])
+
+    def test_get_tasks_stats_filtered_by_organisation_ids(self):
+        # organisation_ids must bind as a query parameter (fastapi.Query), not a request body,
+        # so a matching org returns the two setUp tasks and a non-matching org returns none.
+        matching = self.client.get(f"/tasks/stats?organisation_ids={self.organisation.id}")
+        self.assertEqual(200, matching.status_code)
+        self.assertEqual(2, sum(hour.get("total", 0) for hour in matching.json().values()))
+
+        other = self.client.get("/tasks/stats?organisation_ids=non-existent-org")
+        self.assertEqual(200, other.status_code)
+        self.assertEqual(0, sum(hour.get("total", 0) for hour in (other.json() or {}).values()))
+
     def test_get_task(self):
         # First add a task
         item = create_task_push_dict(1, self.organisation.id)

--- a/mula/tests/integration/test_schedule_store.py
+++ b/mula/tests/integration/test_schedule_store.py
@@ -120,6 +120,83 @@ class ScheduleStoreTestCase(unittest.TestCase):
         self.assertEqual(5, len(schedules_scheduler_two))
         self.assertEqual(5, schedules_scheduler_two_count)
 
+    def _create_schedules(self, amount: int, scheduler_id: str = "test_scheduler_id"):
+        for _ in range(amount):
+            task = functions.create_task(scheduler_id=scheduler_id, organisation=self.organisation.id, priority=1)
+            schedule = models.Schedule(
+                scheduler_id=scheduler_id, organisation=self.organisation.id, hash=task.hash, data=task.model_dump()
+            )
+            self.mock_ctx.datastores.schedule_store.create_schedule(schedule)
+
+    def test_get_schedules_bounded_count_below_cap(self):
+        # Arrange
+        self._create_schedules(3)
+
+        # Act: max_count = offset(0) + max_pages(6) * limit(2) + 1 = 13, real count 3 < 13
+        schedules, count, is_partial_count = self.mock_ctx.datastores.schedule_store.get_schedules(
+            limit=2, max_pages=6, allow_partial_count=True
+        )
+
+        # Assert
+        self.assertEqual(count, 3)
+        self.assertFalse(is_partial_count)
+        self.assertEqual(len(schedules), 2)
+
+    def test_get_schedules_bounded_count_at_cap(self):
+        # Arrange
+        self._create_schedules(10)
+
+        # Act: max_count = offset(0) + max_pages(2) * limit(2) + 1 = 5, real count 10 >= 5
+        schedules, count, is_partial_count = self.mock_ctx.datastores.schedule_store.get_schedules(
+            limit=2, max_pages=2, allow_partial_count=True
+        )
+
+        # Assert
+        self.assertEqual(count, 5)
+        self.assertTrue(is_partial_count)
+        self.assertEqual(len(schedules), 2)
+
+    def test_get_schedules_bounded_count_without_filter(self):
+        # Arrange
+        self._create_schedules(3)
+
+        # Act: no filters means no WHERE clause; the bounded count must project a real column
+        # so the FROM clause survives (a bare SELECT 1 collapses the count to 1)
+        schedules, count, is_partial_count = self.mock_ctx.datastores.schedule_store.get_schedules(
+            limit=150, allow_partial_count=True
+        )
+
+        # Assert
+        self.assertEqual(count, 3)
+        self.assertFalse(is_partial_count)
+
+    def test_get_schedules_limit_zero_returns_full_count(self):
+        # Arrange
+        self._create_schedules(4)
+
+        # Act: limit=0 is the count-probe idiom; no bounded query is possible without a page size
+        schedules, count, is_partial_count = self.mock_ctx.datastores.schedule_store.get_schedules(
+            limit=0, max_pages=1, allow_partial_count=True
+        )
+
+        # Assert
+        self.assertEqual(count, 4)
+        self.assertFalse(is_partial_count)
+        self.assertEqual(len(schedules), 0)
+
+    def test_get_schedules_allow_partial_count_false_is_exact(self):
+        # Arrange
+        self._create_schedules(10)
+
+        # Act: without allow_partial_count the count is always exact, even past the cap
+        schedules, count, is_partial_count = self.mock_ctx.datastores.schedule_store.get_schedules(
+            limit=2, max_pages=2, allow_partial_count=False
+        )
+
+        # Assert
+        self.assertEqual(count, 10)
+        self.assertFalse(is_partial_count)
+
     def test_get_schedule(self):
         # Arrange
         scheduler_id = "test_scheduler_id"

--- a/mula/tests/integration/test_task_store.py
+++ b/mula/tests/integration/test_task_store.py
@@ -231,3 +231,106 @@ class StoreTestCase(unittest.TestCase):
         self.assertEqual(results.get(keys[1]).get("total"), 2)
         self.assertEqual(results.get(keys[2]).get("dispatched"), 2)
         self.assertEqual(results.get(keys[2]).get("total"), 2)
+
+    def test_get_tasks_bounded_count_below_cap(self):
+        # Arrange
+        for _ in range(3):
+            task = functions.create_task(scheduler_id=self.organisation.id, organisation=self.organisation.id)
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act: max_count = offset(0) + max_pages(6) * limit(2) + 1 = 13, real count 3 < 13
+        tasks, count, is_partial_count = self.mock_ctx.datastores.task_store.get_tasks(
+            scheduler_id=self.organisation.id, limit=2, max_pages=6, allow_partial_count=True
+        )
+
+        # Assert: below the cap the count is exact and not flagged partial
+        self.assertEqual(count, 3)
+        self.assertFalse(is_partial_count)
+        self.assertEqual(len(tasks), 2)
+
+    def test_get_tasks_bounded_count_at_cap(self):
+        # Arrange
+        for _ in range(10):
+            task = functions.create_task(scheduler_id=self.organisation.id, organisation=self.organisation.id)
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act: max_count = offset(0) + max_pages(2) * limit(2) + 1 = 5, real count 10 >= 5
+        tasks, count, is_partial_count = self.mock_ctx.datastores.task_store.get_tasks(
+            scheduler_id=self.organisation.id, limit=2, max_pages=2, allow_partial_count=True
+        )
+
+        # Assert: at/above the cap the count is the bounded max_count and flagged partial
+        self.assertEqual(count, 5)
+        self.assertTrue(is_partial_count)
+        self.assertEqual(len(tasks), 2)
+
+    def test_get_tasks_bounded_count_without_filter(self):
+        # Arrange
+        for _ in range(3):
+            task = functions.create_task(scheduler_id=self.organisation.id, organisation=self.organisation.id)
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act: no filters means the query has no WHERE clause; the bounded count must still
+        # project a real column so the FROM clause survives (a bare SELECT 1 collapses to count 1)
+        tasks, count, is_partial_count = self.mock_ctx.datastores.task_store.get_tasks(
+            limit=150, allow_partial_count=True
+        )
+
+        # Assert
+        self.assertEqual(count, 3)
+        self.assertFalse(is_partial_count)
+
+    def test_get_tasks_limit_zero_returns_full_count(self):
+        # Arrange
+        for _ in range(4):
+            task = functions.create_task(scheduler_id=self.organisation.id, organisation=self.organisation.id)
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act: limit=0 is the count-probe idiom; page size is unknown so no bounded query is possible
+        tasks, count, is_partial_count = self.mock_ctx.datastores.task_store.get_tasks(
+            scheduler_id=self.organisation.id, limit=0, max_pages=1, allow_partial_count=True
+        )
+
+        # Assert: exact count, no results, never partial
+        self.assertEqual(count, 4)
+        self.assertFalse(is_partial_count)
+        self.assertEqual(len(tasks), 0)
+
+    def test_get_tasks_allow_partial_count_false_is_exact(self):
+        # Arrange
+        for _ in range(10):
+            task = functions.create_task(scheduler_id=self.organisation.id, organisation=self.organisation.id)
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act: without allow_partial_count the count is always exact, even past the cap
+        tasks, count, is_partial_count = self.mock_ctx.datastores.task_store.get_tasks(
+            scheduler_id=self.organisation.id, limit=2, max_pages=2, allow_partial_count=False
+        )
+
+        # Assert
+        self.assertEqual(count, 10)
+        self.assertFalse(is_partial_count)
+
+    def test_get_status_counts_filtered_by_organisation_ids(self):
+        # Arrange: two tasks for our organisation, one for another
+        other = OrganisationFactory()
+        for org in (self.organisation.id, self.organisation.id, other.id):
+            data = functions.create_test_model()
+            task = models.Task(
+                scheduler_id=self.organisation.id,
+                organisation=org,
+                priority=1,
+                status=models.TaskStatus.COMPLETED,
+                type=functions.TestModel.type,
+                hash=data.hash,
+                data=data.model_dump(),
+            )
+            self.mock_ctx.datastores.task_store.create_task(task)
+
+        # Act
+        only_first = self.mock_ctx.datastores.task_store.get_status_counts(organisation_ids=[self.organisation.id])
+        both = self.mock_ctx.datastores.task_store.get_status_counts(organisation_ids=[self.organisation.id, other.id])
+
+        # Assert: the IN filter scopes the counts to the requested organisations
+        self.assertEqual(only_first[models.TaskStatus.COMPLETED.value], 2)
+        self.assertEqual(both[models.TaskStatus.COMPLETED.value], 3)


### PR DESCRIPTION
### Changes

Follow-up to #5166, which added `allow_partial_count` / `max_pages` bounded counts to the scheduler `/tasks` and `/schedules` endpoints. #5166 shipped without unit tests for the new logic; these are the store- and API-level integration tests that cover it.

The bounded-count logic has subtle behaviour that is easy to regress (it went through several revisions during review of #5166 for exactly these cases):

- `max_count = offset + (max_pages * limit) + 1`, with `is_partial_count = count == max_count` as the sentinel;
- the bounded query must project a **real column** (`with_entities(models.TaskDB.id)` / `models.ScheduleDB.id`) so the FROM clause survives when the query has no WHERE — a bare `literal(1)` collapses the count to 1;
- `limit == 0` is the count-probe idiom and must return the exact count (no page size → no bounded query possible);
- `organisation_ids` on `/tasks/stats` must bind as a `fastapi.Query` list, not a request body.

### Tests added

**`TaskStore` / `ScheduleStore`** (`tests/integration/test_task_store.py`, `test_schedule_store.py`):
- below-cap → exact count, `is_partial_count=False`
- at-cap → count equals `max_count`, `is_partial_count=True`
- **no-filter** bounded count → equals the real total (regression guard for the FROM-clause loss)
- `limit=0` count-probe → exact count, empty results
- `allow_partial_count=False` → exact count even past the cap (regression guard)
- `get_status_counts(organisation_ids=[...])` → `IN` filter scopes counts to the requested orgs

**API** (`tests/integration/test_api.py`):
- `/tasks?allow_partial_count=true` exposes `is_partial_count` (exact below cap, partial at cap)
- `/tasks/stats?organisation_ids=…` filters by org (guards the query-param vs request-body binding)

### Test results

`cd mula && make itest` → **211 passed, 3 skipped, 2 failed**. The 2 failures are the pre-existing `KatalogusTestCase` local Docker DNS-race (`test_get_new_boefjes_by_org_id`, `test_new_boefjes_cache_thread_safety`), documented across the #5166 and #5165 reviews and unrelated to these tests — all 13 new tests pass. `pre-commit run --files …` is green.

### Issue link

Follow-up to #5166 (test coverage only; no runtime code changes).

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.