### PR TITLE
Make kat_cve_2023_34039 actually run its SSH-key check

### DIFF
--- a/boefjes/boefjes/plugins/kat_cve_2023_34039/main.py
+++ b/boefjes/boefjes/plugins/kat_cve_2023_34039/main.py
@@ -14,8 +14,14 @@ https://summoning.team/blog/vmware-vrealize-network-insight-ssh-key-rce-cve-2023
 
 """
 
-import os
 import subprocess
+import tempfile
+from pathlib import Path
+
+# Resolve the keys relative to this module. os.walk("keys") used the process
+# CWD (/app/boefje in the OCI image) instead, so it walked a non-existent
+# directory, silently found no keys and always reported "not vulnerable".
+KEYS_DIR = Path(__file__).parent / "keys"
 
 
 def run(boefje_meta: dict) -> list[tuple[set, str | bytes]]:
@@ -27,13 +33,19 @@ def run(boefje_meta: dict) -> list[tuple[set, str | bytes]]:
     ip = ip_port["address"]["address"]
     port = ip_port["port"]
 
-    for root, dirs, files in os.walk("keys"):
-        for file in files:
-            key_file = str(os.path.join(root, file))
+    for key_file in sorted(p for p in KEYS_DIR.rglob("*") if p.is_file()):
+        # The keys are committed world-readable (mode 0755) and Docker COPY
+        # preserves that mode; OpenSSH refuses a private key with group/world
+        # permissions and exits 255, so every key was skipped. Copy the key to a
+        # private (0600) temp file — NamedTemporaryFile creates it with 0600 —
+        # so ssh will actually use it.
+        with tempfile.NamedTemporaryFile("wb") as tmp:
+            tmp.write(key_file.read_bytes())
+            tmp.flush()
             ssh_command = [
                 "ssh",
                 "-i",
-                key_file,
+                tmp.name,
                 "support@" + ip,
                 "-p",
                 str(port),
@@ -47,19 +59,20 @@ def run(boefje_meta: dict) -> list[tuple[set, str | bytes]]:
             ]
             try:
                 result = subprocess.run(ssh_command, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                coutput = result.returncode
-                if coutput not in (0, 127):  # 0 = it worked, 127 = `exit` does not exists but we did connect
-                    continue
-                return [
-                    (
-                        set(),
-                        "\n".join(
-                            (str(coutput), f"{key_file} is allowed access to vRealize Network Insight on {ip}:{port}")
-                        ),
-                    ),
-                    ({"openkat/finding"}, "CVE-2023-34039"),
-                ]
-
             except Exception:  # noqa: S112
                 continue
+
+            coutput = result.returncode
+            if coutput not in (0, 127):  # 0 = it worked, 127 = `exit` does not exist but we did connect
+                continue
+
+            key_id = key_file.relative_to(KEYS_DIR)
+            return [
+                (
+                    set(),
+                    "\n".join((str(coutput), f"{key_id} is allowed access to vRealize Network Insight on {ip}:{port}")),
+                ),
+                ({"openkat/finding"}, "CVE-2023-34039"),
+            ]
+
     return [(set(), "No known keys allowed")]

--- a/boefjes/tests/plugins/test_cve_2023_34039.py
+++ b/boefjes/tests/plugins/test_cve_2023_34039.py
@@ -1,0 +1,45 @@
+import stat
+from pathlib import Path
+from unittest import mock
+
+from boefjes.plugins.kat_cve_2023_34039.main import KEYS_DIR, run
+
+
+def _meta(service: str = "ssh") -> dict:
+    return {
+        "arguments": {
+            "input": {"service": {"name": service}, "ip_port": {"address": {"address": "1.2.3.4"}, "port": 22}}
+        }
+    }
+
+
+def test_skips_non_ssh_service():
+    assert run(_meta(service="http")) == [({"openkat/deschedule"}, "Skipping because service is not an ssh service")]
+
+
+def test_keys_dir_resolves_to_the_bundled_keys():
+    # os.walk("keys") used the wrong CWD and found nothing; the module-relative
+    # KEYS_DIR must contain the 22 bundled vRNI keys.
+    keys = [p for p in KEYS_DIR.rglob("*") if p.is_file()]
+    assert len(keys) == 22
+
+
+def test_reports_finding_with_a_private_key_copy_when_a_key_is_accepted():
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        key_path = cmd[cmd.index("-i") + 1]
+        captured["mode"] = stat.S_IMODE(Path(key_path).stat().st_mode)
+        return mock.Mock(returncode=0)
+
+    with mock.patch("boefjes.plugins.kat_cve_2023_34039.main.subprocess.run", side_effect=fake_run):
+        out = run(_meta())
+
+    assert ({"openkat/finding"}, "CVE-2023-34039") in out
+    # ssh was handed a 0600 key copy, so OpenSSH no longer refuses it.
+    assert captured["mode"] == 0o600
+
+
+def test_reports_not_vulnerable_when_all_keys_are_rejected():
+    with mock.patch("boefjes.plugins.kat_cve_2023_34039.main.subprocess.run", return_value=mock.Mock(returncode=255)):
+        assert run(_meta()) == [(set(), "No known keys allowed")]


### PR DESCRIPTION
## What

The boefje **never detected the vulnerability**, for two independent, silent reasons:

1. `os.walk("keys")` resolved against the process **CWD** (`/app/boefje` in the OCI image), not the module. It walked a non-existent directory, found no keys, and always returned `"No known keys allowed"`.
2. The 22 bundled keys are committed **world-readable** (mode `0755`) and Docker `COPY` preserves that. OpenSSH refuses a private key with group/world permissions and exits `255`, so every key was skipped anyway.

Either bug alone makes the check a guaranteed false negative.

## Fix

- resolve the keys via `Path(__file__).parent / "keys"`;
- hand `ssh` a **0600 temp copy** of each key (`NamedTemporaryFile` creates it `0600`), so OpenSSH accepts it — without mutating the bundled files or their git mode.

The bundled keys are VMware's published static keys (exploit material for this CVE), not secrets, so their world-readable mode in git is not itself a leak; the runtime copy just satisfies OpenSSH.

## Test

`boefjes/tests/plugins/test_cve_2023_34039.py` (mocks `subprocess.run`): non-ssh service is descheduled; `KEYS_DIR` resolves to the 22 bundled keys; an accepted key yields the `openkat/finding` `CVE-2023-34039` output and the key handed to `ssh` is a `0600` copy; all-rejected yields "No known keys allowed".

🤖 Generated with [Claude Code](https://claude.com/claude-code)