### PR TITLE
Fix CodeQL action version mismatch between init and analyze

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -34,7 +34,7 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v3.29.5
+        uses: github/codeql-action/init@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -42,6 +42,6 @@ jobs:
 
       # Use the CodeQL tools for analyzing.
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v3.29.5
+        uses: github/codeql-action/analyze@f205ea1c3313d32999d8d6a48b4f6530d4437b38 # v4.37.4
         with:
           category: "/language:${{matrix.language}}"


### PR DESCRIPTION
### Changes

CodeQL currently fails on every run with:

```
Error: analyze post-action step failed: Loaded a configuration file for
version '4.37.4', but running version '4.36.0'
```

**Cause.** Dependabot #5275 (merged 2026-08-03) bumped **only** `github/codeql-action/init` from v4.36.0 to v4.37.4 and left `analyze` at v4.36.0. Dependabot tracks the two sub-actions as separate dependencies, so it opens a PR per sub-action; when only one lands the two steps run different versions. `init` writes a config file stamped with its own version, and the older `analyze` post-action refuses to load it — hence the two version numbers in the error match the two pins exactly:

| Step | SHA (before) | Version |
|---|---|---|
| `init` | `f205ea1c` | v4.37.4 (`Merge pull request #4053 … update-v4.37.4`) |
| `analyze` | `7211b7c8` | v4.36.0 (`Merge pull request #3927 … update-v4.36.0`) |

**Fix.** Pin both sub-actions to the same commit (`f205ea1c` = v4.37.4).

While here: both version comments still read `# v3.29.5` even though both SHAs were already v4.x — Dependabot updates the SHA but not a comment it doesn't recognise. Corrected to `# v4.37.4` so the next reader isn't misled.

### Issue link

No issue — CI breakage on main, following the CI-housekeeping convention.

### QA notes

CI-only change; the CodeQL job on this PR is itself the test. `pre-commit` passes on the changed file.

**Worth considering as a follow-up:** group the two `github/codeql-action/*` sub-actions in `.github/dependabot.yml` so they are always bumped together and this can't recur:

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action/*"
```

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.