### PR TITLE
Allow superusers to promote accounts in Rocky

### DIFF
--- a/docs/source/installation-and-deployment/events-and-logging.rst
+++ b/docs/source/installation-and-deployment/events-and-logging.rst
@@ -60,6 +60,7 @@ Event code Model              Routing key            Description                
 900110     KATUser            account_change         A user is deleted.                          D
 900111     TOTPDevice         account_change         2FA is removed.                             D
 900112     TOTPDevice         account_change         2FA is updated.                             U
+900113     KATUser            account_change         Superuser access is granted.                U
 900201     Organization       organization_change    A new organization is created.              C
 900202     Organization       organization_change    Organization information changed.           U
 900203     Organization       organization_change    Organization is removed.                    D

--- a/docs/source/installation-and-deployment/users-and-organizations.rst
+++ b/docs/source/installation-and-deployment/users-and-organizations.rst
@@ -17,6 +17,10 @@ Users
 
 OpenKAT knows four types of users: the client, the red team user, the admin and the superuser. In OpenKAT, permissions utilise a stacked model. This means that a higher permission level includes all lower permissions of the lower levels. The client is a 'read only' type of user, the red teamer is a researcher who can start scans. The admin is an administrative user who can do user management etc, the superuser has the ability to do everything.
 
+Superuser access is global and applies to every organization in an OpenKAT installation. An existing superuser can grant this access to another active account by opening the organization's member overview, editing the member, and selecting ``Grant superuser access`` under ``Global account access``. Rocky shows the installation-wide impact for confirmation before applying the change. Organization admins and other account types cannot grant superuser access.
+
+Rocky cannot revoke superuser access. To revoke it, open the account under :guilabel:`Accounts` > :guilabel:`Users` in Django administration, clear both :guilabel:`Superuser status` and :guilabel:`Staff status`, and save the account.
+
 Rights and functions per user type
 ----------------------------------
 

--- a/rocky/rocky/locale/django.pot
+++ b/rocky/rocky/locale/django.pot
@@ -9,7 +9,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-03-28 14:22+0000\n"
+"POT-Creation-Date: 2026-07-24 20:14+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -589,6 +589,7 @@ msgstr ""
 #: rocky/templates/oois/ooi_mute_finding.html
 #: rocky/templates/organizations/organization_edit.html
 #: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
 #: rocky/templates/partials/delete_ooi_modal.html
 #: rocky/templates/partials/edit_ooi_clearance_level_modal.html
 #: rocky/templates/partials/mute_findings_modal.html
@@ -1662,7 +1663,7 @@ msgstr ""
 msgid "Latest plugin settings"
 msgstr ""
 
-#: katalogus/templates/katalogus_settings.html
+#: katalogus/templates/katalogus_settings.html tools/forms/scheduler.py
 #: rocky/templates/tasks/ooi_detail_task_list.html
 msgid "Plugin"
 msgstr ""
@@ -4868,7 +4869,7 @@ msgstr ""
 msgid "Filter by muted findings"
 msgstr ""
 
-#: tools/forms/findings.py tools/forms/ooi_form.py tools/forms/scheduler.py
+#: tools/forms/findings.py tools/forms/ooi_form.py
 msgid "Search"
 msgstr ""
 
@@ -4961,11 +4962,45 @@ msgid "Running"
 msgstr ""
 
 #: tools/forms/scheduler.py
+msgid "Search (in OOI)"
+msgstr ""
+
+#: tools/forms/scheduler.py
 msgid "Search by object name"
 msgstr ""
 
 #: tools/forms/scheduler.py
-msgid "The selected date is in the future. Please select a different date."
+msgid "Input OOI"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Select specific object"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Search by plugin"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Task id"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "Search by task ID"
+msgstr ""
+
+#: tools/forms/scheduler.py
+#, python-format
+msgid ""
+"The selected date (%s) is in the future. Please select a different date."
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "'from'"
+msgstr ""
+
+#: tools/forms/scheduler.py
+msgid "'to'"
 msgstr ""
 
 #: tools/forms/settings.py
