### PR TITLE
Make the boefje crash when it sees an exception, instead of returning a non usefull mimetype

### DIFF
--- a/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
+++ b/boefjes/boefjes/plugins/kat_webpage_analysis/main.py
@@ -43,10 +43,7 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
             uri = urlunsplit([url_parts.scheme, url_parts.netloc, url_parts.path, url_parts.query, url_parts.fragment])
 
     body_mimetypes = {"openkat-http/body"}
-    try:
-        response = do_request(hostname, session, uri, useragent)
-    except requests.exceptions.RequestException as request_error:
-        return [({"openkat-http/error"}, str(request_error))]
+    response = do_request(hostname, session, uri, useragent)
 
     if "content-type" in response.headers:
         content_type = response.headers["content-type"]


### PR DESCRIPTION
When the boefje webpageanalysis for example times out, it captures the exception and returns a nonsensical mimetype not understood by the scheduler as being an error.


### Changes
Remove the try except, allowing the python exception to bubble up and trigger the regular error flow.

### Issue link

Closes ...

### Demo

_Please add some proof in the form of screenshots or screen recordings to show (off) new functionality, if there are interesting new features for end-users._

### QA notes

_Please add some information for QA on how to test the newly created code._

---

### Code Checklist

<!--- Mandatory: --->

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [ ] This PR only contains functionality relevant to the issue.
- [ ] I have written unit tests for the changes or fixes I made.
- [ ] I have checked the documentation and made changes where necessary.
- [ ] I have performed a self-review of my code and refactored it to the best of my abilities.

<!--- If applicable: --->

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [ ] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the docs/source/developer-documentation/contributor/templates folder](https://github.com/minvws/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
