### PR TITLE
Add get_normalizer_metas to BytesAPIClient and use it in the integration tests

### DIFF
--- a/bytes/tests/client.py
+++ b/bytes/tests/client.py
@@ -119,6 +119,25 @@ class BytesAPIClient:
         return [NormalizerMeta.model_validate(normalizer_meta) for normalizer_meta in normalizer_meta_json]
 
     @retry_with_login
+    def get_normalizer_metas(
+        self, normalizer_meta_ids: list[UUID], limit: int = 100, offset: int = 0
+    ) -> dict[str, NormalizerMeta]:
+        response = self.client.get(
+            "/bytes/normalizer_metas",
+            params={
+                "normalizer_metas": [str(normalizer_meta_id) for normalizer_meta_id in normalizer_meta_ids],
+                "limit": limit,
+                "offset": offset,
+            },
+        )
+        self._verify_response(response)
+
+        return {
+            normalizer_meta_id: NormalizerMeta.model_validate(normalizer_meta)
+            for normalizer_meta_id, normalizer_meta in response.json().items()
+        }
+
+    @retry_with_login
     def save_raw(self, boefje_meta_id: UUID, raw: bytes, mime_types: list[str] | None = None) -> str:
         if not mime_types:
             mime_types = []

--- a/bytes/tests/integration/test_bytes_api.py
+++ b/bytes/tests/integration/test_bytes_api.py
@@ -201,8 +201,7 @@ def test_filtered_normalizer_meta(bytes_api_client: BytesAPIClient) -> None:
 
 def test_get_normalizer_metas_by_uuid_list(bytes_api_client: BytesAPIClient) -> None:
     # The /bytes/normalizer_metas endpoint (plural) takes a list of UUIDs and
-    # returns a dict {uuid: NormalizerMeta}. It has no method on BytesAPIClient
-    # and was the one normalizer-meta route without integration coverage.
+    # returns a dict {uuid: NormalizerMeta}.
     boefje_meta = get_boefje_meta()
     bytes_api_client.save_boefje_meta(boefje_meta)
 
@@ -221,20 +220,17 @@ def test_get_normalizer_metas_by_uuid_list(bytes_api_client: BytesAPIClient) -> 
     third.id = uuid.uuid4()
     bytes_api_client.save_normalizer_meta(third)
 
-    response = bytes_api_client.client.get(
-        "/bytes/normalizer_metas", params=[("normalizer_metas", str(first.id)), ("normalizer_metas", str(second.id))]
-    )
-    response.raise_for_status()
-    body = response.json()
+    normalizer_metas = bytes_api_client.get_normalizer_metas([first.id, second.id])
 
-    assert set(body.keys()) == {str(first.id), str(second.id)}
-    assert str(third.id) not in body
+    assert set(normalizer_metas.keys()) == {str(first.id), str(second.id)}
+    assert str(third.id) not in normalizer_metas
+    assert normalizer_metas[str(first.id)].id == first.id
+    assert normalizer_metas[str(second.id)].id == second.id
+    assert normalizer_metas[str(first.id)].normalizer.id == first.normalizer.id
 
 
 def test_get_normalizer_metas_unknown_uuid_returns_empty(bytes_api_client: BytesAPIClient) -> None:
-    response = bytes_api_client.client.get("/bytes/normalizer_metas", params=[("normalizer_metas", str(uuid.uuid4()))])
-    response.raise_for_status()
-    assert response.json() == {}
+    assert bytes_api_client.get_normalizer_metas([uuid.uuid4()]) == {}
 
 
 def test_normalizer_meta_pointing_to_raw_id(bytes_api_client: BytesAPIClient) -> None:


### PR DESCRIPTION
### Changes

Follow-up to #5114, as requested in #5270:

- Adds a `get_normalizer_metas` method to the test `BytesAPIClient` for `GET /bytes/normalizer_metas` (list of UUIDs → `dict[str, NormalizerMeta]`). It follows the conventions of the sibling methods: `@retry_with_login`, `_verify_response`, and pydantic model validation of the response.
- Rewrites the two `/bytes/normalizer_metas` integration tests from #5114 to go through the client method instead of raw `bytes_api_client.client.get(...)` calls. Since the client now returns validated `NormalizerMeta` models, the assertions also check the returned models (`id`, `normalizer.id`), not just the response keys.

### Issue link

Closes #5270

### QA notes

Test-only change (the client lives in `bytes/tests/`); no runtime code touched.

Verified locally in Docker:
- `bytes make utest` — 14 passed, 1 skipped
- `bytes make itest` — 31 passed, 1 skipped (both rewritten tests pass through the new client method)
- `pre-commit` on the changed files — passed

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have written unit tests for the changes or fixes I made.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.