@@ -5187,6 +5222,7 @@ msgstr ""
 #: tools/view_helpers.py rocky/templates/header.html
 #: rocky/templates/organizations/organization_member_list.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Members"
 msgstr ""
 
@@ -6209,11 +6245,57 @@ msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 #: rocky/views/organization_member_edit.py
+#: rocky/views/organization_member_superuser.py
 msgid "Edit member"
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_edit.html
 msgid "Save member"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid "Global account access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+msgid ""
+"Superuser access applies to every organization and all administrative "
+"functionality in this OpenKAT installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_edit.html
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#: rocky/views/organization_member_superuser.py
+msgid "Grant superuser access"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+#, python-format
+msgid ""
+"You are about to grant <strong>%(email)s</strong> unrestricted access to "
+"every organization and all administrative functionality in this OpenKAT "
+"installation."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "This is a global account permission, not an organization role."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Rocky cannot revoke this permission. To revoke it, open this account under "
+"Accounts > Users in Django administration, clear both Superuser status and "
+"Staff status, and save."
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid "Open this account in Django administration"
+msgstr ""
+
+#: rocky/templates/organizations/organization_member_grant_superuser.html
+msgid ""
+"Only continue when this person is authorized to administer the entire "
+"installation."
 msgstr ""
 
 #: rocky/templates/organizations/organization_member_list.html
@@ -6808,6 +6890,30 @@ msgstr ""
 msgid "Modified date"
 msgstr ""
 
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Filter on this plugin"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Add filter on this plugin"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/partials/stats.html
+msgid "Filter on this status"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/partials/stats.html
+msgid "Add filter on this status"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Filter on this ooi"
+msgstr ""
+
+#: rocky/templates/tasks/boefjes.html rocky/templates/tasks/normalizers.html
+msgid "Add filter on this ooi"
+msgstr ""
+
 #: rocky/templates/tasks/normalizers.html
 msgid "There are no tasks for normalizers."
 msgstr ""
@@ -6853,15 +6959,39 @@ msgid "Loading..."
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
+msgid "Normalizer task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Processing input from Boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Consuming Raw file"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
 msgid "Yielded objects"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
-msgid "Yielded raw files"
+msgid "Yielded raw files for task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Origin boefje task"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "See all similar tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
 msgid "Reschedule"
+msgstr ""
+
+#: rocky/templates/tasks/partials/task_actions.html
+msgid "Related Normalizer tasks"
 msgstr ""
 
 #: rocky/templates/tasks/partials/task_actions.html
@@ -7155,6 +7285,10 @@ msgid "Upload raw"
 msgstr ""
 
 #: rocky/views/bytes_raw.py
+msgid "Getting raw data failed, No such meta."
+msgstr ""
+
+#: rocky/views/bytes_raw.py
 msgid "Getting raw data failed."
 msgstr ""
 
@@ -7432,6 +7566,21 @@ msgstr ""
 msgid "Unblocked member %s successfully."
 msgstr ""
 
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s is inactive and cannot be granted superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "%(email)s already has superuser access."
+msgstr ""
+
+#: rocky/views/organization_member_superuser.py
+#, python-format
+msgid "Superuser access granted to %(email)s."
+msgstr ""
+
 #: rocky/views/organization_settings.py
 #, python-brace-format
 msgid "Recalculated {number_of_bits} bits. Duration: {duration}"
@@ -7451,14 +7600,14 @@ msgid "Scans"
 msgstr ""
 
 #: rocky/views/scheduler.py
-msgid "Your report has been scheduled."
-msgstr ""
-
-#: rocky/views/scheduler.py
 msgid ""
 "Your task is scheduled and will soon be started in the background. Results "
 "will be added to the object list when they are in. It may take some time, a "
 "refresh of the page may be needed to show the results."
+msgstr ""
+
+#: rocky/views/scheduler.py
+msgid "Your report has been scheduled."
 msgstr ""
 
 #: rocky/views/tasks.py

--- a/rocky/rocky/templates/organizations/organization_member_edit.html
+++ b/rocky/rocky/templates/organizations/organization_member_edit.html
@@ -22,6 +22,18 @@
                 </form>
             </div>
         </section>
