### PR TITLE
Fix nuclei boefjes: ship templates and pass -t

### DIFF
--- a/.github/workflows/containerized_boefjes.yml
+++ b/.github/workflows/containerized_boefjes.yml
@@ -18,6 +18,9 @@ on:
       - boefjes/boefjes/plugins/kat_dnssec/**
       - boefjes/boefjes/plugins/kat_nikto/**
       - boefjes/boefjes/plugins/kat_export_http/**
+      - boefjes/boefjes/plugins/kat_nuclei_cve/**
+      - boefjes/boefjes/plugins/kat_nuclei_exposed_panels/**
+      - boefjes/boefjes/plugins/kat_nuclei_take_over/**
       - boefjes/images/**
       - .github/workflows/containerized_boefjes.yml
 

--- a/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.Dockerfile
@@ -1,7 +1,17 @@
 FROM golang:1.25-alpine AS build
 ARG NUCLEI_VERSION=v3.9.0
+# Templates are pinned and baked into the image. Nuclei's runtime
+# `-update-templates` exits 0 without installing anything when the download
+# fails, leaving a scan with no templates and no error to explain it. Pinning
+# also keeps builds reproducible and lets the boefje run without internet
+# access to GitHub.
+ARG NUCLEI_TEMPLATES_VERSION=v10.4.7
 
+RUN apk add --no-cache git
 RUN go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERSION}
+RUN git clone --depth 1 --branch ${NUCLEI_TEMPLATES_VERSION} \
+    https://github.com/projectdiscovery/nuclei-templates.git /nuclei-templates \
+ && rm -rf /nuclei-templates/.git
 
 FROM openkat/boefje-base:latest
 
@@ -10,4 +20,5 @@ ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root
 COPY --from=build /go/bin/nuclei /usr/local/bin/
+COPY --from=build /nuclei-templates /root/nuclei-templates
 COPY ./boefjes/plugins/kat_nuclei_cve ./kat_nuclei_cve

--- a/boefjes/boefjes/plugins/kat_nuclei_cve/main.py
+++ b/boefjes/boefjes/plugins/kat_nuclei_cve/main.py
@@ -11,6 +11,11 @@ def run(boefje_meta: dict) -> list[tuple[set, bytes | str]]:
     cmd = ["/usr/local/bin/nuclei"] + boefje_meta["arguments"]["oci_arguments"] + ["-u", url]
 
     output = subprocess.run(cmd, capture_output=True)
-    output.check_returncode()
+
+    if output.returncode != 0:
+        # nuclei reports why it gave up on stderr ("no templates provided for
+        # scan", an unknown flag, ...). check_returncode() drops that, leaving
+        # only an exit code for whoever reads the failed task.
+        raise RuntimeError(f"nuclei exited with code {output.returncode}: {output.stderr.decode().strip()}")
 
     return [({"openkat/nuclei-output"}, output.stdout.decode())]

--- a/boefjes/boefjes/plugins/kat_nuclei_exposed_panels/boefje.json
+++ b/boefjes/boefjes/plugins/kat_nuclei_exposed_panels/boefje.json
@@ -8,6 +8,7 @@
   "scan_level": 3,
   "oci_image": "docker.underdark.nl/librekat/openkat-nuclei:latest",
   "oci_arguments": [
+    "-t",
     "/root/nuclei-templates/http/exposed-panels/",
     "-jsonl"
   ]

--- a/boefjes/boefjes/plugins/kat_nuclei_take_over/boefje.json
+++ b/boefjes/boefjes/plugins/kat_nuclei_take_over/boefje.json
@@ -8,6 +8,7 @@
   "scan_level": 3,
   "oci_image": "docker.underdark.nl/librekat/openkat-nuclei:latest",
   "oci_arguments": [
+    "-t",
     "/root/nuclei-templates/http/takeovers/",
     "-jsonl"
   ]


### PR DESCRIPTION
### Changes

All three nuclei boefjes fail on every run, for two stacked reasons. Full analysis in #5285; this PR fixes the unambiguous parts.

**1. The image contained no templates.** `boefje.Dockerfile` only copied the nuclei binary, so `/root/nuclei-templates/` did not exist. Nuclei's runtime rescue is a silent failure — `nuclei -update-templates` prints "installing…", exits **0**, and installs **zero** files. Every scan ended in `[FTL] Could not run nuclei: no templates provided for scan`.

This PR clones a pinned `nuclei-templates` release in the build stage and copies it into the image. Pinned rather than fetched at runtime so builds are reproducible, work air-gapped, and cannot silently produce a template-less image.

**2. Two of three boefjes never passed `-t`.** Nuclei takes no positional arguments, so it ignored the path and fell back to its default directory:

```
kat_nuclei_cve            ["-t", ".../http/cves/", "-jsonl"]        ✅
kat_nuclei_exposed_panels [".../http/exposed-panels/", "-jsonl"]    ❌ → now fixed
kat_nuclei_take_over      [".../http/takeovers/", "-jsonl"]         ❌ → now fixed
```

Worth knowing for review: one image serves all three boefjes — only `kat_nuclei_cve` has a Dockerfile and `main.py`, and the runner resolves the plugin by image. The other two are defined *entirely* by `oci_arguments`, which is why a missing flag there silently disabled them since #4644.

**3. Failures now explain themselves.** `check_returncode()` discarded `stderr` even though it was captured, so a failed task showed only `returned non-zero exit status 1`. Diagnosing this required running nuclei by hand. Nuclei's own reason is now included in the raised error.

**4. CI builds the nuclei image on PRs that touch it.** `containerized_boefjes.yml` listed only nmap/dnssec/nikto/export-http under `pull_request.paths`, so nuclei changes were never built before merge — part of why this stayed broken.

### Issue link

Closes #5285

### QA notes

Verified against a locally built image (`--target build` and full image), running each boefje with the exact `oci_arguments` from its own `boefje.json`:

| Boefje | Before | After |
|---|---|---|
| `nuclei-cve` | exit 1, `no templates provided for scan` | **exit 0, 4156 templates loaded** |
| `nuclei-exposed-panels` | exit 1, `no templates provided for scan` | **exit 0, 1554 templates loaded** |
| `nuclei-take-over` | exit 1, `no templates provided for scan` | **exit 0, 73 templates loaded** |

The `-t` behaviour was isolated separately by placing a hand-made template in the image: `-t dir/` → "Templates loaded for current scan: 1", exit 0; bare `dir/` → `[ERR] Could not find template '/root/nuclei-templates'`, exit 1.

Error path checked too: with a non-existent template path, `run()` now raises `RuntimeError: nuclei exited with code 1: … no templates provided for scan` instead of a bare exit code.

`pre-commit` passes on all five changed files.

To reproduce: `cd boefjes && make nuclei`, then run any of the three argument sets against the resulting image.

### Notes for the reviewer

- **Template freshness is now a deliberate act.** Pinning trades staleness for reproducibility — stale templates mean missed findings. #5285 asks @underdarknl whether to add a scheduled bump or review it periodically. Bumping is a one-line `NUCLEI_TEMPLATES_VERSION` change.
- **Image size grows** by the templates tree (~13.5k yaml files). If that is a concern, the clone could be narrowed to the three used subtrees (`http/cves`, `http/exposed-panels`, `http/takeovers`) with a sparse checkout — happy to do that, but I kept the full set since other nuclei boefjes may follow and partial trees are a subtle trap.
- **The error message includes nuclei's ASCII banner**, because that is what nuclei writes to stderr. Complete but noisy; I left it whole rather than guess at which lines matter.
- Deliberately **out of scope** (both in #5285, both affecting all 12 containerized boefjes): the `:latest` tag mismatch, and the `OCI_IMAGE` build-arg that CI never sets — the latter looks like it silently prevents worker-mode deployments from claiming any tasks.

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.
- [x] I have included comments in the code to elaborate on what is not self-evident.