### PR TITLE
Add @brennodewinter to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @hasecon @cookiemonster @underdarknl
+* @hasecon @cookiemonster @underdarknl @brennodewinter


### PR DESCRIPTION
### Changes

Adds `@brennodewinter` to `.github/CODEOWNERS`, so he is requested on PRs and can help clear the code-owner gate.

```diff
-* @hasecon @cookiemonster @underdarknl
+* @hasecon @cookiemonster @underdarknl @brennodewinter
```

### Why

Brenno is joining PR review. He is already an active contributor on this repository 


### QA notes

Config-only change; nothing to test at runtime. GitHub validates CODEOWNERS syntax and flags unknown or unauthorised users in the repository's CODEOWNERS view.

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.