+        {% if request.user.is_superuser and object.user.is_active and not object.user.is_superuser %}
+            <section>
+                <div>
+                    <h2>{% translate "Global account access" %}</h2>
+                    <p>
+                        {% translate "Superuser access applies to every organization and all administrative functionality in this OpenKAT installation." %}
+                    </p>
+                    <a class="button ghost destructive"
+                       href="{% url 'organization_member_grant_superuser' organization.code object.id %}">{% translate "Grant superuser access" %}</a>
+                </div>
+            </section>
+        {% endif %}
     </main>
 {% endblock content %}
 {% block html_at_end_body %}

--- a/rocky/rocky/templates/organizations/organization_member_grant_superuser.html
+++ b/rocky/rocky/templates/organizations/organization_member_grant_superuser.html
@@ -1,0 +1,36 @@
+{% extends "layouts/base.html" %}
+
+{% load i18n %}
+
+{% block content %}
+    {% include "header.html" %}
+
+    <main id="main-content">
+        <section>
+            <div>
+                <h1>{% translate "Grant superuser access" %}</h1>
+                <div class="warning" role="alert">
+                    <p>
+                        {% blocktranslate with email=member.user.email trimmed %}
+                            You are about to grant <strong>{{ email }}</strong> unrestricted access to every organization and all administrative functionality in this OpenKAT installation.
+                        {% endblocktranslate %}
+                    </p>
+                    <p>
+                        {% translate "This is a global account permission, not an organization role." %}
+                        {% translate "Rocky cannot revoke this permission. To revoke it, open this account under Accounts > Users in Django administration, clear both Superuser status and Staff status, and save." %}
+                    </p>
+                    <a href="{% url 'admin:account_katuser_change' member.user.id %}">{% translate "Open this account in Django administration" %}</a>
+                </div>
+                <p>{% translate "Only continue when this person is authorized to administer the entire installation." %}</p>
+                <form method="post">
+                    {% csrf_token %}
+                    <div class="button-container">
+                        <button type="submit" class="destructive">{% translate "Grant superuser access" %}</button>
+                        <a class="button ghost"
+                           href="{% url 'organization_member_edit' organization.code member.id %}">{% translate "Cancel" %}</a>
+                    </div>
+                </form>
+            </div>
+        </section>
+    </main>
+{% endblock content %}

--- a/rocky/rocky/urls.py
+++ b/rocky/rocky/urls.py
@@ -34,6 +34,7 @@ from rocky.views.organization_member_add import (
 )
 from rocky.views.organization_member_edit import OrganizationMemberEditView
 from rocky.views.organization_member_list import OrganizationMemberListView
+from rocky.views.organization_member_superuser import GrantSuperuserAccessView
 from rocky.views.organization_settings import OrganizationSettingsView
 from rocky.views.privacy_statement import PrivacyStatementView
 from rocky.views.scan_profile import ScanProfileDetailView
@@ -114,6 +115,11 @@ urlpatterns += i18n_patterns(
         "<organization_code>/members/edit/<int:pk>/",
         OrganizationMemberEditView.as_view(),
         name="organization_member_edit",
+    ),
+    path(
+        "<organization_code>/members/<int:pk>/grant-superuser/",
+        GrantSuperuserAccessView.as_view(),
+        name="organization_member_grant_superuser",
     ),
     path("<organization_code>/health/v1/", HealthChecks.as_view(), name="health_beautified"),
     path("<organization_code>/objects/", OOIListView.as_view(), name="ooi_list"),

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -64,9 +64,7 @@ class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateVi
     def post(self, request, *args, **kwargs):
         with transaction.atomic():
             target_member = get_object_or_404(
-                OrganizationMember.objects.select_for_update(),
-                pk=kwargs["pk"],
-                organization=self.organization,
+                OrganizationMember.objects.select_for_update(), pk=kwargs["pk"], organization=self.organization
             )
             target_user = User.objects.select_for_update().get(pk=target_member.user_id)
             previous_is_superuser = target_user.is_superuser

