### PR TITLE
Extract Software from Shodan banners

### DIFF
--- a/boefjes/boefjes/plugins/kat_shodan/normalize.py
+++ b/boefjes/boefjes/plugins/kat_shodan/normalize.py
@@ -6,6 +6,7 @@ from boefjes.normalizer_models import NormalizerOutput
 from octopoes.models import Reference
 from octopoes.models.ooi.findings import CVEFindingType, Finding
 from octopoes.models.ooi.network import IPPort, PortState, Protocol
+from octopoes.models.ooi.software import Software, SoftwareInstance
 
 
 def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
@@ -34,3 +35,13 @@ def run(input_ooi: dict, raw: bytes) -> Iterable[NormalizerOutput]:
                     f = Finding(finding_type=ft.reference, ooi=ip_port.reference)
                     yield ft
                     yield f
+
+            # Shodan reports the detected product/version per banner. It was
+            # dropped entirely, so no Software was recorded and CVEs could not
+            # be bound to the software on a port.
+            product = scan.get("product")
+            if product:
+                cpe23 = scan.get("cpe23") or []
+                software = Software(name=product, version=scan.get("version"), cpe=cpe23[0] if cpe23 else None)
+                yield software
+                yield SoftwareInstance(ooi=ip_port.reference, software=software.reference)

--- a/boefjes/boefjes/plugins/kat_shodan/normalizer.json
+++ b/boefjes/boefjes/plugins/kat_shodan/normalizer.json
@@ -8,6 +8,8 @@
   "produces": [
     "Finding",
     "IPPort",
-    "CVEFindingType"
+    "CVEFindingType",
+    "Software",
+    "SoftwareInstance"
   ]
 }

--- a/boefjes/tests/plugins/test_shodan.py
+++ b/boefjes/tests/plugins/test_shodan.py
@@ -4,6 +4,7 @@ from boefjes.plugins.kat_shodan.normalize import run
 from octopoes.models import Reference
 from octopoes.models.ooi.findings import CVEFindingType, Finding
 from octopoes.models.ooi.network import IPPort, PortState, Protocol
+from octopoes.models.ooi.software import Software, SoftwareInstance
 
 input_ooi = {"primary_key": "IPAddressV4|internet|1.2.3.4", "network": {"name": "internet"}}
 
@@ -75,3 +76,39 @@ def test_shodan_normalizer_empty_vulns_dict_emits_no_findings():
 
     assert [r for r in results if isinstance(r, Finding)] == []
     assert [r for r in results if isinstance(r, CVEFindingType)] == []
+
+
+def test_shodan_normalizer_extracts_software():
+    raw = json.dumps(
+        {
+            "data": [
+                {
+                    "port": 22,
+                    "transport": "tcp",
+                    "product": "OpenSSH",
+                    "version": "8.4p1",
+                    "cpe23": ["cpe:2.3:a:openbsd:openssh:8.4p1:*:*:*:*:*:*:*"],
+                }
+            ]
+        }
+    ).encode()
+
+    results = list(run(input_ooi, raw))
+
+    software = [r for r in results if isinstance(r, Software)]
+    instances = [r for r in results if isinstance(r, SoftwareInstance)]
+    ip_ports = [r for r in results if isinstance(r, IPPort)]
+    assert len(software) == 1
+    assert software[0].name == "OpenSSH"
+    assert software[0].version == "8.4p1"
+    assert software[0].cpe == "cpe:2.3:a:openbsd:openssh:8.4p1:*:*:*:*:*:*:*"
+    assert len(instances) == 1
+    assert instances[0].ooi == ip_ports[0].reference
+
+
+def test_shodan_normalizer_no_software_without_product():
+    raw = json.dumps({"data": [{"port": 80, "transport": "tcp"}]}).encode()
+
+    results = list(run(input_ooi, raw))
+
+    assert [r for r in results if isinstance(r, Software)] == []


### PR DESCRIPTION
## What

`kat_shodan` emitted ports and CVE findings but never read the detected `product`/`version`, so **no `Software` was recorded** and CVEs could not be bound to the software running on a port.

## Fix

Yield `Software` + `SoftwareInstance` per `data[]` entry from `product`/`version`, carrying the CPE 2.3 string (`cpe23[0]`) when present. `normalizer.json` `produces` now lists `Software`/`SoftwareInstance`.

## Test

`test_shodan.py`: a banner with product/version yields Software bound to the port; a banner without a product yields none. Existing tests unchanged.

## Scope / follow-up

The `data[].ssl` certificate block remains unparsed — that is a larger, separate change (validity/subject/SAN extraction, like the Censys certificate handling) left as follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)