### PR TITLE
Point OCI_IMAGE defaults at the librekat registry

### DIFF
--- a/boefjes/boefjes/plugins/kat_adr_validator/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_adr_validator/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/dns-sec:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-adr-validator:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 COPY --from=registry.gitlab.com/commonground/don/adr-validator:0.2.0 /usr/local/bin/adr-validator /usr/local/bin/

--- a/boefjes/boefjes/plugins/kat_dnssec/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_dnssec/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/dns-sec:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-dns-sec:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_export_http/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_export_http/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/export-http:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-export-http:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 COPY ./boefjes/plugins/kat_export_http ./kat_export_http

--- a/boefjes/boefjes/plugins/kat_masscan/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_masscan/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/masscan:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-masscan:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 # Packages:

--- a/boefjes/boefjes/plugins/kat_nmap_tcp/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_nmap_tcp/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/nmap:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-nmap:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_nuclei_cve/boefje.Dockerfile
@@ -5,7 +5,7 @@ RUN go install -v github.com/projectdiscovery/nuclei/v3/cmd/nuclei@${NUCLEI_VERS
 
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/nuclei:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-nuclei:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_pdio_subfinder/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_pdio_subfinder/boefje.Dockerfile
@@ -5,7 +5,7 @@ RUN go install -v github.com/projectdiscovery/subfinder/v2/cmd/subfinder@${SUBFI
 
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/pdio-subfinder:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-pdio-subfinder:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 COPY --from=build /go/bin/subfinder /usr/local/bin/

--- a/boefjes/boefjes/plugins/kat_ssl_certificates/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_ssl_certificates/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/ssl-certificates:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-ssl-certificates:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_ssl_scan/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_ssl_scan/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/ssl-scan:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-ssl-scan:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_testssl_sh_ciphers/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_testssl_sh_ciphers/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/testssl-sh-ciphers:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-testssl-sh-ciphers:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/boefjes/boefjes/plugins/kat_webpage_capture/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_webpage_capture/boefje.Dockerfile
@@ -25,7 +25,7 @@ COPY ./boefjes/logging.json logging.json
 ENTRYPOINT ["/usr/bin/python3.13", "-m", "worker"]
 CMD []
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/webpage-capture:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-webpage-capture:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 ENV PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
 

--- a/boefjes/boefjes/plugins/kat_wpscan/boefje.Dockerfile
+++ b/boefjes/boefjes/plugins/kat_wpscan/boefje.Dockerfile
@@ -1,6 +1,6 @@
 FROM openkat/boefje-base:latest
 
-ARG OCI_IMAGE=ghcr.io/minvws/openkat/wp-scan:latest
+ARG OCI_IMAGE=docker.underdark.nl/librekat/openkat-wp-scan:latest
 ENV OCI_IMAGE=$OCI_IMAGE
 
 USER root

--- a/docs/source/installation-and-deployment/separate-boefje-workers.rst
+++ b/docs/source/installation-and-deployment/separate-boefje-workers.rst
@@ -13,7 +13,7 @@ It also gives a lot more flexibility when scaling horizontally.
 
 .. code:: shell
 
-    $ docker run ghcr.io/minvws/openkat/nmap --help
+    $ docker run docker.underdark.nl/librekat/openkat-nmap --help
     Usage: python -m worker [OPTIONS] [INPUT_URL]
 
     Options:
@@ -27,9 +27,9 @@ Additionally, you could start the process with a filter on specific plugin ids, 
 
 .. code:: shell
 
-    $ docker run --network nl-kat-coordination_boefjes ghcr.io/minvws/openkat/nmap -p nmap-udp  # optional filter
+    $ docker run --network nl-kat-coordination_boefjes docker.underdark.nl/librekat/openkat-nmap -p nmap-udp  # optional filter
     1970-17-28T15:26:16.333927 [info] Starting runtime
-    1970-17-28T15:26:16.334173 [info] Configured BoefjeAPI [base_url=http://boefje:8000, outgoing_request_timeout=30, images=['ghcr.io/minvws/openkat/nmap:latest'], plugins=['nmap-udp']]
+    1970-17-28T15:26:16.334173 [info] Configured BoefjeAPI [base_url=http://boefje:8000, outgoing_request_timeout=30, images=['docker.underdark.nl/librekat/openkat-nmap:latest'], plugins=['nmap-udp']]
     1970-17-28T15:26:16.331262 [info] Created worker pool for queue 'boefje'
     1970-17-28T15:26:16.334481 [info] Started listening for tasks from worker pid=16
     1970-17-28T15:26:16.334501 [info] Started listening for tasks from worker pid=17


### PR DESCRIPTION
### Changes

Twelve boefje Dockerfiles still defaulted `ARG OCI_IMAGE` to `ghcr.io/minvws/openkat/...`, a registry we no longer use. Since **CI never passes this build-arg**, that stale default is exactly what gets baked into every published image.

It is not a cosmetic string. `worker/__main__.py` reads it and hands it to the API client, which filters the scheduler with:

```python
{"column": "data", "field": "boefje__oci_image", "operator": "in", "value": self.oci_images}
```

Tasks carry the `oci_image` from `boefje.json` (`docker.underdark.nl/librekat/openkat-*:latest`), so a worker advertising a `ghcr.io/minvws/...` image matches nothing and **claims no tasks at all**. The project's own documentation states the mechanism plainly: *"This long running process will automatically filter the scheduler on tasks for the `OCI_IMAGE` specified through its env."*

This is invisible in the default docker-compose setup because the docker runner starts a container per task and `worker/__main__.py` returns early on `input_url`, before it ever reads `OCI_IMAGE`.

Each default is now taken from the `oci_image` in that plugin's own `boefje.json`, which is the value tasks actually carry. That also fixes **`kat_adr_validator`, which pointed at the dns-sec image** — a copy-paste error hiding underneath the stale registry.

`boefjes/images/generic.Dockerfile` already had the correct value and is untouched; `kat_nikto` has no `ARG OCI_IMAGE` at all, consistent with the Makefile note that nikto cannot run as a worker, so it is left alone.

Docs: `separate-boefje-workers.rst` is the guide for precisely this mode and told readers to run the minvws image, so its three references now use the librekat one. The 1.20 and 1.21 release notes keep their original image names — they are a historical record.

### Issue link

Refs #5285 (structural cause 5 in the analysis)

### QA notes

Verified by building a boefje image and reading the baked value back out:

```
$ docker build -f boefjes/plugins/kat_dnssec/boefje.Dockerfile -t oci-default-test .
$ docker run --rm --entrypoint sh oci-default-test -c 'echo "$OCI_IMAGE"'
docker.underdark.nl/librekat/openkat-dns-sec:latest
```

which matches `kat_dnssec/boefje.json` exactly. A script check confirms every Dockerfile default now equals its own `boefje.json` `oci_image`, and no `ghcr.io/minvws` reference remains anywhere under `boefjes/`.

Behaviour in the compose setup is unchanged, since that path never reads the variable.

### Note for the reviewer

This touches `kat_nuclei_cve/boefje.Dockerfile`, which #5286 also modifies (different lines — build stage and COPY there, the ARG line here). Whichever merges second may want a trivial rebase.

Still open from #5285 and deliberately not addressed here: `boefje.json` pins `:latest` while CI publishes `main` / `v1.x.x` / `pr-N` tags, so `latest` is only produced on release tags. That one needs a decision from you rather than a fix from me.

---

### Code Checklist

- [x] This PR only contains functionality relevant to the issue.
- [x] I have checked the documentation and made changes where necessary.
- [x] I have performed a self-review of my code and refactored it to the best of my abilities.