--- a/rocky/rocky/views/organization_member_superuser.py
+++ b/rocky/rocky/views/organization_member_superuser.py
@@ -1,0 +1,108 @@
+from datetime import datetime, timezone
+from functools import cached_property
+
+import structlog
+from account.mixins import OrganizationView
+from django.contrib import messages
+from django.contrib.auth import get_user_model
+from django.contrib.auth.mixins import UserPassesTestMixin
+from django.db import transaction
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import reverse
+from django.utils.translation import gettext_lazy as _
+from django.views.generic import TemplateView
+from tools.models import OrganizationMember
+
+logger = structlog.get_logger(__name__)
+User = get_user_model()
+
+SUPERUSER_ACCESS_GRANTED_EVENT_CODE = "900113"
+
+
+class GrantSuperuserAccessView(UserPassesTestMixin, OrganizationView, TemplateView):
+    """Grant installation-wide superuser access from an organization member page."""
+
+    template_name = "organizations/organization_member_grant_superuser.html"
+    raise_exception = True
+
+    @cached_property
+    def member(self):
+        """Resolve the target only after the actor has passed the permission check."""
+        return get_object_or_404(
+            OrganizationMember.objects.select_related("user"), pk=self.kwargs["pk"], organization=self.organization
+        )
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["member"] = self.member
+        context["breadcrumbs"] = [
+            {
+                "url": reverse("organization_member_list", kwargs={"organization_code": self.organization.code}),
+                "text": _("Members"),
+            },
+            {
+                "url": reverse(
+                    "organization_member_edit",
+                    kwargs={"organization_code": self.organization.code, "pk": self.member.id},
+                ),
+                "text": _("Edit member"),
+            },
+            {
+                "url": reverse(
+                    "organization_member_grant_superuser",
+                    kwargs={"organization_code": self.organization.code, "pk": self.member.id},
+                ),
+                "text": _("Grant superuser access"),
+            },
+        ]
+        return context
+
+    def post(self, request, *args, **kwargs):
+        with transaction.atomic():
+            target_member = get_object_or_404(
+                OrganizationMember.objects.select_for_update(),
+                pk=kwargs["pk"],
+                organization=self.organization,
+            )
+            target_user = User.objects.select_for_update().get(pk=target_member.user_id)
+            previous_is_superuser = target_user.is_superuser
+            previous_is_staff = target_user.is_staff
+
+            if not target_user.is_active:
+                messages.warning(
+                    request,
+                    _("%(email)s is inactive and cannot be granted superuser access.") % {"email": target_user.email},
+                )
+                return HttpResponseRedirect(self.get_success_url())
+
+            if previous_is_superuser and previous_is_staff:
+                messages.warning(request, _("%(email)s already has superuser access.") % {"email": target_user.email})
+                return HttpResponseRedirect(self.get_success_url())
+
+            target_user.is_superuser = True
+            target_user.is_staff = True
+            target_user.save(update_fields=["is_superuser", "is_staff"])
+
+            audit_event = {
+                "event_code": SUPERUSER_ACCESS_GRANTED_EVENT_CODE,
+                "actor_id": request.user.id,
+                "actor_email": request.user.email,
+                "target_id": target_user.id,
+                "target_email": target_user.email,
+                "previous_is_superuser": previous_is_superuser,
+                "previous_is_staff": previous_is_staff,
+                "is_superuser": target_user.is_superuser,
+                "is_staff": target_user.is_staff,
+                "changed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            transaction.on_commit(lambda: logger.info("Superuser access granted", **audit_event))
+
+        messages.success(request, _("Superuser access granted to %(email)s.") % {"email": target_user.email})
+        return HttpResponseRedirect(self.get_success_url())
+
+    def get_success_url(self):
+        return reverse("organization_member_list", kwargs={"organization_code": self.organization.code})

--- a/rocky/tests/test_members.py
+++ b/rocky/tests/test_members.py
@@ -1,10 +1,16 @@
 import pytest
+from django.contrib.messages import get_messages
 from django.core.exceptions import PermissionDenied
+from django.db import transaction
 from django.http import Http404
+from django.test import Client
+from django.urls import reverse
+from django_otp import DEVICE_ID_SESSION_KEY
 from pytest_django.asserts import assertContains, assertNotContains
 
 from rocky.views.organization_member_add import OrganizationMemberAddAccountTypeView, OrganizationMemberAddView
 from rocky.views.organization_member_edit import OrganizationMemberEditView
+from rocky.views.organization_member_superuser import SUPERUSER_ACCESS_GRANTED_EVENT_CODE, GrantSuperuserAccessView
 from tests.conftest import setup_request
 
 
@@ -157,6 +163,191 @@ def test_admin_edits_redteamer_to_block(rf, admin_member, redteam_member):
 
     redteam_member.refresh_from_db()
     assert redteam_member.blocked is True
+
+
+def test_superuser_sees_grant_superuser_action(rf, superuser_member, admin_member):
+    request = setup_request(rf.get("organization_member_edit"), superuser_member.user)
+    response = OrganizationMemberEditView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assertContains(response, "Global account access")
+    assertContains(
+        response,
+        reverse(
+            "organization_member_grant_superuser",
+            kwargs={"organization_code": admin_member.organization.code, "pk": admin_member.id},
+        ),
+    )
+
+
+def test_admin_does_not_see_grant_superuser_action(rf, admin_member, redteam_member):
+    request = setup_request(rf.get("organization_member_edit"), admin_member.user)
+    response = OrganizationMemberEditView.as_view()(
+        request, organization_code=redteam_member.organization.code, pk=redteam_member.id
+    )
+
+    assertNotContains(response, "Global account access")
+    assertNotContains(response, "Grant superuser access")
+
+
+def test_superuser_can_view_grant_superuser_confirmation(rf, superuser_member, admin_member):
+    request = setup_request(rf.get("organization_member_grant_superuser"), superuser_member.user)
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assertContains(response, "Grant superuser access")
+    assertContains(response, admin_member.user.email)
+    assertContains(response, "unrestricted access to every organization")
+    assertContains(response, "clear both Superuser status and Staff status")
+    assertContains(response, reverse("admin:account_katuser_change", args=[admin_member.user.id]))
+    assertContains(response, "csrfmiddlewaretoken")
+
+
+def test_superuser_can_grant_superuser_access(
+    rf, superuser_member, admin_member, log_output, django_capture_on_commit_callbacks
+):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+    with django_capture_on_commit_callbacks(execute=True):
+        response = GrantSuperuserAccessView.as_view()(
+            request, organization_code=admin_member.organization.code, pk=admin_member.id
+        )
+
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "organization_member_list", kwargs={"organization_code": admin_member.organization.code}
+    )
+
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is True
+    assert admin_member.user.is_staff is True
+
+    audit_log = log_output.entries[-1]
+    assert audit_log["event"] == "Superuser access granted"
+    assert audit_log["event_code"] == SUPERUSER_ACCESS_GRANTED_EVENT_CODE
+    assert audit_log["actor_id"] == superuser_member.user.id
+    assert audit_log["target_id"] == admin_member.user.id
+    assert audit_log["previous_is_superuser"] is False
+    assert audit_log["previous_is_staff"] is False
+    assert audit_log["is_superuser"] is True
+    assert audit_log["is_staff"] is True
+    assert audit_log["changed_at"]
+
+
+def test_grant_superuser_access_does_not_log_a_rolled_back_change(
+    rf, superuser_member, admin_member, log_output, django_capture_on_commit_callbacks
+):
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+
+    with django_capture_on_commit_callbacks(execute=True), pytest.raises(RuntimeError), transaction.atomic():
+        GrantSuperuserAccessView.as_view()(
+            request, organization_code=admin_member.organization.code, pk=admin_member.id
+        )
+        raise RuntimeError
+
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert not any(entry.get("event") == "Superuser access granted" for entry in log_output.entries)
+
+
+@pytest.mark.parametrize("actor_fixture", ["admin_member", "redteam_member", "client_member"])
+def test_non_superusers_cannot_grant_superuser_access(rf, request, actor_fixture, redteam_member):
+    actor = request.getfixturevalue(actor_fixture)
+    view_request = setup_request(rf.post("organization_member_grant_superuser"), actor.user)
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            view_request, organization_code=redteam_member.organization.code, pk=redteam_member.id
+        )
+
+    redteam_member.user.refresh_from_db()
+    assert redteam_member.user.is_superuser is False
+    assert redteam_member.user.is_staff is False
+
+
+def test_non_superuser_cannot_determine_if_grant_target_exists(rf, admin_member, redteam_member):
+    existing_target = setup_request(rf.post("organization_member_grant_superuser"), admin_member.user)
+    missing_target = setup_request(rf.post("organization_member_grant_superuser"), admin_member.user)
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            existing_target, organization_code=redteam_member.organization.code, pk=redteam_member.id
+        )
+
+    with pytest.raises(PermissionDenied):
+        GrantSuperuserAccessView.as_view()(
+            missing_target, organization_code=redteam_member.organization.code, pk=redteam_member.id + 100_000
+        )
+
+
+def test_grant_superuser_access_is_idempotent(rf, superuser_member, superuser_member_b, log_output):
+    superuser_member_b.user.is_staff = True
+    superuser_member_b.user.save(update_fields=["is_staff"])
+    log_output.entries.clear()
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=superuser_member_b.organization.code, pk=superuser_member_b.id
+    )
+
+    assert response.status_code == 302
+    superuser_member_b.user.refresh_from_db()
+    assert superuser_member_b.user.is_superuser is True
+    assert superuser_member_b.user.is_staff is True
+    assert [str(message) for message in get_messages(request)] == [
+        f"{superuser_member_b.user.email} already has superuser access."
+    ]
+    assert not any(entry.get("event") == "Superuser access granted" for entry in log_output.entries)
+
+
+def test_inactive_user_cannot_be_granted_superuser_access(rf, superuser_member, admin_member):
+    admin_member.user.is_active = False
+    admin_member.user.save(update_fields=["is_active"])
+    request = setup_request(rf.post("organization_member_grant_superuser"), superuser_member.user)
+
+    response = GrantSuperuserAccessView.as_view()(
+        request, organization_code=admin_member.organization.code, pk=admin_member.id
+    )
+
+    assert response.status_code == 302
+    admin_member.user.refresh_from_db()
+    assert admin_member.user.is_superuser is False
+    assert admin_member.user.is_staff is False
+    assert [str(message) for message in get_messages(request)] == [
+        f"{admin_member.user.email} is inactive and cannot be granted superuser access."
+    ]
+
+
+def test_grant_superuser_access_requires_csrf(superuser_member, client_member):
+    superuser_member.onboarded = True
+    superuser_member.save(update_fields=["onboarded"])
+    csrf_client = Client(enforce_csrf_checks=True)
+    csrf_client.force_login(superuser_member.user)
+    session = csrf_client.session
+    session[DEVICE_ID_SESSION_KEY] = superuser_member.user.staticdevice_set.get().persistent_id
+    session.save()
+    url = reverse(
+        "organization_member_grant_superuser",
+        kwargs={"organization_code": client_member.organization.code, "pk": client_member.id},
+    )
+
+    response = csrf_client.get(url)
+    assert response.status_code == 200
+
+    response = csrf_client.post(url)
+    assert response.status_code == 403
+    client_member.user.refresh_from_db()
+    assert client_member.user.is_superuser is False
+    assert client_member.user.is_staff is False
+
+    response = csrf_client.post(url, {"csrfmiddlewaretoken": csrf_client.cookies["csrftoken"].value})
+    assert response.status_code == 302
+    client_member.user.refresh_from_db()
+    assert client_member.user.is_superuser is True
+    assert client_member.user.is_staff is True
 
 
 def test_account_type_view_existence(rf, admin_member):


### PR DESCRIPTION
### Changes

Adds a separate installation-wide **Grant superuser access** action to Rocky's member edit flow.

- only an existing superuser can see or invoke the action;
- the target is identified on a dedicated confirmation page that explains the global impact;
- POST + CSRF sets both `is_superuser` and `is_staff` inside a locked transaction;
- inactive accounts fail closed and already-promoted accounts remain an idempotent no-op;
- event `900113` records actor, target, previous/new state and timestamp after the database commit;
- unauthorized requests resolve before the target member lookup, avoiding a membership-ID oracle;
- the interface and documentation give the exact Django Admin recovery path because Rocky cannot revoke the permission yet.

The root cause was that Rocky modeled organization roles separately from global account flags and exposed no controlled UI action for `KATUser.is_superuser`; operators therefore needed shell or Django Admin access.

The generated `django.pot` refresh is isolated in its own commit. It includes the feature strings plus reproducible pre-existing catalog drift from current scheduler/task/bytes sources because the repository-native generator refreshes the complete catalog.

No migration, new dependency, configuration change, organization-role change, or breaking change is required.

### Issue link

Closes #5266

### Demo

The action appears under **Global account access** on an active non-superuser's member edit page. It opens a dedicated warning page showing the target email, installation-wide scope, recovery path, destructive confirmation, and cancel action.

### QA notes

1. Sign in as a superuser and edit an active non-superuser member.
2. Select **Grant superuser access** under **Global account access**.
3. Verify the target email, global warning, and Django Admin recovery instructions.
4. Confirm and verify the account now has both superuser and staff status and event `900113` is logged.
5. Repeat the POST and verify it is a no-op with clear feedback.
6. Verify admin, redteam, and client accounts neither see the action nor can invoke its URL.
7. Verify an inactive account does not show the action and cannot be promoted by direct POST.

Local validation:

- `prek run --all-files --show-diff-on-failure --color never`
- full Rocky unit test suite on PostgreSQL 15
- `pytest tests/test_members.py -q --no-cov` — 28 passed

Docker-based integration tests were not available locally; the repository CI workflow covers them.

### LibreKAT core values assessment

This change materially affects **safety first**, **reliability and security**, **integrity and independence**, **sovereignty and autonomy**, **humanity and respect**, **just culture**, and **sustainability and continuity**. Superuser rights are installation-wide, so the action is limited to existing superusers, uses POST with CSRF protection, names the target, and shows the impact before confirmation. Authorization happens before target lookup. The success event is emitted through `transaction.on_commit()` with actor, target, old/new state and timestamp, so rollback cannot leave a false success record. Inactive targets fail closed.

The four-phase values/security/UX review found and resolved three concrete scenarios: an undocumented recovery path after a mistaken grant, target-ID disclosure before authorization, and audit logging before commit. Rocky still cannot revoke superuser access; the UI and operator documentation therefore identify the exact supported recovery path through **Django administration → Accounts → Users**, clearing both **Superuser status** and **Staff status**. This remaining operational dependency is visible rather than hidden. Application logging is not a transactional outbox, so a process crash immediately after commit can still lose the event; introducing an outbox is disproportionate to this scoped change and remains a documented residual risk.

No external service, dependency, data flow, file format, public interoperability promise, or organization-role semantics change. The capability reduces dependence on shell access and the continuity risk of maintaining only one operational superuser, while preserving explicit human confirmation and auditability.

---

### Code Checklist

- [ ] All the commits in this PR are properly PGP-signed and verified.
- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.

- [ ] Tickets have been created for newly discovered issues.
- [ ] For any non-trivial functionality, I have added integration and/or end-to-end tests.
- [ ] I have informed others of any required `.env` changes files if required and changed the `.env-dist` accordingly.
- [x] I have included comments in the code to elaborate on what is not self-evident from the code itself, including references to issues and discussions online, or implicit behavior of an interface.

---

## Checklist for code reviewers:

Copy-paste the checklist from [the contributor templates](https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_code.md) into your comment.

---

## Checklist for QA:

Copy-paste the checklist from [the contributor templates](https://github.com/SSC-ICT-Innovatie/nl-kat-coordination/blob/main/docs/source/developer-documentation/contributor/templates/pull_request_template_review_qa.md) into your comment.
